### PR TITLE
Audio vis output queue nullptr crash and misc changes

### DIFF
--- a/src/IOThread.cpp
+++ b/src/IOThread.cpp
@@ -50,7 +50,7 @@ void IOThread::setInputQueue(std::string qname, ThreadQueueBase *threadQueue) {
     this->onBindInput(qname, threadQueue);
 };
 
-void *IOThread::getInputQueue(std::string qname) {
+ThreadQueueBase *IOThread::getInputQueue(std::string qname) {
     return input_queues[qname];
 };
 
@@ -59,7 +59,7 @@ void IOThread::setOutputQueue(std::string qname, ThreadQueueBase *threadQueue) {
     this->onBindOutput(qname, threadQueue);
 };
 
-void *IOThread::getOutputQueue(std::string qname) {
+ThreadQueueBase *IOThread::getOutputQueue(std::string qname) {
     return output_queues[qname];
 };
 

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -115,9 +115,9 @@ public:
     virtual void onBindInput(std::string name, ThreadQueueBase* threadQueue);
 
     void setInputQueue(std::string qname, ThreadQueueBase *threadQueue);
-    void *getInputQueue(std::string qname);
+    ThreadQueueBase *getInputQueue(std::string qname);
     void setOutputQueue(std::string qname, ThreadQueueBase *threadQueue);
-    void *getOutputQueue(std::string qname);
+    ThreadQueueBase *getOutputQueue(std::string qname);
     
 protected:
     std::map<std::string, ThreadQueueBase *, map_string_less> input_queues;

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -21,21 +21,27 @@ struct map_string_less : public std::binary_function<std::string,std::string,boo
 
 class ReferenceCounter {
 public:
-    mutable std::mutex m_mutex;
     
     void setRefCount(int rc) {
-        refCount.store(rc);
+        std::lock_guard < std::recursive_mutex > lock(m_mutex);
+        refCount = rc;
     }
     
     void decRefCount() {
-        refCount.store(refCount.load()-1);
+        std::lock_guard < std::recursive_mutex > lock(m_mutex);
+        refCount--;
     }
     
     int getRefCount() {
-        return refCount.load();
+        std::lock_guard < std::recursive_mutex > lock(m_mutex);
+        return refCount;
     }
 protected:
-    std::atomic_int refCount;
+    //this is a basic mutex for all ReferenceCounter derivatives operations INCLUDING the counter itself for consistency !
+   mutable std::recursive_mutex m_mutex;
+
+private:
+   int refCount;
 };
 
 

--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -379,8 +379,8 @@ void AudioThread::run() {
 
     std::cout << "Audio thread started." << std::endl;
 
-    inputQueue = (AudioThreadInputQueue *)getInputQueue("AudioDataInput");
-    threadQueueNotify = (DemodulatorThreadCommandQueue*)getOutputQueue("NotifyQueue");
+    inputQueue = static_cast<AudioThreadInputQueue *>(getInputQueue("AudioDataInput"));
+    threadQueueNotify = static_cast<DemodulatorThreadCommandQueue*>(getOutputQueue("NotifyQueue"));
     
     while (!terminated) {
         AudioThreadCommand command;

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -28,7 +28,7 @@ public:
     }
 
     ~AudioThreadInput() {
-        std::lock_guard < std::mutex > lock(m_mutex);
+        std::lock_guard < std::recursive_mutex > lock(m_mutex);
     }
 };
 

--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -90,7 +90,7 @@ public:
     }
 
     ~DemodulatorThreadPostIQData() {
-        std::lock_guard < std::mutex > lock(m_mutex);
+        std::lock_guard < std::recursive_mutex > lock(m_mutex);
     }
 };
 

