### PR TITLE
Fixes for two crashes

### DIFF
--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -428,7 +428,7 @@ bool AudioThread::isActive() {
 void AudioThread::setActive(bool state) {
 
     AudioThreadInput *dummy;
-    if (state && !active) {
+    if (state && !active && inputQueue) {
         while (!inputQueue->empty()) {  // flush queue
             inputQueue->pop(dummy);
             if (dummy) {
@@ -438,10 +438,12 @@ void AudioThread::setActive(bool state) {
         deviceController[parameters.deviceId]->bindThread(this);
     } else if (!state && active) {
         deviceController[parameters.deviceId]->removeThread(this);
-        while (!inputQueue->empty()) {  // flush queue
-            inputQueue->pop(dummy);
-            if (dummy) {
-                dummy->decRefCount();
+        if(inputQueue) {
+            while (!inputQueue->empty()) {  // flush queue
+                inputQueue->pop(dummy);
+                if (dummy) {
+                    dummy->decRefCount();
+                }
             }
         }
     }

--- a/src/sdr/SDRThread.cpp
+++ b/src/sdr/SDRThread.cpp
@@ -41,8 +41,12 @@ int SDRThread::enumerate_rtl(std::vector<SDRDeviceInfo *> *devs) {
             deviceProduct = product;
             deviceManufacturer = manufact;
 
-            rtlsdr_dev_t *devTest;
-            rtlsdr_open(&devTest, i);
+            rtlsdr_dev_t *devTest = nullptr;
+            if(rtlsdr_open(&devTest, i) < 0)
+            {
+                std::cout << "\tFailed to open device " << i << std::endl;
+                continue;
+            }
 
             std::cout << "\t Tuner type: ";
             switch (rtlsdr_get_tuner_type(devTest)) {


### PR DESCRIPTION
Hit a pair of crashes when using CubicSDR

* If rtlsdr_open fails, devTest is left uninitialized
* If the audio thread setActive() is called before run(), we dereference a null inputQueue.