### PR TITLE
I/Q raw demodulator

### DIFF
--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -121,6 +121,7 @@ AppConfig::AppConfig() {
     winH.store(0);
     winMax.store(false);
     themeId.store(0);
+    snap.store(1);
 }
 
 
@@ -186,6 +187,15 @@ int AppConfig::getTheme() {
 }
 
 
+void AppConfig::setSnap(long long snapVal) {
+    this->snap.store(snapVal);
+}
+
+long long AppConfig::getSnap() {
+    return snap.load();
+}
+
+
 bool AppConfig::save() {
     DataTree cfg;
 
@@ -200,8 +210,8 @@ bool AppConfig::save() {
         *window_node->newChild("h") = winH.load();
 
         *window_node->newChild("max") = winMax.load();
-
         *window_node->newChild("theme") = themeId.load();
+        *window_node->newChild("snap") = snap.load();
     }
     
     DataNode *devices_node = cfg.rootNode()->newChild("devices");
@@ -275,6 +285,11 @@ bool AppConfig::load() {
             themeId.store(theme);
         }
 
+        if (win_node->hasAnother("snap")) {
+			long long snapVal;
+			win_node->getNext("snap")->element()->get(snapVal);
+			snap.store(snapVal);
+		}
     }
     
     if (cfg.rootNode()->hasAnother("devices")) {

--- a/src/AppConfig.h
+++ b/src/AppConfig.h
@@ -55,7 +55,10 @@ public:
 
     void setTheme(int themeId);
     int getTheme();
-    
+
+    void setSnap(long long snapVal);
+    long long getSnap();
+
     bool save();
     bool load();
     bool reset();
@@ -65,4 +68,5 @@ private:
     std::atomic_int winX,winY,winW,winH;
     std::atomic_bool winMax;
     std::atomic_int themeId;
+    std::atomic_llong snap;
 };

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -376,16 +376,21 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
                 "Frequency Offset", wxGetApp().getOffset(), -2000000000, 2000000000, this);
         if (ofs != -1) {
             wxGetApp().setOffset(ofs);
+            wxGetApp().saveConfig();
         }
     } else if (event.GetId() == wxID_SET_DS_OFF) {
         wxGetApp().setDirectSampling(0);
+        wxGetApp().saveConfig();
     } else if (event.GetId() == wxID_SET_DS_I) {
         wxGetApp().setDirectSampling(1);
+        wxGetApp().saveConfig();
     } else if (event.GetId() == wxID_SET_DS_Q) {
         wxGetApp().setDirectSampling(2);
+        wxGetApp().saveConfig();
     } else if (event.GetId() == wxID_SET_SWAP_IQ) {
         bool swap_state = !wxGetApp().getSwapIQ();
         wxGetApp().setSwapIQ(swap_state);
+        wxGetApp().saveConfig();
         iqSwapMenuItem->Check(swap_state);
     } else if (event.GetId() == wxID_SET_PPM) {
         long ofs = wxGetNumberFromUser("Frequency correction for device in PPM.\ni.e. -51 for -51 PPM\n\nNote: you can adjust PPM interactively\nby holding ALT over the frequency tuning bar.\n", "Parts per million (PPM)",

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -57,6 +57,7 @@ AppFrame::AppFrame() :
     demodModeSelector->addChoice(DEMOD_TYPE_LSB, "LSB");
     demodModeSelector->addChoice(DEMOD_TYPE_USB, "USB");
     demodModeSelector->addChoice(DEMOD_TYPE_DSB, "DSB");
+    demodModeSelector->addChoice(DEMOD_TYPE_RAW, "I/Q");
     demodModeSelector->setSelection(DEMOD_TYPE_FM);
     demodModeSelector->setHelpTip("Choose modulation type: Frequency Modulation, Amplitude Modulation and Lower, Upper or Double Side-Band.");
     demodTray->Add(demodModeSelector, 2, wxEXPAND | wxALL, 0);

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -319,6 +319,9 @@ AppFrame::AppFrame() :
     if (max) {
         this->Maximize();
     }
+
+    long long freqSnap = wxGetApp().getConfig()->getSnap();
+    wxGetApp().setFrequencySnap(freqSnap);
             
     ThemeMgr::mgr.setTheme(wxGetApp().getConfig()->getTheme());
 
@@ -528,6 +531,7 @@ void AppFrame::OnClose(wxCloseEvent& event) {
     wxGetApp().getConfig()->setWindow(this->GetPosition(), this->GetClientSize());
     wxGetApp().getConfig()->setWindowMaximized(this->IsMaximized());
     wxGetApp().getConfig()->setTheme(ThemeMgr::mgr.getTheme());
+    wxGetApp().getConfig()->setSnap(wxGetApp().getFrequencySnap());
     wxGetApp().getConfig()->save();
     event.Skip();
 }

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -193,7 +193,6 @@ void CubicSDR::setOffset(long long ofs) {
     
     SDRDeviceInfo *dev = (*getDevices())[getDevice()];
     config.getDevice(dev->getDeviceId())->setOffset(ofs);
-    config.save();
 }
 
 void CubicSDR::setDirectSampling(int mode) {
@@ -204,7 +203,6 @@ void CubicSDR::setDirectSampling(int mode) {
 
     SDRDeviceInfo *dev = (*getDevices())[getDevice()];
     config.getDevice(dev->getDeviceId())->setDirectSampling(mode);
-    config.save();
 }
 
 int CubicSDR::getDirectSampling() {
@@ -215,7 +213,6 @@ void CubicSDR::setSwapIQ(bool swapIQ) {
     sdrPostThread->setSwapIQ(swapIQ);
     SDRDeviceInfo *dev = (*getDevices())[getDevice()];
     config.getDevice(dev->getDeviceId())->setIQSwap(swapIQ);
-    config.save();
 }
 
 bool CubicSDR::getSwapIQ() {
@@ -309,7 +306,6 @@ void CubicSDR::setPPM(int ppm_in) {
     SDRDeviceInfo *dev = (*getDevices())[getDevice()];
 
     config.getDevice(dev->getDeviceId())->setPPM(ppm_in);
-    config.save();
 }
 
 int CubicSDR::getPPM() {

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -22,7 +22,7 @@
 class CubicSDR: public wxApp {
 public:
     CubicSDR() :
-    m_glContext(NULL), frequency(DEFAULT_FREQ), sdrThread(NULL), sdrPostThread(NULL), threadCmdQueueSDR(NULL), iqVisualQueue(NULL), iqPostDataQueue(NULL), audioVisualQueue(NULL), t_SDR(NULL),  t_PostSDR(NULL), sampleRate(DEFAULT_SAMPLE_RATE), offset(0), snap(1) {
+    appframe(NULL), m_glContext(NULL), frequency(DEFAULT_FREQ), sdrThread(NULL), sdrPostThread(NULL), threadCmdQueueSDR(NULL), iqVisualQueue(NULL), iqPostDataQueue(NULL), audioVisualQueue(NULL), t_SDR(NULL),  t_PostSDR(NULL), sampleRate(DEFAULT_SAMPLE_RATE), offset(0), snap(1), directSamplingMode(0), ppm(0) {
 
     }
 

--- a/src/CubicSDRDefs.h
+++ b/src/CubicSDRDefs.h
@@ -53,5 +53,5 @@ public:
         return refCount.load();
     }
 protected:
-    std::atomic<int> refCount;
+    std::atomic_int refCount;
 };

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -52,12 +52,12 @@ public:
 
     AudioThreadInput *currentInput;
     AudioThreadInputQueue *inputQueue;
-    std::atomic<unsigned int> audioQueuePtr;
-    std::atomic<unsigned int> underflowCount;
-    std::atomic<bool> terminated;
-    std::atomic<bool> initialized;
-    std::atomic<bool> active;
-    std::atomic<int> outputDevice;
+    std::atomic_uint audioQueuePtr;
+    std::atomic_uint underflowCount;
+    std::atomic_bool terminated;
+    std::atomic_bool initialized;
+    std::atomic_bool active;
+    std::atomic_int outputDevice;
     std::atomic<float> gain;
 
     AudioThread(AudioThreadInputQueue *inputQueue, DemodulatorThreadCommandQueue* threadQueueNotify);

--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -13,6 +13,8 @@
 #define DEMOD_TYPE_LSB 3
 #define DEMOD_TYPE_USB 4
 #define DEMOD_TYPE_DSB 5
+#define DEMOD_TYPE_RAW 6
+
 
 class DemodulatorThread;
 class DemodulatorThreadCommand {

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -2,7 +2,7 @@
 
 DemodulatorInstance::DemodulatorInstance() :
         t_Demod(NULL), t_PreDemod(NULL), t_Audio(NULL), threadQueueDemod(NULL), demodulatorThread(NULL), terminated(true), audioTerminated(true), demodTerminated(
-        true), preDemodTerminated(true), active(false), squelch(false), stereo(false), currentFrequency(0), currentBandwidth(0), currentOutputDevice(-1) {
+        true), preDemodTerminated(true), active(false), squelch(false), stereo(false), tracking(false), follow(false), currentAudioSampleRate(0), currentFrequency(0), currentBandwidth(0), currentOutputDevice(-1) {
 
     label = new std::string("Unnamed");
     threadQueueDemod = new DemodulatorThreadInputQueue;

--- a/src/demod/DemodulatorInstance.h
+++ b/src/demod/DemodulatorInstance.h
@@ -87,18 +87,19 @@ private:
     void checkBandwidth();
 
     std::atomic<std::string *> label; //
-    bool terminated; //
-    bool demodTerminated; //
-    bool audioTerminated; //
-    bool preDemodTerminated;
-    std::atomic<bool> active;
-    std::atomic<bool> squelch;
-    std::atomic<bool> stereo;
+    std::atomic_bool terminated; //
+    std::atomic_bool demodTerminated; //
+    std::atomic_bool audioTerminated; //
+    std::atomic_bool preDemodTerminated;
+    std::atomic_bool active;
+    std::atomic_bool squelch;
+    std::atomic_bool stereo;
 
-    long long currentFrequency;
-    int currentBandwidth;
-    int currentDemodType;
-    int currentOutputDevice;
-    int currentAudioSampleRate;
-    bool follow, tracking;
+    std::atomic_llong currentFrequency;
+    std::atomic_int currentBandwidth;
+    std::atomic_int currentDemodType;
+    std::atomic_int currentOutputDevice;
+    std::atomic_int currentAudioSampleRate;
+    std::atomic<float> currentAudioGain;
+    std::atomic_bool follow, tracking;
   };

--- a/src/demod/DemodulatorPreThread.h
+++ b/src/demod/DemodulatorPreThread.h
@@ -68,8 +68,8 @@ protected:
     nco_crcf freqShifter;
     int shiftFrequency;
 
-    std::atomic<bool> terminated;
-    std::atomic<bool> initialized;
+    std::atomic_bool terminated;
+    std::atomic_bool initialized;
 
     DemodulatorWorkerThread *workerThread;
     std::thread *t_Worker;

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -61,7 +61,7 @@ void DemodulatorThread::threadMain() {
 
     // Automatic IQ gain
     iqAutoGain = agc_crcf_create();
-    agc_crcf_set_bandwidth(iqAutoGain, 0.9);
+    agc_crcf_set_bandwidth(iqAutoGain, 0.1);
 
     AudioThreadInput *ati_vis = new AudioThreadInput;
     ati_vis->data.reserve(DEMOD_VIS_SIZE);
@@ -372,8 +372,8 @@ void DemodulatorThread::threadMain() {
 
                 if (demodulatorType == DEMOD_TYPE_RAW) {
                     for (int i = 0; i < stereoSize / 2; i++) {
-                        ati_vis->data[i] = ati->data[i * 2] * 0.5;
-                        ati_vis->data[i + stereoSize / 2] = ati->data[i * 2 + 1] * 0.5;
+                        ati_vis->data[i] = ati->data[i * 2] * 0.75;
+                        ati_vis->data[i + stereoSize / 2] = ati->data[i * 2 + 1] * 0.75;
                     }
                 } else {
                     for (int i = 0; i < stereoSize / 2; i++) {

--- a/src/demod/DemodulatorThread.h
+++ b/src/demod/DemodulatorThread.h
@@ -31,6 +31,9 @@ public:
     void setStereo(bool state);
     bool isStereo();
 
+    void setAGC(bool state);
+    bool getAGC();
+
     float getSignalLevel();
     void setSquelchLevel(float signal_level_in);
     float getSquelchLevel();
@@ -72,9 +75,10 @@ protected:
     float amOutputCeilMA;
     float amOutputCeilMAA;
 
-    std::atomic<bool> stereo;
-    std::atomic<bool> terminated;
-    std::atomic<int> demodulatorType;
+    std::atomic_bool stereo;
+    std::atomic_bool agcEnabled;
+    std::atomic_bool terminated;
+    std::atomic_int demodulatorType;
     int audioSampleRate;
 
     DemodulatorThreadCommandQueue* threadQueueNotify;

--- a/src/demod/DemodulatorWorkerThread.h
+++ b/src/demod/DemodulatorWorkerThread.h
@@ -93,5 +93,5 @@ protected:
     DemodulatorThreadWorkerCommandQueue *commandQueue;
     DemodulatorThreadWorkerResultQueue *resultQueue;
 
-    std::atomic<bool> terminated;
+    std::atomic_bool terminated;
 };

--- a/src/sdr/SDRPostThread.h
+++ b/src/sdr/SDRPostThread.h
@@ -31,10 +31,10 @@ protected:
 	
     std::mutex busy_demod;
     std::vector<DemodulatorInstance *> demodulators;
-    std::atomic<bool> terminated;
+    std::atomic_bool terminated;
     iirfilt_crcf dcFilter;
     int num_vis_samples;
-    std::atomic<bool> swapIQ;
+    std::atomic_bool swapIQ;
     
 private:
     std::vector<liquid_float_complex> _lut;

--- a/src/sdr/SDRThread.h
+++ b/src/sdr/SDRThread.h
@@ -149,10 +149,10 @@ public:
 
 protected:
     std::atomic<uint32_t> sampleRate;
-    std::atomic<long long> offset;
+    std::atomic_llong offset;
     std::atomic<SDRThreadCommandQueue*> commandQueue;
     std::atomic<SDRThreadIQDataQueue*> iqDataOutQueue;
 
-    std::atomic<bool> terminated;
-    std::atomic<int> deviceId;
+    std::atomic_bool terminated;
+    std::atomic_int deviceId;
 };

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -820,8 +820,8 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
                 demod = wxGetApp().getDemodMgr().newThread();
                 demod->setFrequency(freq);
 
-                demod->setBandwidth(mgr->getLastBandwidth());
                 demod->setDemodulatorType(mgr->getLastDemodulatorType());
+                demod->setBandwidth(mgr->getLastBandwidth());
                 demod->setSquelchLevel(mgr->getLastSquelchLevel());
                 demod->setSquelchEnabled(mgr->isLastSquelchEnabled());
                 demod->setStereo(mgr->isLastStereo());

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -907,9 +907,8 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
         } else {
             demod = wxGetApp().getDemodMgr().newThread();
             demod->setFrequency(freq);
-            demod->setBandwidth(bw);
-
             demod->setDemodulatorType(mgr->getLastDemodulatorType());
+            demod->setBandwidth(bw);
             demod->setSquelchLevel(mgr->getLastSquelchLevel());
             demod->setSquelchEnabled(mgr->isLastSquelchEnabled());
             demod->setStereo(mgr->isLastStereo());


### PR DESCRIPTION
- Adds I/Q demodulation mode which is a pass-thru for the current demodulator stream
  - Left channel = I, Right channel = Q
- Bandwidth will lock to audio bandwidth when I/Q mode is active
- Can use arbitrary rates with Jack audio in dummy mode (i.e. CubicSDR -> Jack -> baudline)
- Demodulator I/Q AGC will now disable when gain slider < 12.5% for input pass-thru
- Fix some actual and possible crashes
- Frequency snap now saved on exit
- Reduce amount of configuration saves (on UI or exit only now)
- Code cleanup