--- a/src/demod/DemodulatorPreThread.cpp
+++ b/src/demod/DemodulatorPreThread.cpp
@@ -56,9 +56,9 @@ void DemodulatorPreThread::run() {
 
     ReBuffer<DemodulatorThreadPostIQData> buffers("DemodulatorPreThreadBuffers");
 
-    iqInputQueue = (DemodulatorThreadInputQueue*)getInputQueue("IQDataInput");
-    iqOutputQueue = (DemodulatorThreadPostInputQueue*)getOutputQueue("IQDataOutput");
-    threadQueueNotify = (DemodulatorThreadCommandQueue*)getOutputQueue("NotifyQueue");
+    iqInputQueue = static_cast<DemodulatorThreadInputQueue*>(getInputQueue("IQDataInput"));
+    iqOutputQueue = static_cast<DemodulatorThreadPostInputQueue*>(getOutputQueue("IQDataOutput"));
+    threadQueueNotify = static_cast<DemodulatorThreadCommandQueue*>(getOutputQueue("NotifyQueue"));
     
     std::vector<liquid_float_complex> in_buf_data;
     std::vector<liquid_float_complex> out_buf_data;

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -32,7 +32,7 @@ void DemodulatorThread::onBindOutput(std::string name, ThreadQueueBase *threadQu
         //protects because it may be changed at runtime
         std::lock_guard < std::mutex > lock(m_mutexAudioVisOutputQueue);
 
-        audioVisOutputQueue = (DemodulatorThreadOutputQueue *)threadQueue;
+        audioVisOutputQueue = static_cast<DemodulatorThreadOutputQueue*>(threadQueue);
     }
 }
 
@@ -69,10 +69,10 @@ void DemodulatorThread::run() {
     
     std::cout << "Demodulator thread started.." << std::endl;
     
-    iqInputQueue = (DemodulatorThreadPostInputQueue*)getInputQueue("IQDataInput");
-    audioOutputQueue = (AudioThreadInputQueue*)getOutputQueue("AudioDataOutput");
-    threadQueueControl = (DemodulatorThreadControlCommandQueue *)getInputQueue("ControlQueue");
-    threadQueueNotify = (DemodulatorThreadCommandQueue*)getOutputQueue("NotifyQueue");
+    iqInputQueue = static_cast<DemodulatorThreadPostInputQueue*>(getInputQueue("IQDataInput"));
+    audioOutputQueue = static_cast<AudioThreadInputQueue*>(getOutputQueue("AudioDataOutput"));
+    threadQueueControl = static_cast<DemodulatorThreadControlCommandQueue *>(getInputQueue("ControlQueue"));
+    threadQueueNotify = static_cast<DemodulatorThreadCommandQueue*>(getOutputQueue("NotifyQueue"));
     
     ModemIQData modemData;
     

--- a/src/demod/DemodulatorThread.h
+++ b/src/demod/DemodulatorThread.h
@@ -40,8 +40,8 @@ protected:
     float abMagnitude(double alpha, double beta, float inphase, float quadrature);
     float linearToDb(float linear);
 
-    DemodulatorInstance *demodInstance;
-    ReBuffer<AudioThreadInput> outputBuffers;
+    DemodulatorInstance *demodInstance = nullptr;
+    ReBuffer<AudioThreadInput> outputBuffers = nullptr;
 
     std::atomic_bool muted;
 
@@ -49,12 +49,15 @@ protected:
     std::atomic<float> signalLevel;
     bool squelchEnabled, squelchBreak;
     
-    Modem *cModem;
-    ModemKit *cModemKit;
+    Modem *cModem = nullptr;
+    ModemKit *cModemKit = nullptr;
     
-    DemodulatorThreadPostInputQueue* iqInputQueue;
-    AudioThreadInputQueue *audioOutputQueue;
-    DemodulatorThreadOutputQueue* audioVisOutputQueue;
-    DemodulatorThreadControlCommandQueue *threadQueueControl;
-    DemodulatorThreadCommandQueue* threadQueueNotify;
+    DemodulatorThreadPostInputQueue* iqInputQueue = nullptr;
+    AudioThreadInputQueue *audioOutputQueue = nullptr;
+    DemodulatorThreadOutputQueue* audioVisOutputQueue = nullptr;
+    DemodulatorThreadControlCommandQueue *threadQueueControl = nullptr;
+    DemodulatorThreadCommandQueue* threadQueueNotify = nullptr;
+
+    //protects the audioVisOutputQueue dynamic binding change at runtime (in DemodulatorMgr)
+    mutable std::mutex m_mutexAudioVisOutputQueue;
 };

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -14,8 +14,8 @@ void DemodulatorWorkerThread::run() {
 
     std::cout << "Demodulator worker thread started.." << std::endl;
     
-    commandQueue = (DemodulatorThreadWorkerCommandQueue *)getInputQueue("WorkerCommandQueue");
-    resultQueue = (DemodulatorThreadWorkerResultQueue *)getOutputQueue("WorkerResultQueue");
+    commandQueue = static_cast<DemodulatorThreadWorkerCommandQueue *>(getInputQueue("WorkerCommandQueue"));
+    resultQueue = static_cast<DemodulatorThreadWorkerResultQueue *>(getOutputQueue("WorkerResultQueue"));
     
     while (!terminated) {
         bool filterChanged = false;

--- a/src/modules/modem/Modem.h
+++ b/src/modules/modem/Modem.h
@@ -32,7 +32,7 @@ public:
     }
     
     ~ModemIQData() {
-        std::lock_guard < std::mutex > lock(m_mutex);
+        std::lock_guard < std::recursive_mutex > lock(m_mutex);
     }
 };
 

