### PR TITLE
Remove invalid const

### DIFF
--- a/src/sdr/SDRDeviceInfo.cpp
+++ b/src/sdr/SDRDeviceInfo.cpp
@@ -174,7 +174,7 @@ std::string SDRDeviceInfo::getDeviceId() {
     return deviceId;
 }
 
-const int SDRDeviceInfo::getIndex() const {
+int SDRDeviceInfo::getIndex() const {
     return index;
 }
 

--- a/src/sdr/SDRDeviceInfo.h
+++ b/src/sdr/SDRDeviceInfo.h
@@ -85,7 +85,7 @@ public:
     
     std::string getDeviceId();
     
-    const int getIndex() const;
+    int getIndex() const;
     void setIndex(const int index);
     
     bool isAvailable() const;


### PR DESCRIPTION
const int return value doesn't really exist / is ignored. Fix a warning.