### PR TITLE
Improve FM Stereo

### DIFF
--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -84,9 +84,10 @@ public:
 
     firfilt_rrrf firStereoLeft;
     firfilt_rrrf firStereoRight;
+    iirfilt_crcf iirStereoPilot;
 
     DemodulatorThreadPostIQData() :
-            sampleRate(0), audioResampler(NULL), stereoResampler(NULL), audioResampleRatio(0), audioSampleRate(0), firStereoLeft(NULL), firStereoRight(NULL) {
+            sampleRate(0), audioResampler(NULL), stereoResampler(NULL), audioResampleRatio(0), audioSampleRate(0), firStereoLeft(NULL), firStereoRight(NULL), iirStereoPilot(NULL) {
 
     }
 

--- a/src/demod/DemodulatorPreThread.cpp
+++ b/src/demod/DemodulatorPreThread.cpp
@@ -37,8 +37,8 @@ void DemodulatorPreThread::initialize() {
     stereoResampler = msresamp_rrrf_create(audioResampleRatio, As);
 
     // Stereo filters / shifters
-    double firStereoCutoff = 0.5 * ((double) 36000 / (double) params.audioSampleRate);         // filter cutoff frequency
-    float ft = 0.05f;         // filter transition
+    double firStereoCutoff = ((double) 16000 / (double) params.audioSampleRate);
+    float ft = ((double) 1000 / (double) params.audioSampleRate);         // filter transition
     float mu = 0.0f;         // fractional timing offset
 
     if (firStereoCutoff < 0) {
@@ -59,7 +59,7 @@ void DemodulatorPreThread::initialize() {
     // stereo pilot filter
     unsigned int order =   5;       // filter order
     float        f0    =   ((double) 19000 / (double) params.bandwidth);
-    float        fc    =   f0 + ((double) 3000 / (double) params.bandwidth);
+    float        fc    =   ((double) 19500 / (double) params.bandwidth);
     float        Ap    =   1.0f;
     As    =  60.0f;
     iirStereoPilot = iirfilt_crcf_create_prototype(LIQUID_IIRDES_CHEBY2, LIQUID_IIRDES_BANDPASS, LIQUID_IIRDES_SOS, order, fc, f0, Ap, As);

--- a/src/demod/DemodulatorPreThread.h
+++ b/src/demod/DemodulatorPreThread.h
@@ -60,6 +60,7 @@ protected:
 
     firfilt_rrrf firStereoLeft;
     firfilt_rrrf firStereoRight;
+    iirfilt_crcf iirStereoPilot;
 
     DemodulatorThreadParameters params;
     DemodulatorThreadParameters lastParams;

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -268,8 +268,8 @@ void DemodulatorThread::threadMain() {
 //            
             nco_crcf_set_frequency(stereoShifter, nco_crcf_get_frequency(stereoPilot)*2);
             nco_crcf_set_phase(stereoShifter, nco_crcf_get_phase(stereoPilot));
-            std::cout << "[PLL] phase error: " << phase_error;
-            std::cout << " freq:" << (((nco_crcf_get_frequency(stereoPilot) / (2.0 * M_PI)) * inp->sampleRate)) << std::endl;
+//            std::cout << "[PLL] phase error: " << phase_error;
+//            std::cout << " freq:" << (((nco_crcf_get_frequency(stereoPilot) / (2.0 * M_PI)) * inp->sampleRate)) << std::endl;
             
             if (audio_out_size != resampledStereoData.size()) {
                 if (resampledStereoData.capacity() < audio_out_size) {

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -51,8 +51,8 @@ void DemodulatorWorkerThread::threadMain() {
                 result.audioSampleRate = filterCommand.audioSampleRate;
 
                 // Stereo filters / shifters
-                double firStereoCutoff = 0.5 * ((double) 36000 / (double) filterCommand.audioSampleRate);         // filter cutoff frequency
-                float ft = 0.05f;         // filter transition
+                double firStereoCutoff = ((double) 16000 / (double) filterCommand.audioSampleRate);
+                float ft = ((double) 1000 / (double) filterCommand.audioSampleRate);        // filter transition
                 float mu = 0.0f;         // fractional timing offset
 
                 if (firStereoCutoff < 0) {
@@ -70,10 +70,10 @@ void DemodulatorWorkerThread::threadMain() {
                 result.firStereoLeft = firfilt_rrrf_create(h, h_len);
                 result.firStereoRight = firfilt_rrrf_create(h, h_len);
 
-                
-                unsigned int order =   5;
+                // stereo pilot filter
+                unsigned int order =   5;       // filter order
                 float        f0    =   ((double) 19000 / (double) filterCommand.bandwidth);
-                float        fc    =   f0 + ((double) 3000 / (double) filterCommand.bandwidth);
+                float        fc    =   ((double) 19500 / (double) filterCommand.bandwidth);
                 float        Ap    =   1.0f;
                 As    =  60.0f;
                 

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -69,6 +69,15 @@ void DemodulatorWorkerThread::threadMain() {
 
                 result.firStereoLeft = firfilt_rrrf_create(h, h_len);
                 result.firStereoRight = firfilt_rrrf_create(h, h_len);
+
+                
+                unsigned int order =   5;
+                float        f0    =   ((double) 19000 / (double) filterCommand.bandwidth);
+                float        fc    =   f0 + ((double) 3000 / (double) filterCommand.bandwidth);
+                float        Ap    =   1.0f;
+                As    =  60.0f;
+                
+                result.iirStereoPilot = iirfilt_crcf_create_prototype(LIQUID_IIRDES_CHEBY2, LIQUID_IIRDES_BANDPASS, LIQUID_IIRDES_SOS, order, fc, f0, Ap, As);
             }
 
             if (filterCommand.bandwidth) {

--- a/src/demod/DemodulatorWorkerThread.h
+++ b/src/demod/DemodulatorWorkerThread.h
@@ -16,7 +16,7 @@ public:
 
     DemodulatorWorkerThreadResult() :
             cmd(DEMOD_WORKER_THREAD_RESULT_NULL), iqResampler(NULL), iqResampleRatio(0), audioResampler(NULL), stereoResampler(NULL), audioResamplerRatio(
-                    0), firStereoLeft(NULL), firStereoRight(NULL), sampleRate(0), bandwidth(0), audioSampleRate(0) {
+                    0), firStereoLeft(NULL), firStereoRight(NULL), iirStereoPilot(NULL), sampleRate(0), bandwidth(0), audioSampleRate(0) {
 
     }
 
@@ -35,6 +35,7 @@ public:
 
     firfilt_rrrf firStereoLeft;
     firfilt_rrrf firStereoRight;
+    iirfilt_crcf iirStereoPilot;
 
     long long sampleRate;
     unsigned int bandwidth;


### PR DESCRIPTION
- Now utilizing 2 * 19khz PLL VCO for 38khz stereo mix instead of static 38khz NCO (translation: phase and frequency lock to actual FM stereo pilot tone)
- Proper volume balance between mono/stereo
