### PR TITLE
Add ReBuffer buffer count warning, fix SDRPostThread off-by-one error

### DIFF
--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -45,6 +45,10 @@ template<class BufferType = ReferenceCounter>
 class ReBuffer {
     
 public:
+    ReBuffer(std::string bufferId) : bufferId(bufferId) {
+        
+    }
+    
     BufferType *getBuffer() {
         BufferType* buf = NULL;
         for (outputBuffersI = outputBuffers.begin(); outputBuffersI != outputBuffers.end(); outputBuffersI++) {
@@ -65,10 +69,11 @@ public:
             return buf;
         }
         
-//        if (outputBuffers.size() > 100) {
-//            std::cout << "Buffer over 100.." << std::endl;
-//        }
-        
+#define REBUFFER_WARNING_THRESHOLD 100
+        if (outputBuffers.size() > REBUFFER_WARNING_THRESHOLD) {
+            std::cout << "Warning: ReBuffer '" << bufferId << "' count '" << outputBuffers.size() << "' exceeds threshold of '" << REBUFFER_WARNING_THRESHOLD << "'" << std::endl;
+        }
+
         buf = new BufferType();
         outputBuffers.push_back(buf);
         
@@ -83,6 +88,7 @@ public:
         }
     }
 private:
+    std::string bufferId;
     std::deque<BufferType*> outputBuffers;
     typename std::deque<BufferType*>::iterator outputBuffersI;
 };

--- a/src/demod/DemodulatorPreThread.cpp
+++ b/src/demod/DemodulatorPreThread.cpp
@@ -53,7 +53,7 @@ void DemodulatorPreThread::run() {
 
     std::cout << "Demodulator preprocessor thread started.." << std::endl;
 
-    ReBuffer<DemodulatorThreadPostIQData> buffers;
+    ReBuffer<DemodulatorThreadPostIQData> buffers("DemodulatorPreThreadBuffers");
 
     iqInputQueue = (DemodulatorThreadInputQueue*)getInputQueue("IQDataInput");
     iqOutputQueue = (DemodulatorThreadPostInputQueue*)getOutputQueue("IQDataOutput");

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -12,7 +12,7 @@
 #include <pthread.h>
 #endif
 
-DemodulatorThread::DemodulatorThread(DemodulatorInstance *parent) : IOThread(), squelchLevel(-100), signalLevel(-100), squelchEnabled(false), cModem(nullptr), cModemKit(nullptr), iqInputQueue(NULL), audioOutputQueue(NULL), audioVisOutputQueue(NULL), threadQueueControl(NULL), threadQueueNotify(NULL) {
+DemodulatorThread::DemodulatorThread(DemodulatorInstance *parent) : IOThread(), squelchLevel(-100), signalLevel(-100), squelchEnabled(false), cModem(nullptr), cModemKit(nullptr), iqInputQueue(NULL), audioOutputQueue(NULL), audioVisOutputQueue(NULL), threadQueueControl(NULL), threadQueueNotify(NULL), outputBuffers("DemodulatorThreadBuffers") {
     
     demodInstance = parent;
     muted.store(false);
@@ -57,7 +57,7 @@ void DemodulatorThread::run() {
     pthread_setschedparam(tID, SCHED_FIFO, &prio);
 #endif
     
-    ReBuffer<AudioThreadInput> audioVisBuffers;
+    ReBuffer<AudioThreadInput> audioVisBuffers("DemodulatorThreadAudioBuffers");
     
     std::cout << "Demodulator thread started.." << std::endl;
     

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -1,6 +1,6 @@
 #include "FFTDataDistributor.h"
 
-FFTDataDistributor::FFTDataDistributor() : fftSize(DEFAULT_FFT_SIZE), linesPerSecond(DEFAULT_WATERFALL_LPS), lineRateAccum(0.0) {
+FFTDataDistributor::FFTDataDistributor() : fftSize(DEFAULT_FFT_SIZE), linesPerSecond(DEFAULT_WATERFALL_LPS), lineRateAccum(0.0), outputBuffers("FFTDataDistributorBuffers") {
     bufferedItems = 0;
 }
 

--- a/src/process/ScopeVisualProcessor.cpp
+++ b/src/process/ScopeVisualProcessor.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 #include <string>
 
-ScopeVisualProcessor::ScopeVisualProcessor(): fftInData(NULL), fftwOutput(NULL), fftw_plan(NULL), maxScopeSamples(1024) {
+ScopeVisualProcessor::ScopeVisualProcessor(): fftInData(NULL), fftwOutput(NULL), fftw_plan(NULL), maxScopeSamples(1024), outputBuffers("ScopeVisualProcessorBuffers") {
     scopeEnabled.store(true);
     spectrumEnabled.store(true);
     fft_average_rate = 0.65;

--- a/src/process/SpectrumVisualProcessor.cpp
+++ b/src/process/SpectrumVisualProcessor.cpp
@@ -2,7 +2,7 @@
 #include "CubicSDR.h"
 
 
-SpectrumVisualProcessor::SpectrumVisualProcessor() : lastInputBandwidth(0), lastBandwidth(0), fftwInput(NULL), fftwOutput(NULL), fftInData(NULL), fftLastData(NULL), lastDataSize(0), fftw_plan(NULL), resampler(NULL), resamplerRatio(0) {
+SpectrumVisualProcessor::SpectrumVisualProcessor() : lastInputBandwidth(0), lastBandwidth(0), fftwInput(NULL), fftwOutput(NULL), fftInData(NULL), fftLastData(NULL), lastDataSize(0), fftw_plan(NULL), resampler(NULL), resamplerRatio(0), outputBuffers("SpectrumVisualProcessorBuffers") {
     
     is_view.store(false);
     fftSize.store(0);

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <deque>
 
-SDRPostThread::SDRPostThread() : IOThread() {
+SDRPostThread::SDRPostThread() : IOThread(), buffers("SDRPostThreadBuffers"), visualDataBuffers("SDRPostThreadVisualDataBuffers") {
     iqDataInQueue = NULL;
     iqDataOutQueue = NULL;
     iqVisualQueue = NULL;
@@ -238,7 +238,7 @@ void SDRPostThread::run() {
                     firpfbch_crcf_analyzer_execute(channelizer, &data_in->data[i], &dataOut[i]);
                 }
 
-                for (int i = 0, iMax = numChannels; i < iMax; i++) {
+                for (int i = 0, iMax = numChannels+1; i < iMax; i++) {
                     demodChannelActive[i] = 0;
                 }
                 
@@ -276,6 +276,8 @@ void SDRPostThread::run() {
                     demodDataOut->frequency = chanCenters[i];
                     demodDataOut->sampleRate = chanBw;
 
+//                    std::cout << "Active channel(" << i << "/" << numChannels <<  ") nRunDemods:" << nRunDemods << ", doVis: " << doVis << ", demodVis: " << doDemodVis << std::endl;
+                    
                     // Calculate channel buffer size
                     int chanDataSize = (outSize/numChannels);
 

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 
-SDRThread::SDRThread() : IOThread() {
+SDRThread::SDRThread() : IOThread(), buffers("SDRThreadBuffers") {
     device = NULL;
 
     deviceConfig.store(NULL);


### PR DESCRIPTION
This wasn't the original problem, but once a demodulator hit the right-edge filterbank channel it would never de-activate and chew up the I/Q bandwidth memory refcounts for that channel if inactive.