--- a/src/process/FFTVisualDataThread.cpp
+++ b/src/process/FFTVisualDataThread.cpp
@@ -24,8 +24,8 @@ SpectrumVisualProcessor *FFTVisualDataThread::getProcessor() {
 }
 
 void FFTVisualDataThread::run() {
-    DemodulatorThreadInputQueue *pipeIQDataIn = (DemodulatorThreadInputQueue *)getInputQueue("IQDataInput");
-    SpectrumVisualDataQueue *pipeFFTDataOut = (SpectrumVisualDataQueue *)getOutputQueue("FFTDataOutput");
+    DemodulatorThreadInputQueue *pipeIQDataIn = static_cast<DemodulatorThreadInputQueue *>(getInputQueue("IQDataInput"));
+    SpectrumVisualDataQueue *pipeFFTDataOut = static_cast<SpectrumVisualDataQueue *>(getOutputQueue("FFTDataOutput"));
     
     fftQueue.set_max_num_items(100);
     pipeFFTDataOut->set_max_num_items(100);

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -161,10 +161,10 @@ void SDRPostThread::run() {
 
     std::cout << "SDR post-processing thread started.." << std::endl;
 
-    iqDataInQueue = (SDRThreadIQDataQueue*)getInputQueue("IQDataInput");
-    iqDataOutQueue = (DemodulatorThreadInputQueue*)getOutputQueue("IQDataOutput");
-    iqVisualQueue = (DemodulatorThreadInputQueue*)getOutputQueue("IQVisualDataOutput");
-    iqActiveDemodVisualQueue = (DemodulatorThreadInputQueue*)getOutputQueue("IQActiveDemodVisualDataOutput");
+    iqDataInQueue = static_cast<SDRThreadIQDataQueue*>(getInputQueue("IQDataInput"));
+    iqDataOutQueue = static_cast<DemodulatorThreadInputQueue*>(getOutputQueue("IQDataOutput"));
+    iqVisualQueue = static_cast<DemodulatorThreadInputQueue*>(getOutputQueue("IQVisualDataOutput"));
+    iqActiveDemodVisualQueue = static_cast<DemodulatorThreadInputQueue*>(getOutputQueue("IQActiveDemodVisualDataOutput"));
 
     iqDataInQueue->set_max_num_items(0);
     

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -216,7 +216,7 @@ void SDRThread::readStream(SDRThreadIQDataQueue* iqDataOutQueue) {
 }
 
 void SDRThread::readLoop() {
-    SDRThreadIQDataQueue* iqDataOutQueue = (SDRThreadIQDataQueue*) getOutputQueue("IQDataOutput");
+    SDRThreadIQDataQueue* iqDataOutQueue = static_cast<SDRThreadIQDataQueue*>( getOutputQueue("IQDataOutput"));
     
     if (iqDataOutQueue == NULL) {
         return;


### PR DESCRIPTION
Hello @cjcliffe here is my first ever pull request in GitHub:)
There are several commits in this pull request:
-  FIX is the real essential fix for the crashes I had very often, due to a really unprotected concurrent modification of the audio vis output queue,
- MISCn are various suggestions of improvements, that you may consider or discard at will.

All commits are orthogonal, and the affected code has enough coments to be  self-explanatory I guess.

