### PR TITLE
Fix limitless manual gain slider while using mouse wheel

### DIFF
--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -164,6 +164,15 @@ void GainCanvas::OnMouseWheelMoved(wxMouseEvent& event) {
         gInfo = gainInfo[panelHit];
         
         gInfo->current = gInfo->current + ((movement / 100.0) * ((gInfo->high - gInfo->low) / 100.0));
+        
+        //BEGIN Clamp to prevent the meter to escape
+        if (gInfo->current > gInfo->high) {
+            gInfo->current = gInfo->high;
+        }
+        if (gInfo->current < gInfo->low) {
+            gInfo->current = gInfo->low;
+        }
+       
         gInfo->changed = true;
         
         float levelVal = float(gInfo->current-gInfo->low)/float(gInfo->high-gInfo->low);


### PR DESCRIPTION
@cjcliffe Gain slider is working with mousewheel, except the meter is escaping to +-infinity:)

That actually fixes it in GainCanvas.cpp:

``````cpp
void GainCanvas::OnMouseWheelMoved(wxMouseEvent& event) {
    InteractiveCanvas::OnMouseWheelMoved(event);
  ...
        gInfo->current = gInfo->current + ((movement / 100.0) * ((gInfo->high - gInfo->low) / 100.0));

        //BEGIN Clamp to prevent the meter to escape :)
        if (gInfo->current > gInfo->high) {
            gInfo->current = gInfo->high;
        }
        if (gInfo->current < gInfo->low) {
            gInfo->current = gInfo->low;
        }
        //END Clamp to prevent the meter to escape :)

        gInfo->changed = true;
        
        float levelVal = float(gInfo->current-gInfo->low)/float(gInfo->high-gInfo->low);
        gInfo->levelPanel.setSize(1.0, levelVal);
        gInfo->levelPanel.setPosition(0.0, levelVal-1.0);

        gInfo->valuePanel.setText(std::to_string(int(gInfo->current)));
    }
``````
It is just the same kind of clamping that is already done in MeterCanvas.