### PR TITLE
Keyboard frequency input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ SET (cubicsdr_sources
     src/CubicSDR.cpp
 	src/AppFrame.cpp
 	src/AppConfig.cpp
+	src/FrequencyDialog.cpp
 	src/sdr/SDRThread.cpp
 	src/sdr/SDRPostThread.cpp
 	src/demod/DemodulatorPreThread.cpp
@@ -269,6 +270,7 @@ SET (cubicsdr_headers
     src/CubicSDR.h
 	src/AppFrame.h
 	src/AppConfig.h
+	src/FrequencyDialog.h
 	src/sdr/SDRThread.h
 	src/sdr/SDRPostThread.h
 	src/demod/DemodulatorPreThread.h

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -13,7 +13,7 @@
 #endif
 
 #include "CubicSDR.h"
-#include "AppFrame.h"
+#include "FrequencyDialog.h"
 
 #ifdef _OSX_APP_
 #include "CoreFoundation/CoreFoundation.h"
@@ -92,7 +92,7 @@ bool CubicSDR::OnInit() {
     t_PostSDR = new std::thread(&SDRPostThread::threadMain, sdrPostThread);
     t_SDR = new std::thread(&SDRThread::threadMain, sdrThread);
 
-    AppFrame *appframe = new AppFrame();
+    appframe = new AppFrame();
 
 #ifdef __APPLE__
     int main_policy;
@@ -271,3 +271,11 @@ int CubicSDR::getPPM() {
     return ppm;
 }
 
+
+void CubicSDR::showFrequencyInput() {
+    FrequencyDialog fdialog(appframe, -1, _("Set Frequency"), wxPoint(-100,-100), wxSize(320, 75 ));
+
+    if ( fdialog.ShowModal() != wxID_OK ) {
+    } else {
+    }
+}

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -273,7 +273,7 @@ int CubicSDR::getPPM() {
 
 
 void CubicSDR::showFrequencyInput() {
-    FrequencyDialog fdialog(appframe, -1, demodMgr.getActiveDemodulator()?_("Set Demodulator Frequency"):_("Set Frequency"), demodMgr.getActiveDemodulator(), wxPoint(-100,-100), wxSize(320, 75 ));
+    FrequencyDialog fdialog(appframe, -1, demodMgr.getActiveDemodulator()?_("Set Demodulator Frequency"):_("Set Center Frequency"), demodMgr.getActiveDemodulator(), wxPoint(-100,-100), wxSize(320, 75 ));
     fdialog.ShowModal();
 }
 

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -273,9 +273,7 @@ int CubicSDR::getPPM() {
 
 
 void CubicSDR::showFrequencyInput() {
-    FrequencyDialog fdialog(appframe, -1, _("Set Frequency"), wxPoint(-100,-100), wxSize(320, 75 ));
-
-    if ( fdialog.ShowModal() != wxID_OK ) {
-    } else {
-    }
+    FrequencyDialog fdialog(appframe, -1, demodMgr.getActiveDemodulator()?_("Set Demodulator Frequency"):_("Set Frequency"), demodMgr.getActiveDemodulator(), wxPoint(-100,-100), wxSize(320, 75 ));
+    fdialog.ShowModal();
 }
+

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -15,6 +15,7 @@
 #include "AudioThread.h"
 #include "DemodulatorMgr.h"
 #include "AppConfig.h"
+#include "AppFrame.h"
 
 #define NUM_DEMODULATORS 1
 
@@ -56,7 +57,10 @@ public:
     void setPPM(int ppm_in);
     int getPPM();
 
+    void showFrequencyInput();
+
 private:
+    AppFrame *appframe;
     AppConfig config;
     PrimaryGLContext *m_glContext;
     std::vector<SDRDeviceInfo *> devs;

--- a/src/FrequencyDialog.cpp
+++ b/src/FrequencyDialog.cpp
@@ -1,0 +1,21 @@
+#include "FrequencyDialog.h"
+
+wxBEGIN_EVENT_TABLE(FrequencyDialog, wxDialog) wxEND_EVENT_TABLE()
+
+FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxString & title, const wxPoint & position, const wxSize & size, long style) :
+        wxDialog(parent, id, title, position, size, style) {
+    wxString freqStr = "105.7Mhz";
+
+    dialogText = new wxTextCtrl(this, -1, freqStr, wxPoint(6, 1), wxSize(size.GetWidth() - 20, size.GetHeight() - 70), wxTE_PROCESS_ENTER);
+    dialogText->SetFont(wxFont(20, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD));
+    Connect(wxEVT_TEXT_ENTER, wxCommandEventHandler(FrequencyDialog::OnEnter));
+
+    SetEscapeId(wxID_CANCEL);
+
+    Centre();
+}
+
+void FrequencyDialog::OnEnter(wxCommandEvent &event) {
+    std::cout << dialogText->GetValue().ToStdString() << std::endl;
+    Close();
+}

--- a/src/FrequencyDialog.cpp
+++ b/src/FrequencyDialog.cpp
@@ -5,12 +5,12 @@
 #include <iomanip>
 #include "CubicSDR.h"
 
-wxBEGIN_EVENT_TABLE(FrequencyDialog, wxDialog)
-EVT_CHAR_HOOK(FrequencyDialog::OnChar)
+wxBEGIN_EVENT_TABLE(FrequencyDialog, wxDialog) EVT_CHAR_HOOK(FrequencyDialog::OnChar)
 wxEND_EVENT_TABLE()
 
-FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxString & title, DemodulatorInstance *demod, const wxPoint & position, const wxSize & size, long style) :
-wxDialog(parent, id, title, position, size, style) {
+FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxString & title, DemodulatorInstance *demod, const wxPoint & position,
+        const wxSize & size, long style) :
+        wxDialog(parent, id, title, position, size, style) {
     wxString freqStr;
     activeDemod = demod;
 
@@ -20,7 +20,8 @@ wxDialog(parent, id, title, position, size, style) {
         freqStr = frequencyToStr(wxGetApp().getFrequency());
     }
 
-    dialogText = new wxTextCtrl(this, wxID_FREQ_INPUT, freqStr, wxPoint(6, 1), wxSize(size.GetWidth() - 20, size.GetHeight() - 70), wxTE_PROCESS_ENTER);
+    dialogText = new wxTextCtrl(this, wxID_FREQ_INPUT, freqStr, wxPoint(6, 1), wxSize(size.GetWidth() - 20, size.GetHeight() - 70),
+    wxTE_PROCESS_ENTER);
     dialogText->SetFont(wxFont(20, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD));
 
     Centre();
@@ -122,7 +123,8 @@ void FrequencyDialog::OnChar(wxKeyEvent& event) {
 
     std::string allowed("0123456789.MKGHZmkghz");
 
-    if (allowed.find_first_of(c) != std::string::npos || c == WXK_BACK) {
+    if (allowed.find_first_of(c) != std::string::npos || c == WXK_DELETE || c == WXK_BACK || c == WXK_NUMPAD_DECIMAL
+            || (c >= WXK_NUMPAD0 && c <= WXK_NUMPAD9)) {
         event.DoAllowNextEvent();
     } else if (event.ControlDown() && c == 'V') {
         // Alter clipboard contents to remove unwanted chars

--- a/src/FrequencyDialog.cpp
+++ b/src/FrequencyDialog.cpp
@@ -1,23 +1,62 @@
 #include "FrequencyDialog.h"
 
-wxBEGIN_EVENT_TABLE(FrequencyDialog, wxDialog) wxEND_EVENT_TABLE()
+#include "wx/clipbrd.h"
+
+wxBEGIN_EVENT_TABLE(FrequencyDialog, wxDialog)
+EVT_CHAR_HOOK(FrequencyDialog::OnChar)
+wxEND_EVENT_TABLE()
 
 FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxString & title, const wxPoint & position, const wxSize & size, long style) :
-        wxDialog(parent, id, title, position, size, style) {
+wxDialog(parent, id, title, position, size, style) {
     wxString freqStr = "105.7Mhz";
 
-    dialogText = new wxTextCtrl(this, -1, freqStr, wxPoint(6, 1), wxSize(size.GetWidth() - 20, size.GetHeight() - 70), wxTE_PROCESS_ENTER);
+    dialogText = new wxTextCtrl(this, wxID_FREQ_INPUT, freqStr, wxPoint(6, 1), wxSize(size.GetWidth() - 20, size.GetHeight() - 70), wxTE_PROCESS_ENTER);
     dialogText->SetFont(wxFont(20, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD));
-    Connect(wxEVT_TEXT_ENTER, wxCommandEventHandler(FrequencyDialog::OnEnter));
-
-    SetEscapeId(wxID_CANCEL);
 
     Centre();
 
     dialogText->SetSelection(-1, -1);
 }
 
-void FrequencyDialog::OnEnter(wxCommandEvent &event) {
-    std::cout << dialogText->GetValue().ToStdString() << std::endl;
-    Close();
+std::string& FrequencyDialog::filterChars(std::string& s, const std::string& allowed) {
+    s.erase(remove_if(s.begin(), s.end(), [&allowed](const char& c) {
+        return allowed.find(c) == std::string::npos;
+    }), s.end());
+    return s;
+}
+
+void FrequencyDialog::OnChar(wxKeyEvent& event) {
+    wxChar c = event.GetKeyCode();
+
+    switch (c) {
+    case WXK_RETURN:
+    case WXK_NUMPAD_ENTER:
+        // Do Stuff
+
+        Close();
+        break;
+    case WXK_ESCAPE:
+        Close();
+        break;
+    }
+
+    std::string allowed("0123456789.MKGHZmkghz");
+
+    if (allowed.find_first_of(c) != std::string::npos || c == WXK_BACK) {
+        event.DoAllowNextEvent();
+    } else if (event.ControlDown() && c == 'V') {
+        // Alter clipboard contents to remove unwanted chars
+        wxTheClipboard->Open();
+        wxTextDataObject data;
+        wxTheClipboard->GetData(data);
+        std::string clipText = data.GetText().ToStdString();
+        std::string pasteText = filterChars(clipText,std::string(allowed));
+        wxTheClipboard->SetData(new wxTextDataObject(pasteText));
+        wxTheClipboard->Close();
+        event.Skip();
+    } else if (c == WXK_RIGHT || c == WXK_LEFT || event.ControlDown()) {
+        event.Skip();
+    } else {
+        std::cout << (int) c << std::endl;
+    }
 }

--- a/src/FrequencyDialog.cpp
+++ b/src/FrequencyDialog.cpp
@@ -13,6 +13,8 @@ FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxStrin
     SetEscapeId(wxID_CANCEL);
 
     Centre();
+
+    dialogText->SetSelection(-1, -1);
 }
 
 void FrequencyDialog::OnEnter(wxCommandEvent &event) {

--- a/src/FrequencyDialog.h
+++ b/src/FrequencyDialog.h
@@ -18,11 +18,13 @@ public:
 
     wxTextCtrl * dialogText;
 
+    long long strToFrequency(std::string freqStr);
+    std::string frequencyToStr(long long freq);
+
 private:
 
     void OnEnter ( wxCommandEvent &event );
     void OnChar ( wxKeyEvent &event );
     std::string& filterChars(std::string& s, const std::string& allowed);
-
     DECLARE_EVENT_TABLE()
 };

--- a/src/FrequencyDialog.h
+++ b/src/FrequencyDialog.h
@@ -5,6 +5,7 @@
 #include "wx/string.h"
 #include "wx/button.h"
 
+#define wxID_FREQ_INPUT 3001
 
 class FrequencyDialog: public wxDialog
 {
@@ -20,6 +21,8 @@ public:
 private:
 
     void OnEnter ( wxCommandEvent &event );
+    void OnChar ( wxKeyEvent &event );
+    std::string& filterChars(std::string& s, const std::string& allowed);
 
     DECLARE_EVENT_TABLE()
 };

--- a/src/FrequencyDialog.h
+++ b/src/FrequencyDialog.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "wx/dialog.h"
+#include "wx/textctrl.h"
+#include "wx/string.h"
+#include "wx/button.h"
+
+
+class FrequencyDialog: public wxDialog
+{
+public:
+
+    FrequencyDialog ( wxWindow * parent, wxWindowID id, const wxString & title,
+                  const wxPoint & pos = wxDefaultPosition,
+                  const wxSize & size = wxDefaultSize,
+                  long style = wxDEFAULT_DIALOG_STYLE );
+
+    wxTextCtrl * dialogText;
+
+private:
+
+    void OnEnter ( wxCommandEvent &event );
+
+    DECLARE_EVENT_TABLE()
+};

--- a/src/FrequencyDialog.h
+++ b/src/FrequencyDialog.h
@@ -4,6 +4,7 @@
 #include "wx/textctrl.h"
 #include "wx/string.h"
 #include "wx/button.h"
+#include "DemodulatorInstance.h"
 
 #define wxID_FREQ_INPUT 3001
 
@@ -12,6 +13,7 @@ class FrequencyDialog: public wxDialog
 public:
 
     FrequencyDialog ( wxWindow * parent, wxWindowID id, const wxString & title,
+                  DemodulatorInstance *demod = NULL,
                   const wxPoint & pos = wxDefaultPosition,
                   const wxSize & size = wxDefaultSize,
                   long style = wxDEFAULT_DIALOG_STYLE );
@@ -22,7 +24,7 @@ public:
     std::string frequencyToStr(long long freq);
 
 private:
-
+    DemodulatorInstance *activeDemod;
     void OnEnter ( wxCommandEvent &event );
     void OnChar ( wxKeyEvent &event );
     std::string& filterChars(std::string& s, const std::string& allowed);

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -346,7 +346,7 @@ void TuningCanvas::OnMouseLeftWindow(wxMouseEvent& event) {
     SetCursor(wxCURSOR_CROSS);
     hoverIndex = 0;
     hoverState = TUNING_HOVER_NONE;
-    wxGetApp().getDemodMgr().setActiveDemodulator(wxGetApp().getDemodMgr().getLastActiveDemodulator());
+    wxGetApp().getDemodMgr().setActiveDemodulator(NULL);
 
     if (currentPPM != lastPPM) {
         wxGetApp().saveConfig();
@@ -368,7 +368,7 @@ void TuningCanvas::setHelpTip(std::string tip) {
 void TuningCanvas::OnKeyDown(wxKeyEvent& event) {
     InteractiveCanvas::OnKeyDown(event);
 
-    if (event.GetKeyCode() == WXK_SPACE && hoverState == TUNING_HOVER_CENTER || hoverState == TUNING_HOVER_FREQ) {
+    if (event.GetKeyCode() == WXK_SPACE && (hoverState == TUNING_HOVER_CENTER || hoverState == TUNING_HOVER_FREQ)) {
         wxGetApp().showFrequencyInput();
     }
 }

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -271,21 +271,28 @@ void TuningCanvas::OnMouseMoved(wxMouseEvent& event) {
     } else {
         switch (hoverState) {
         case TUNING_HOVER_FREQ:
-                setStatusText("Click, wheel or drag a digit to change frequency. Hold ALT to change PPM. Hold SHIFT to disable carry.");
+                setStatusText("Click, wheel or drag a digit to change frequency; SPACE for direct input. Hold ALT to change PPM. Hold SHIFT to disable carry.");
             break;
         case TUNING_HOVER_BW:
                 setStatusText("Click, wheel or drag a digit to change bandwidth.  Hold SHIFT to disable carry.");
             break;
         case TUNING_HOVER_CENTER:
-                setStatusText("Click, wheel or drag a digit to change center frequency.  Hold SHIFT to disable carry.");
+                setStatusText("Click, wheel or drag a digit to change center frequency; SPACE for direct input.  Hold SHIFT to disable carry.");
             break;
         case TUNING_HOVER_PPM:
                  setStatusText("Click, wheel or drag a digit to change device PPM offset.  Hold SHIFT to disable carry.");
              break;
+        case TUNING_HOVER_NONE:
+            setStatusText("");
+            break;
       }
     }
 
-
+    if (hoverState == TUNING_HOVER_BW || hoverState == TUNING_HOVER_FREQ) {
+         wxGetApp().getDemodMgr().setActiveDemodulator(wxGetApp().getDemodMgr().getLastActiveDemodulator());
+     } else {
+         wxGetApp().getDemodMgr().setActiveDemodulator(NULL);
+     }
 }
 
 void TuningCanvas::OnMouseDown(wxMouseEvent& event) {
@@ -339,6 +346,7 @@ void TuningCanvas::OnMouseLeftWindow(wxMouseEvent& event) {
     SetCursor(wxCURSOR_CROSS);
     hoverIndex = 0;
     hoverState = TUNING_HOVER_NONE;
+    wxGetApp().getDemodMgr().setActiveDemodulator(wxGetApp().getDemodMgr().getLastActiveDemodulator());
 
     if (currentPPM != lastPPM) {
         wxGetApp().saveConfig();
@@ -359,6 +367,10 @@ void TuningCanvas::setHelpTip(std::string tip) {
 
 void TuningCanvas::OnKeyDown(wxKeyEvent& event) {
     InteractiveCanvas::OnKeyDown(event);
+
+    if (event.GetKeyCode() == WXK_SPACE && hoverState == TUNING_HOVER_CENTER || hoverState == TUNING_HOVER_FREQ) {
+        wxGetApp().showFrequencyInput();
+    }
 }
 
 void TuningCanvas::OnKeyUp(wxKeyEvent& event) {

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -193,6 +193,8 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
         }
     }
 
+    glContext->setHoverAlpha(0);
+
     for (int i = 0, iMax = demods.size(); i < iMax; i++) {
         if (activeDemodulator == demods[i] || lastActiveDemodulator == demods[i]) {
             continue;

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -302,21 +302,14 @@ void WaterfallCanvas::OnKeyDown(wxKeyEvent& event) {
         if (!activeDemod) {
             break;
         }
-        if (activeDemod->isSquelchEnabled()) {
-            activeDemod->setSquelchEnabled(false);
-        } else {
-            activeDemod->squelchAuto();
-        }
-        break;
-    case WXK_SPACE:
-        if (!activeDemod) {
-            break;
-        }
         if (activeDemod->isStereo()) {
             activeDemod->setStereo(false);
         } else {
             activeDemod->setStereo(true);
         }
+        break;
+    case WXK_SPACE:
+        wxGetApp().showFrequencyInput();
         break;
     default:
         event.Skip();
@@ -720,14 +713,14 @@ void WaterfallCanvas::OnMouseMoved(wxMouseEvent& event) {
 
                 mouseTracker.setVertDragLock(true);
                 mouseTracker.setHorizDragLock(false);
-                setStatusText("Click and drag to change demodulator bandwidth. D to delete, SPACE for stereo.");
+                setStatusText("Click and drag to change demodulator bandwidth. D to delete, S for stereo.");
             } else {
                 SetCursor(wxCURSOR_SIZING);
                 nextDragState = WF_DRAG_FREQUENCY;
 
                 mouseTracker.setVertDragLock(true);
                 mouseTracker.setHorizDragLock(false);
-                setStatusText("Click and drag to change demodulator frequency. D to delete, SPACE for stereo.");
+                setStatusText("Click and drag to change demodulator frequency. D to delete, S for stereo.");
             }
         } else {
             SetCursor(wxCURSOR_CROSS);

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -141,7 +141,7 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     ColorTheme *currentTheme = ThemeMgr::mgr.currentTheme;
     int last_type = wxGetApp().getDemodMgr().getLastDemodulatorType();
 
-    if (mouseTracker.mouseInView()) {
+    if (mouseTracker.mouseInView() || wxGetApp().getDemodMgr().getActiveDemodulator()) {
         hoverAlpha += (1.0f-hoverAlpha)*0.1f;
         if (hoverAlpha > 1.5f) {
             hoverAlpha = 1.5f;
@@ -713,23 +713,23 @@ void WaterfallCanvas::OnMouseMoved(wxMouseEvent& event) {
 
                 mouseTracker.setVertDragLock(true);
                 mouseTracker.setHorizDragLock(false);
-                setStatusText("Click and drag to change demodulator bandwidth. D to delete, S for stereo.");
+                setStatusText("Click and drag to change demodulator bandwidth. SPACE for direct frequency input. D to delete, S for stereo.");
             } else {
                 SetCursor(wxCURSOR_SIZING);
                 nextDragState = WF_DRAG_FREQUENCY;
 
                 mouseTracker.setVertDragLock(true);
                 mouseTracker.setHorizDragLock(false);
-                setStatusText("Click and drag to change demodulator frequency. D to delete, S for stereo.");
+                setStatusText("Click and drag to change demodulator frequency; SPACE for direct input. D to delete, S for stereo.");
             }
         } else {
             SetCursor(wxCURSOR_CROSS);
             nextDragState = WF_DRAG_NONE;
             if (shiftDown) {
-                setStatusText("Click to create a new demodulator or hold ALT to drag range.");
+                setStatusText("Click to create a new demodulator or hold ALT to drag range, SPACE for direct center frequency input.");
             } else {
                 setStatusText(
-                        "Click to move active demodulator frequency or hold ALT to drag range; hold SHIFT to create new.  Right drag or A / Z to Zoom.  Arrow keys (+SHIFT) to move center frequency.");
+                        "Click to move active demodulator frequency or hold ALT to drag range; hold SHIFT to create new.  Right drag or A / Z to Zoom.  Arrow keys (+SHIFT) to move center frequency; SPACE for direct input.");
             }
         }
 


### PR DESCRIPTION
- Summon frequency dialog by pressing SPACE
- Stereo key remapped to 'S'
- Cancel dialog with ESC
- Accept dialog with ENTER
- Parses MHz, GHz and KHz suffix (m,g,k is sufficient)
- Decimals without suffix assumes MHz
- No decimals without suffix assumes Hz
- Set demodulator frequency when hovered over waterfall demodulator or tuning bar demod frequency
- Set center frequency if not hovered over demod or hovered over tuning bar center frequency
