### PR TITLE
Updates and improvements for low-bandwidth input usage

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1322,3 +1322,9 @@ void AppFrame::updateModemProperties(ModemArgInfoList args) {
     modemPropertiesUpdated.store(true);
 }
 
+void AppFrame::setMainWaterfallFFTSize(int fftSize) {
+    wxGetApp().getSpectrumProcessor()->setFFTSize(fftSize);
+    spectrumCanvas->setFFTSize(fftSize);
+    waterfallDataThread->getProcessor()->setFFTSize(fftSize);
+    waterfallCanvas->setFFTSize(fftSize);
+}

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -69,7 +69,8 @@ public:
     FFTVisualDataThread *getWaterfallDataThread();
 
     void updateModemProperties(ModemArgInfoList args);
-    
+    void setMainWaterfallFFTSize(int fftSize);
+
 private:
     void OnMenu(wxCommandEvent& event);
     void OnClose(wxCloseEvent& event);

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -442,7 +442,11 @@ void CubicSDR::setSampleRate(long long rate_in) {
     sdrThread->setSampleRate(sampleRate);
     setFrequency(frequency);
 
-    if (rate_in <= CHANNELIZER_RATE_MAX) {
+    if (rate_in <= CHANNELIZER_RATE_MAX / 2) {
+        appframe->setMainWaterfallFFTSize(512);
+        appframe->getWaterfallDataThread()->getProcessor()->setHideDC(false);
+        spectrumVisualThread->getProcessor()->setHideDC(false);
+    } else if (rate_in <= CHANNELIZER_RATE_MAX) {
         appframe->setMainWaterfallFFTSize(1024);
         appframe->getWaterfallDataThread()->getProcessor()->setHideDC(false);
         spectrumVisualThread->getProcessor()->setHideDC(false);

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -442,7 +442,7 @@ void CubicSDR::setSampleRate(long long rate_in) {
     sdrThread->setSampleRate(sampleRate);
     setFrequency(frequency);
 
-    if (rate_in <= CHANNELIZER_RATE_MAX / 2) {
+    if (rate_in <= CHANNELIZER_RATE_MAX / 8) {
         appframe->setMainWaterfallFFTSize(512);
         appframe->getWaterfallDataThread()->getProcessor()->setHideDC(false);
         spectrumVisualThread->getProcessor()->setHideDC(false);

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -441,6 +441,16 @@ void CubicSDR::setSampleRate(long long rate_in) {
     sampleRate = rate_in;
     sdrThread->setSampleRate(sampleRate);
     setFrequency(frequency);
+
+    if (rate_in <= CHANNELIZER_RATE_MAX) {
+        appframe->setMainWaterfallFFTSize(1024);
+        appframe->getWaterfallDataThread()->getProcessor()->setHideDC(false);
+        spectrumVisualThread->getProcessor()->setHideDC(false);
+    } else if (rate_in > CHANNELIZER_RATE_MAX) {
+        appframe->setMainWaterfallFFTSize(2048);
+        appframe->getWaterfallDataThread()->getProcessor()->setHideDC(true);
+        spectrumVisualThread->getProcessor()->setHideDC(true);
+    }
 }
 
 void CubicSDR::setDevice(SDRDeviceInfo *dev) {

--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -208,7 +208,7 @@ void AudioThread::enumerateDevices(std::vector<RtAudio::DeviceInfo> &devs) {
 
         std::cout << "Audio Device #" << i << " " << info.name << std::endl;
         std::cout << "\tDefault Output? " << (info.isDefaultOutput ? "Yes" : "No") << std::endl;
-        std::cout << "\tDefault Input? " << (info.isDefaultOutput ? "Yes" : "No") << std::endl;
+        std::cout << "\tDefault Input? " << (info.isDefaultInput ? "Yes" : "No") << std::endl;
         std::cout << "\tInput channels: " << info.inputChannels << std::endl;
         std::cout << "\tOutput channels: " << info.outputChannels << std::endl;
         std::cout << "\tDuplex channels: " << info.duplexChannels << std::endl;

--- a/src/panel/WaterfallPanel.cpp
+++ b/src/panel/WaterfallPanel.cpp
@@ -16,14 +16,6 @@ void WaterfallPanel::setup(int fft_size_in, int num_waterfall_lines_in) {
         points.resize(fft_size);
     }
     
-    for (int i = 0; i < 2; i++) {
-        if (waterfall[i]) {
-            glDeleteTextures(1, &waterfall[i]);
-            waterfall[i] = 0;
-        }
-        
-        waterfall_ofs[i] = waterfall_lines - 1;
-    }
     texInitialized.store(false);
     bufferInitialized.store(false);
 }
@@ -65,7 +57,7 @@ void WaterfallPanel::step() {
         return;
     }
     
-    if (points.size()) {
+    if (points.size() && points.size() == fft_size) {
         for (int j = 0; j < 2; j++) {
             for (int i = 0, iMax = half_fft_size; i < iMax; i++) {
                 float v = points[j * half_fft_size + i];
@@ -94,6 +86,15 @@ void WaterfallPanel::update() {
     }
     
     if (!texInitialized.load()) {
+        for (int i = 0; i < 2; i++) {
+            if (waterfall[i]) {
+                glDeleteTextures(1, &waterfall[i]);
+                waterfall[i] = 0;
+            }
+            
+            waterfall_ofs[i] = waterfall_lines - 1;
+        }
+
         glGenTextures(2, waterfall);
         
         unsigned char *waterfall_tex;
@@ -110,12 +111,13 @@ void WaterfallPanel::update() {
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
             
-            glBindTexture(GL_TEXTURE_2D, waterfall[i]);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, half_fft_size, waterfall_lines, 0, GL_COLOR_INDEX, GL_UNSIGNED_BYTE, (GLvoid *) waterfall_tex);
         }
         
         delete[] waterfall_tex;
-        
+
+        refreshTheme();
+
         texInitialized.store(true);
     }
     

--- a/src/process/SpectrumVisualProcessor.cpp
+++ b/src/process/SpectrumVisualProcessor.cpp
@@ -92,26 +92,30 @@ void SpectrumVisualProcessor::setup(int fftSize_in) {
     if (fftwInput) {
         free(fftwInput);
     }
-    fftwInput = (fftwf_complex*) fftwf_malloc(memSize);
+    //fftwInput = (fftwf_complex*) fftwf_malloc(memSize);
+	fftwInput = (fftwf_complex*)malloc(memSize);
     memset(fftwInput,0,memSize);
 
     if (fftInData) {
         free(fftInData);
     }
-    fftInData = (fftwf_complex*) fftwf_malloc(memSize);
+    //fftInData = (fftwf_complex*) fftwf_malloc(memSize);
+	fftInData = (fftwf_complex*)malloc(memSize);
     memset(fftwInput,0,memSize);
     
     if (fftLastData) {
         free(fftLastData);
     }
-    fftLastData = (fftwf_complex*) fftwf_malloc(memSize);
+    //fftLastData = (fftwf_complex*) fftwf_malloc(memSize);
+	fftLastData = (fftwf_complex*)malloc(memSize);
     memset(fftwInput,0,memSize);
     
     if (fftwOutput) {
         free(fftwOutput);
     }
-    fftwOutput = (fftwf_complex*) fftwf_malloc(memSize);
-    memset(fftwInput,0,memSize);
+    //fftwOutput = (fftwf_complex*) fftwf_malloc(memSize);
+	fftwOutput = (fftwf_complex*)malloc(memSize);
+	memset(fftwInput,0,memSize);
     
     if (fftw_plan) {
         fftwf_destroy_plan(fftw_plan);

--- a/src/process/SpectrumVisualProcessor.h
+++ b/src/process/SpectrumVisualProcessor.h
@@ -38,6 +38,7 @@ public:
     int getDesiredInputSize();
     
     void setup(int fftSize);
+    void setFFTSize(int fftSize);
     void setHideDC(bool hideDC);
     
     void setScaleFactor(float sf);
@@ -48,7 +49,7 @@ protected:
     
     ReBuffer<SpectrumVisualData> outputBuffers;
     std::atomic_bool is_view;
-    std::atomic_int fftSize;
+    std::atomic_int fftSize, newFFTSize;
     std::atomic_int fftSizeInternal;
     std::atomic_llong centerFreq;
     std::atomic_long bandwidth;
@@ -82,4 +83,5 @@ private:
     std::mutex busy_run;
     std::atomic_bool hideDC;
     std::atomic<float> scaleFactor;
+    std::atomic_bool fftSizeChanged;
 };

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -210,6 +210,7 @@ void SDRPostThread::terminate() {
 void SDRPostThread::runSingleCH(SDRThreadIQData *data_in) {
     if (sampleRate != data_in->sampleRate) {
         sampleRate = data_in->sampleRate;
+        numChannels = 1;
         doRefresh.store(true);
     }
     
@@ -232,28 +233,7 @@ void SDRPostThread::runSingleCH(SDRThreadIQData *data_in) {
         updateActiveDemodulators();
         doRefresh.store(false);
     }
-
-//    if (iqDataOutQueue != NULL && !iqDataOutQueue->full()) {
-//        DemodulatorThreadIQData *iqDataOut = visualDataBuffers.getBuffer();
-//        
-//        bool doVis = false;
-//        
-//        if (iqVisualQueue != NULL && !iqVisualQueue->full()) {
-//            doVis = true;
-//        }
-//        
-//        iqDataOut->setRefCount(1 + (doVis?1:0));
-//        
-//        iqDataOut->frequency = data_in->frequency;
-//        iqDataOut->sampleRate = data_in->sampleRate;
-//        iqDataOut->data.assign(data_in->data.begin(), data_in->data.begin() + dataSize);
-//        
-//        iqDataOutQueue->push(iqDataOut);
-//        if (doVis) {
-//            iqVisualQueue->push(iqDataOut);
-//        }
-//    }
-
+    
     int refCount = nRunDemods;
     bool doIQDataOut = (iqDataOutQueue != NULL && !iqDataOutQueue->full());
     bool doDemodVisOut = (nRunDemods && iqActiveDemodVisualQueue != NULL && !iqActiveDemodVisualQueue->full());

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -156,186 +156,47 @@ void SDRPostThread::run() {
     iqActiveDemodVisualQueue = (DemodulatorThreadInputQueue*)getOutputQueue("IQActiveDemodVisualDataOutput");
 
     iqDataInQueue->set_max_num_items(0);
-
-    std::vector<liquid_float_complex> dcBuf;
     
     while (!terminated) {
         SDRThreadIQData *data_in;
         
         iqDataInQueue->pop(data_in);
         //        std::lock_guard < std::mutex > lock(data_in->m_mutex);
-        
-        if (data_in && data_in->data.size() && data_in->numChannels) {
-            if (numChannels != data_in->numChannels || sampleRate != data_in->sampleRate) {
-                numChannels = data_in->numChannels;
-                sampleRate = data_in->sampleRate;
-                initPFBChannelizer();
-                doRefresh.store(true);
-            }
-            
-            int dataSize = data_in->data.size();
-            int outSize = data_in->data.size();
 
-            if (outSize > dataOut.capacity()) {
-                dataOut.reserve(outSize);
-            }
-            if (outSize != dataOut.size()) {
-                dataOut.resize(outSize);
-            }
-            int activeVisChannel = -1;
-            
-            if (iqDataOutQueue != NULL && !iqDataOutQueue->full() && activeVisChannel < 0) {
-                DemodulatorThreadIQData *iqDataOut = visualDataBuffers.getBuffer();
-                
-                bool doVis = false;
-                
-                if (iqVisualQueue != NULL && !iqVisualQueue->full()) {
-                    doVis = true;
-                }
-                
-                iqDataOut->setRefCount(1 + (doVis?1:0));
-                
-                iqDataOut->frequency = data_in->frequency;
-                iqDataOut->sampleRate = data_in->sampleRate;
-                iqDataOut->data.assign(data_in->data.begin(), data_in->data.begin() + dataSize);
+        busy_demod.lock();
 
-                iqDataOutQueue->push(iqDataOut);
-                if (doVis) {
-                    iqVisualQueue->push(iqDataOut);
-                }
+        if (data_in && data_in->data.size()) {
+            if(data_in->numChannels > 1) {
+                runPFBCH(data_in);
+            } else {
+                runSingleCH(data_in);
             }
-
-            busy_demod.lock();
-            
-            if (frequency != data_in->frequency) {
-                frequency = data_in->frequency;
-                doRefresh.store(true);
-            }
-
-            if (doRefresh.load()) {
-                updateActiveDemodulators();
-                updateChannels();
-                doRefresh.store(false);
-            }
-
-            DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
-            int activeDemodChannel = -1;
-            
-            // Find active demodulators
-            if (nRunDemods || (activeVisChannel >= 0)) {
-                
-                // channelize data
-                // firpfbch output rate is (input rate / channels)
-                for (int i = 0, iMax = dataSize; i < iMax; i+=numChannels) {
-                    firpfbch_crcf_analyzer_execute(channelizer, &data_in->data[i], &dataOut[i]);
-                }
-
-                for (int i = 0, iMax = numChannels+1; i < iMax; i++) {
-                    demodChannelActive[i] = 0;
-                }
-                
-                // Find nearest channel for each demodulator
-                for (int i = 0; i < nRunDemods; i++) {
-                    DemodulatorInstance *demod = runDemods[i];
-                    demodChannel[i] = getChannelAt(demod->getFrequency());
-                    if (demod == activeDemod) {
-                        activeDemodChannel = demodChannel[i];
-                    }
-                }
-                
-                for (int i = 0; i < nRunDemods; i++) {
-                    // cache channel usage refcounts
-                    if (demodChannel[i] >= 0) {
-                        demodChannelActive[demodChannel[i]]++;
-                    }
-                }
-                
-                // Run channels
-                for (int i = 0; i < numChannels+1; i++) {
-                    int doDemodVis = ((activeDemodChannel == i) && (iqActiveDemodVisualQueue != NULL) && !iqActiveDemodVisualQueue->full())?1:0;
-                    
-                    if (!doDemodVis && demodChannelActive[i] == 0) {
-                        continue;
-                    }
-                    
-                    DemodulatorThreadIQData *demodDataOut = buffers.getBuffer();
-                    demodDataOut->setRefCount(demodChannelActive[i] + doDemodVis);
-                    demodDataOut->frequency = chanCenters[i];
-                    demodDataOut->sampleRate = chanBw;
-                    
-                    // Calculate channel buffer size
-                    int chanDataSize = (outSize/numChannels);
-
-                    if (demodDataOut->data.size() != chanDataSize) {
-                        if (demodDataOut->data.capacity() < chanDataSize) {
-                            demodDataOut->data.reserve(chanDataSize);
-                        }
-                        demodDataOut->data.resize(chanDataSize);
-                    }
-
-                    int idx = i;
-                    
-                    // Extra channel wraps lower side band of lowest channel
-                    // to fix frequency gap on upper side of spectrum
-                    if (i == numChannels) {
-                        idx = (numChannels/2);
-                    }
-                    
-                    // prepare channel data buffer
-                    if (i == 0) {   // Channel 0 requires DC correction
-                        if (dcBuf.size() != chanDataSize) {
-                            dcBuf.resize(chanDataSize);
-                        }
-                        for (int j = 0; j < chanDataSize; j++) {
-                            dcBuf[j] = dataOut[idx];
-							idx += numChannels;
-						}
-                        iirfilt_crcf_execute_block(dcFilter, &dcBuf[0], chanDataSize, &demodDataOut->data[0]);
-                    } else {
-                        for (int j = 0; j < chanDataSize; j++) {
-                            demodDataOut->data[j] = dataOut[idx];
-							idx += numChannels;
-						}
-                    }
-
-                    if (doDemodVis) {
-                        iqActiveDemodVisualQueue->push(demodDataOut);
-                    }
-                    
-                    for (int j = 0; j < nRunDemods; j++) {
-                        if (demodChannel[j] == i) {
-                            DemodulatorInstance *demod = runDemods[j];
-                            demod->getIQInputDataPipe()->push(demodDataOut);
-                        }
-                    }
-                }
-            }
-            
-            bool doUpdate = false;
-            for (int j = 0; j < nRunDemods; j++) {
-                DemodulatorInstance *demod = runDemods[j];
-                if (abs(frequency - demod->getFrequency()) > (sampleRate / 2)) {
-                    doUpdate = true;
-                }
-            }
-            
-            if (doUpdate) {
-                updateActiveDemodulators();
-            }
-            
-            busy_demod.unlock();
         }
-        data_in->decRefCount();
-    }
 
-//    buffers.purge();
+        data_in->decRefCount();
+
+        bool doUpdate = false;
+        for (int j = 0; j < nRunDemods; j++) {
+            DemodulatorInstance *demod = runDemods[j];
+            if (abs(frequency - demod->getFrequency()) > (sampleRate / 2)) {
+                doUpdate = true;
+            }
+        }
+        
+        if (doUpdate) {
+            updateActiveDemodulators();
+        }
+        
+        busy_demod.unlock();
+    }
     
     if (iqVisualQueue && !iqVisualQueue->empty()) {
         DemodulatorThreadIQData *visualDataDummy;
         iqVisualQueue->pop(visualDataDummy);
     }
 
-//    visualDataBuffers.purge();
+    //    buffers.purge();
+    //    visualDataBuffers.purge();
 
     std::cout << "SDR post-processing thread done." << std::endl;
 }
@@ -344,4 +205,243 @@ void SDRPostThread::terminate() {
     terminated = true;
     SDRThreadIQData *dummy = new SDRThreadIQData;
     iqDataInQueue->push(dummy);
+}
+
+void SDRPostThread::runSingleCH(SDRThreadIQData *data_in) {
+    if (sampleRate != data_in->sampleRate) {
+        sampleRate = data_in->sampleRate;
+        doRefresh.store(true);
+    }
+    
+    int dataSize = data_in->data.size();
+    int outSize = data_in->data.size();
+    
+    if (outSize > dataOut.capacity()) {
+        dataOut.reserve(outSize);
+    }
+    if (outSize != dataOut.size()) {
+        dataOut.resize(outSize);
+    }
+    
+    if (frequency != data_in->frequency) {
+        frequency = data_in->frequency;
+        doRefresh.store(true);
+    }
+    
+    if (doRefresh.load()) {
+        updateActiveDemodulators();
+        doRefresh.store(false);
+    }
+
+//    if (iqDataOutQueue != NULL && !iqDataOutQueue->full()) {
+//        DemodulatorThreadIQData *iqDataOut = visualDataBuffers.getBuffer();
+//        
+//        bool doVis = false;
+//        
+//        if (iqVisualQueue != NULL && !iqVisualQueue->full()) {
+//            doVis = true;
+//        }
+//        
+//        iqDataOut->setRefCount(1 + (doVis?1:0));
+//        
+//        iqDataOut->frequency = data_in->frequency;
+//        iqDataOut->sampleRate = data_in->sampleRate;
+//        iqDataOut->data.assign(data_in->data.begin(), data_in->data.begin() + dataSize);
+//        
+//        iqDataOutQueue->push(iqDataOut);
+//        if (doVis) {
+//            iqVisualQueue->push(iqDataOut);
+//        }
+//    }
+
+    int refCount = nRunDemods;
+    bool doIQDataOut = (iqDataOutQueue != NULL && !iqDataOutQueue->full());
+    bool doDemodVisOut = (nRunDemods && iqActiveDemodVisualQueue != NULL && !iqActiveDemodVisualQueue->full());
+    bool doVisOut = (iqVisualQueue != NULL && !iqVisualQueue->full());
+    
+    if (doIQDataOut) {
+        refCount++;
+    }
+    if (doDemodVisOut) {
+        refCount++;
+    }
+    if (doVisOut) {
+        refCount++;
+    }
+    
+    if (refCount) {
+        DemodulatorThreadIQData *demodDataOut = buffers.getBuffer();
+        demodDataOut->setRefCount(refCount);
+        demodDataOut->frequency = frequency;
+        demodDataOut->sampleRate = sampleRate;
+        
+        if (demodDataOut->data.size() != dataSize) {
+            if (demodDataOut->data.capacity() < dataSize) {
+                demodDataOut->data.reserve(dataSize);
+            }
+            demodDataOut->data.resize(dataSize);
+        }
+        
+        iirfilt_crcf_execute_block(dcFilter, &data_in->data[0], dataSize, &demodDataOut->data[0]);
+
+        if (doDemodVisOut) {
+            iqActiveDemodVisualQueue->push(demodDataOut);
+        }
+        
+        if (doIQDataOut) {
+            iqDataOutQueue->push(demodDataOut);
+        }
+
+        if (doVisOut) {
+            iqVisualQueue->push(demodDataOut);
+        }
+        
+        for (int i = 0; i < nRunDemods; i++) {
+            runDemods[i]->getIQInputDataPipe()->push(demodDataOut);
+        }
+    }
+}
+
+void SDRPostThread::runPFBCH(SDRThreadIQData *data_in) {
+    if (numChannels != data_in->numChannels || sampleRate != data_in->sampleRate) {
+        numChannels = data_in->numChannels;
+        sampleRate = data_in->sampleRate;
+        initPFBChannelizer();
+        doRefresh.store(true);
+    }
+    
+    int dataSize = data_in->data.size();
+    int outSize = data_in->data.size();
+    
+    if (outSize > dataOut.capacity()) {
+        dataOut.reserve(outSize);
+    }
+    if (outSize != dataOut.size()) {
+        dataOut.resize(outSize);
+    }
+    
+    if (iqDataOutQueue != NULL && !iqDataOutQueue->full()) {
+        DemodulatorThreadIQData *iqDataOut = visualDataBuffers.getBuffer();
+        
+        bool doVis = false;
+        
+        if (iqVisualQueue != NULL && !iqVisualQueue->full()) {
+            doVis = true;
+        }
+        
+        iqDataOut->setRefCount(1 + (doVis?1:0));
+        
+        iqDataOut->frequency = data_in->frequency;
+        iqDataOut->sampleRate = data_in->sampleRate;
+        iqDataOut->data.assign(data_in->data.begin(), data_in->data.begin() + dataSize);
+        
+        iqDataOutQueue->push(iqDataOut);
+        if (doVis) {
+            iqVisualQueue->push(iqDataOut);
+        }
+    }
+    
+    if (frequency != data_in->frequency) {
+        frequency = data_in->frequency;
+        doRefresh.store(true);
+    }
+    
+    if (doRefresh.load()) {
+        updateActiveDemodulators();
+        updateChannels();
+        doRefresh.store(false);
+    }
+    
+    DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+    int activeDemodChannel = -1;
+    
+    // Find active demodulators
+    if (nRunDemods) {
+        
+        // channelize data
+        // firpfbch output rate is (input rate / channels)
+        for (int i = 0, iMax = dataSize; i < iMax; i+=numChannels) {
+            firpfbch_crcf_analyzer_execute(channelizer, &data_in->data[i], &dataOut[i]);
+        }
+        
+        for (int i = 0, iMax = numChannels+1; i < iMax; i++) {
+            demodChannelActive[i] = 0;
+        }
+        
+        // Find nearest channel for each demodulator
+        for (int i = 0; i < nRunDemods; i++) {
+            DemodulatorInstance *demod = runDemods[i];
+            demodChannel[i] = getChannelAt(demod->getFrequency());
+            if (demod == activeDemod) {
+                activeDemodChannel = demodChannel[i];
+            }
+        }
+        
+        for (int i = 0; i < nRunDemods; i++) {
+            // cache channel usage refcounts
+            if (demodChannel[i] >= 0) {
+                demodChannelActive[demodChannel[i]]++;
+            }
+        }
+        
+        // Run channels
+        for (int i = 0; i < numChannels+1; i++) {
+            int doDemodVis = ((activeDemodChannel == i) && (iqActiveDemodVisualQueue != NULL) && !iqActiveDemodVisualQueue->full())?1:0;
+            
+            if (!doDemodVis && demodChannelActive[i] == 0) {
+                continue;
+            }
+            
+            DemodulatorThreadIQData *demodDataOut = buffers.getBuffer();
+            demodDataOut->setRefCount(demodChannelActive[i] + doDemodVis);
+            demodDataOut->frequency = chanCenters[i];
+            demodDataOut->sampleRate = chanBw;
+            
+            // Calculate channel buffer size
+            int chanDataSize = (outSize/numChannels);
+            
+            if (demodDataOut->data.size() != chanDataSize) {
+                if (demodDataOut->data.capacity() < chanDataSize) {
+                    demodDataOut->data.reserve(chanDataSize);
+                }
+                demodDataOut->data.resize(chanDataSize);
+            }
+            
+            int idx = i;
+            
+            // Extra channel wraps lower side band of lowest channel
+            // to fix frequency gap on upper side of spectrum
+            if (i == numChannels) {
+                idx = (numChannels/2);
+            }
+            
+            // prepare channel data buffer
+            if (i == 0) {   // Channel 0 requires DC correction
+                if (dcBuf.size() != chanDataSize) {
+                    dcBuf.resize(chanDataSize);
+                }
+                for (int j = 0; j < chanDataSize; j++) {
+                    dcBuf[j] = dataOut[idx];
+                    idx += numChannels;
+                }
+                iirfilt_crcf_execute_block(dcFilter, &dcBuf[0], chanDataSize, &demodDataOut->data[0]);
+            } else {
+                for (int j = 0; j < chanDataSize; j++) {
+                    demodDataOut->data[j] = dataOut[idx];
+                    idx += numChannels;
+                }
+            }
+            
+            if (doDemodVis) {
+                iqActiveDemodVisualQueue->push(demodDataOut);
+            }
+            
+            for (int j = 0; j < nRunDemods; j++) {
+                if (demodChannel[j] == i) {
+                    DemodulatorInstance *demod = runDemods[j];
+                    demod->getIQInputDataPipe()->push(demodDataOut);
+                }
+            }
+        }
+    }
 }

--- a/src/sdr/SDRPostThread.h
+++ b/src/sdr/SDRPostThread.h
@@ -18,6 +18,8 @@ public:
     void run();
     void terminate();
 
+    void runSingleCH(SDRThreadIQData *data_in);
+    void runPFBCH(SDRThreadIQData *data_in);
     void setIQVisualRange(long long frequency, int bandwidth);
         
 protected:
@@ -54,4 +56,5 @@ private:
     long long frequency;
     firpfbch_crcf channelizer;
     iirfilt_crcf dcFilter;
+    std::vector<liquid_float_complex> dcBuf;
 };

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -333,6 +333,10 @@ int SDRThread::getOptimalElementCount(long long sampleRate, int fps) {
 }
 
 int SDRThread::getOptimalChannelCount(long long sampleRate) {
+    if (sampleRate <= CHANNELIZER_RATE_MAX) {
+        return 1;
+    }
+    
     int optimal_rate = CHANNELIZER_RATE_MAX;
     int optimal_count = int(ceil(double(sampleRate)/double(optimal_rate)));
     

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -169,6 +169,9 @@ void SpectrumCanvas::setScaleFactorEnabled(bool en) {
     scaleFactorEnabled = en;
 }
 
+void SpectrumCanvas::setFFTSize(int fftSize) {
+    spectrumPanel.setFFTSize(fftSize);
+}
 
 void SpectrumCanvas::updateScaleFactor(float factor) {
     SpectrumVisualProcessor *sp = wxGetApp().getSpectrumProcessor();

--- a/src/visual/SpectrumCanvas.h
+++ b/src/visual/SpectrumCanvas.h
@@ -26,6 +26,7 @@ public:
     void disableView();
 
     void setScaleFactorEnabled(bool en);
+    void setFFTSize(int fftSize);
     
     SpectrumVisualDataQueue *getVisualDataQueue();
     

--- a/src/visual/WaterfallCanvas.h
+++ b/src/visual/WaterfallCanvas.h
@@ -20,6 +20,7 @@ public:
 
     WaterfallCanvas(wxWindow *parent, int *attribList = NULL);
     void setup(int fft_size_in, int waterfall_lines_in);
+    void setFFTSize(int fft_size_in);
     ~WaterfallCanvas();
 
     DragState getDragState();
@@ -59,7 +60,7 @@ private:
     DragState dragState;
     DragState nextDragState;
 
-    int fft_size;
+    int fft_size, new_fft_size;
     int waterfall_lines;
     int dragOfs;
 
@@ -77,6 +78,7 @@ private:
     bool preBuf;
     std::mutex tex_update;
     int minBandwidth;
+    std::atomic_bool fft_size_changed;
     // event table
 wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
Low bandwidth threshold is equal to the channelizer maximum channel rate.

channelizer_max_rate = 500KHz

When input sample rate <= channelizer_max_rate:
- PFBCH is disabled
- Reduces FFT display to 1024

When input sample rate <= channelizer_max_rate / 8:
- Reduces FFT display to 512
