### PR TITLE
Replace mutex lock/unlock pairs with guards, cleanups

### DIFF
--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -47,39 +47,39 @@ bool DeviceConfig::getAGCMode() {
 
 
 void DeviceConfig::setDeviceId(std::string deviceId) {
-    busy_lock.lock();
+    std::lock_guard < std::mutex > lock(busy_lock);
     this->deviceId = deviceId;
-    busy_lock.unlock();
+    
 }
 
 std::string DeviceConfig::getDeviceId() {
     std::string tmp;
 
-    busy_lock.lock();
+    std::lock_guard < std::mutex > lock(busy_lock);
     tmp = deviceId;
-    busy_lock.unlock();
+    
 
     return tmp;
 }
 
 void DeviceConfig::setDeviceName(std::string deviceName) {
-    busy_lock.lock();
+    std::lock_guard < std::mutex > lock(busy_lock);
     this->deviceName = deviceName;
-    busy_lock.unlock();
+   
 }
 
 std::string DeviceConfig::getDeviceName() {
     std::string tmp;
     
-    busy_lock.lock();
+    std::lock_guard < std::mutex > lock(busy_lock);
     tmp = (deviceName=="")?deviceId:deviceName;
-    busy_lock.unlock();
+   
     
     return tmp;
 }
 
 void DeviceConfig::save(DataNode *node) {
-    busy_lock.lock();
+    std::lock_guard < std::mutex > lock(busy_lock);
     *node->newChild("id") = deviceId;
     *node->newChild("name") = deviceName;
     *node->newChild("ppm") = (int)ppm.load();
@@ -115,11 +115,11 @@ void DeviceConfig::save(DataNode *node) {
             *gainNode->newChild("value") = gain_i->second;
         }
     }
-    busy_lock.unlock();
+   
 }
 
 void DeviceConfig::load(DataNode *node) {
-    busy_lock.lock();
+    std::lock_guard < std::mutex > lock(busy_lock);
     if (node->hasAnother("name")) {
         deviceName = node->getNext("name")->element()->toString();
     }
@@ -201,7 +201,7 @@ void DeviceConfig::load(DataNode *node) {
             }
         }
     }
-    busy_lock.unlock();
+   
 }
 
 void DeviceConfig::setStreamOpts(ConfigSettings opts) {

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1604,16 +1604,16 @@ bool AppFrame::loadSession(std::string fileName) {
         DataNode *header = l.rootNode()->getNext("header");
 
         if (header->hasAnother("version")) {
-            std::string version(*header->getNext("version"));
+        std::string version(*header->getNext("version"));
 //            std::cout << "Loading " << version << " session file" << std::endl;
         }
 
         if (header->hasAnother("center_freq")) {
-            long long center_freq = *header->getNext("center_freq");
+        long long center_freq = *header->getNext("center_freq");
 //            std::cout << "\tCenter Frequency: " << center_freq << std::endl;
-            wxGetApp().setFrequency(center_freq);
-        }
 
+        wxGetApp().setFrequency(center_freq);
+        }
 
         if (header->hasAnother("sample_rate")) {
             int sample_rate = *header->getNext("sample_rate");
@@ -1631,135 +1631,135 @@ bool AppFrame::loadSession(std::string fileName) {
         }
 
         if (l.rootNode()->hasAnother("demodulators")) {
-            DataNode *demodulators = l.rootNode()->getNext("demodulators");
+        DataNode *demodulators = l.rootNode()->getNext("demodulators");
 
-            int numDemodulators = 0;
-            DemodulatorInstance *loadedDemod = NULL;
-            DemodulatorInstance *newDemod = NULL;
-            std::vector<DemodulatorInstance *> demodsLoaded;
+        int numDemodulators = 0;
+        DemodulatorInstance *loadedDemod = NULL;
+        DemodulatorInstance *newDemod = NULL;
+        std::vector<DemodulatorInstance *> demodsLoaded;
+        
+        while (demodulators->hasAnother("demodulator")) {
+            DataNode *demod = demodulators->getNext("demodulator");
+
+            if (!demod->hasAnother("bandwidth") || !demod->hasAnother("frequency")) {
+                continue;
+            }
+
+            long bandwidth = *demod->getNext("bandwidth");
+            long long freq = *demod->getNext("frequency");
+            float squelch_level = demod->hasAnother("squelch_level") ? (float) *demod->getNext("squelch_level") : 0;
+            int squelch_enabled = demod->hasAnother("squelch_enabled") ? (int) *demod->getNext("squelch_enabled") : 0;
+            int muted = demod->hasAnother("muted") ? (int) *demod->getNext("muted") : 0;
+            int delta_locked = demod->hasAnother("delta_lock") ? (int) *demod->getNext("delta_lock") : 0;
+            int delta_ofs = demod->hasAnother("delta_ofs") ? (int) *demod->getNext("delta_ofs") : 0;
+            std::string output_device = demod->hasAnother("output_device") ? string(*(demod->getNext("output_device"))) : "";
+            float gain = demod->hasAnother("gain") ? (float) *demod->getNext("gain") : 1.0;
             
-            while (demodulators->hasAnother("demodulator")) {
-                DataNode *demod = demodulators->getNext("demodulator");
+            std::string type = "FM";
 
-                if (!demod->hasAnother("bandwidth") || !demod->hasAnother("frequency")) {
-                    continue;
+            DataNode *demodTypeNode = demod->hasAnother("type")?demod->getNext("type"):nullptr;
+            
+            if (demodTypeNode && demodTypeNode->element()->getDataType() == DATA_INT) {
+                int legacyType = *demodTypeNode;
+                int legacyStereo = demod->hasAnother("stereo") ? (int) *demod->getNext("stereo") : 0;
+                switch (legacyType) {   // legacy demod ID
+                    case 1: type = legacyStereo?"FMS":"FM"; break;
+                    case 2: type = "AM"; break;
+                    case 3: type = "LSB"; break;
+                    case 4: type = "USB"; break;
+                    case 5: type = "DSB"; break;
+                    case 6: type = "ASK"; break;
+                    case 7: type = "APSK"; break;
+                    case 8: type = "BPSK"; break;
+                    case 9: type = "DPSK"; break;
+                    case 10: type = "PSK"; break;
+                    case 11: type = "OOK"; break;
+                    case 12: type = "ST"; break;
+                    case 13: type = "SQAM"; break;
+                    case 14: type = "QAM"; break;
+                    case 15: type = "QPSK"; break;
+                    case 16: type = "I/Q"; break;
+                    default: type = "FM"; break;
                 }
+            } else if (demodTypeNode && demodTypeNode->element()->getDataType() == DATA_STRING) {
+                demodTypeNode->element()->get(type);
+            }
 
-                long bandwidth = *demod->getNext("bandwidth");
-                long long freq = *demod->getNext("frequency");
-                float squelch_level = demod->hasAnother("squelch_level") ? (float) *demod->getNext("squelch_level") : 0;
-                int squelch_enabled = demod->hasAnother("squelch_enabled") ? (int) *demod->getNext("squelch_enabled") : 0;
-                int muted = demod->hasAnother("muted") ? (int) *demod->getNext("muted") : 0;
-                int delta_locked = demod->hasAnother("delta_lock") ? (int) *demod->getNext("delta_lock") : 0;
-                int delta_ofs = demod->hasAnother("delta_ofs") ? (int) *demod->getNext("delta_ofs") : 0;
-                std::string output_device = demod->hasAnother("output_device") ? string(*(demod->getNext("output_device"))) : "";
-                float gain = demod->hasAnother("gain") ? (float) *demod->getNext("gain") : 1.0;
-                
-                std::string type = "FM";
-
-                DataNode *demodTypeNode = demod->hasAnother("type")?demod->getNext("type"):nullptr;
-                
-                if (demodTypeNode && demodTypeNode->element()->getDataType() == DATA_INT) {
-                    int legacyType = *demodTypeNode;
-                    int legacyStereo = demod->hasAnother("stereo") ? (int) *demod->getNext("stereo") : 0;
-                    switch (legacyType) {   // legacy demod ID
-                        case 1: type = legacyStereo?"FMS":"FM"; break;
-                        case 2: type = "AM"; break;
-                        case 3: type = "LSB"; break;
-                        case 4: type = "USB"; break;
-                        case 5: type = "DSB"; break;
-                        case 6: type = "ASK"; break;
-                        case 7: type = "APSK"; break;
-                        case 8: type = "BPSK"; break;
-                        case 9: type = "DPSK"; break;
-                        case 10: type = "PSK"; break;
-                        case 11: type = "OOK"; break;
-                        case 12: type = "ST"; break;
-                        case 13: type = "SQAM"; break;
-                        case 14: type = "QAM"; break;
-                        case 15: type = "QPSK"; break;
-                        case 16: type = "I/Q"; break;
-                        default: type = "FM"; break;
-                    }
-                } else if (demodTypeNode && demodTypeNode->element()->getDataType() == DATA_STRING) {
-                    demodTypeNode->element()->get(type);
-                }
-
-                ModemSettings mSettings;
-                
-                if (demod->hasAnother("settings")) {
-                    DataNode *modemSettings = demod->getNext("settings");
-                    for (int msi = 0, numSettings = modemSettings->numChildren(); msi < numSettings; msi++) {
-                        DataNode *settingNode = modemSettings->child(msi);
-                        std::string keyName = settingNode->getName();
-                        std::string strSettingValue = settingNode->element()->toString();
-                        
-                        if (keyName != "" && strSettingValue != "") {
-                            mSettings[keyName] = strSettingValue;
-                        }
+            ModemSettings mSettings;
+            
+            if (demod->hasAnother("settings")) {
+                DataNode *modemSettings = demod->getNext("settings");
+                for (int msi = 0, numSettings = modemSettings->numChildren(); msi < numSettings; msi++) {
+                    DataNode *settingNode = modemSettings->child(msi);
+                    std::string keyName = settingNode->getName();
+                    std::string strSettingValue = settingNode->element()->toString();
+                    
+                    if (keyName != "" && strSettingValue != "") {
+                        mSettings[keyName] = strSettingValue;
                     }
                 }
-                
-                newDemod = wxGetApp().getDemodMgr().newThread();
+            }
+            
+            newDemod = wxGetApp().getDemodMgr().newThread();
 
-                if (demod->hasAnother("active")) {
-                    loadedDemod = newDemod;
-                }
+            if (demod->hasAnother("active")) {
+                loadedDemod = newDemod;
+            }
 
-                numDemodulators++;
-                newDemod->setDemodulatorType(type);
-                newDemod->writeModemSettings(mSettings);
-                newDemod->setBandwidth(bandwidth);
-                newDemod->setFrequency(freq);
-                newDemod->setGain(gain);
-                newDemod->updateLabel(freq);
-                newDemod->setMuted(muted?true:false);
-                if (delta_locked) {
-                    newDemod->setDeltaLock(true);
-                    newDemod->setDeltaLockOfs(delta_ofs);
+            numDemodulators++;
+            newDemod->setDemodulatorType(type);
+            newDemod->writeModemSettings(mSettings);
+            newDemod->setBandwidth(bandwidth);
+            newDemod->setFrequency(freq);
+            newDemod->setGain(gain);
+            newDemod->updateLabel(freq);
+            newDemod->setMuted(muted?true:false);
+            if (delta_locked) {
+                newDemod->setDeltaLock(true);
+                newDemod->setDeltaLockOfs(delta_ofs);
+            }
+            if (squelch_enabled) {
+                newDemod->setSquelchEnabled(true);
+                newDemod->setSquelchLevel(squelch_level);
+            }
+            
+            bool found_device = false;
+            std::map<int, RtAudio::DeviceInfo>::iterator i;
+            for (i = outputDevices.begin(); i != outputDevices.end(); i++) {
+                if (i->second.name == output_device) {
+                    newDemod->setOutputDevice(i->first);
+                    found_device = true;
                 }
-                if (squelch_enabled) {
-                    newDemod->setSquelchEnabled(true);
-                    newDemod->setSquelchLevel(squelch_level);
-                }
-                
-                bool found_device = false;
-                std::map<int, RtAudio::DeviceInfo>::iterator i;
-                for (i = outputDevices.begin(); i != outputDevices.end(); i++) {
-                    if (i->second.name == output_device) {
-                        newDemod->setOutputDevice(i->first);
-                        found_device = true;
-                    }
-                }
+            }
 
 //                if (!found_device) {
 //                    std::cout << "\tWarning: named output device '" << output_device << "' was not found. Using default output.";
 //                }
 
-                newDemod->run();
-                newDemod->setActive(true);
-                demodsLoaded.push_back(newDemod);
-    //            wxGetApp().bindDemodulator(newDemod);
+            newDemod->run();
+            newDemod->setActive(true);
+            demodsLoaded.push_back(newDemod);
+//            wxGetApp().bindDemodulator(newDemod);
 
                 std::cout << "\tAdded demodulator at frequency " << newDemod->getFrequency() << " type " << type << std::endl;
 //                std::cout << "\t\tBandwidth: " << bandwidth << std::endl;
 //                std::cout << "\t\tSquelch Level: " << squelch_level << std::endl;
 //                std::cout << "\t\tSquelch Enabled: " << (squelch_enabled ? "true" : "false") << std::endl;
 //                std::cout << "\t\tOutput Device: " << output_device << std::endl;
-            }
-            
-            DemodulatorInstance *focusDemod = loadedDemod?loadedDemod:newDemod;
-            
-            if (focusDemod) {
-                wxGetApp().bindDemodulators(&demodsLoaded);
-                wxGetApp().getDemodMgr().setActiveDemodulator(focusDemod, false);
-            }
+        }
+        
+        DemodulatorInstance *focusDemod = loadedDemod?loadedDemod:newDemod;
+        
+        if (focusDemod) {
+            wxGetApp().bindDemodulators(&demodsLoaded);
+            wxGetApp().getDemodMgr().setActiveDemodulator(focusDemod, false);
+        }
         }
     } catch (DataTypeMismatchException &e) {
         std::cout << e.what() << std::endl;
         return false;
     }
-    
+
     currentSessionFile = fileName;
 
     std::string filePart = fileName.substr(fileName.find_last_of(filePathSeparator) + 1);

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -397,7 +397,10 @@ void CubicSDR::removeRemote(std::string remoteAddr) {
 }
 
 void CubicSDR::sdrThreadNotify(SDRThread::SDRThreadState state, std::string message) {
-    notify_busy.lock();
+
+    std::lock_guard < std::mutex > lock(notify_busy);
+
+   
     if (state == SDRThread::SDR_THREAD_INITIALIZED) {
         appframe->initDeviceParams(getDevice());
     }
@@ -415,12 +418,13 @@ void CubicSDR::sdrThreadNotify(SDRThread::SDRThreadState state, std::string mess
 //        info->ShowModal();
     }
     //if (appframe) { appframe->SetStatusText(message); }
-    notify_busy.unlock();
+  
 }
 
 
 void CubicSDR::sdrEnumThreadNotify(SDREnumerator::SDREnumState state, std::string message) {
-    notify_busy.lock();
+    std::lock_guard < std::mutex > lock(notify_busy);
+
     if (state == SDREnumerator::SDR_ENUM_MESSAGE) {
         notifyMessage = message;
     }
@@ -432,7 +436,7 @@ void CubicSDR::sdrEnumThreadNotify(SDREnumerator::SDREnumState state, std::strin
         devicesFailed.store(true);
     }
     //if (appframe) { appframe->SetStatusText(message); }
-    notify_busy.unlock();
+   
 
 }
 
@@ -748,9 +752,9 @@ bool CubicSDR::areModulesMissing() {
 
 std::string CubicSDR::getNotification() {
     std::string msg;
-    notify_busy.lock();
+    std::lock_guard < std::mutex > lock(notify_busy);
     msg = notifyMessage;
-    notify_busy.unlock();
+   
     return msg;
 }
 

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -212,7 +212,9 @@ private:
     std::atomic_bool useLocalMod;
     std::string notifyMessage;
     std::string modulePath;
+    
     std::mutex notify_busy;
+    
     std::atomic_bool frequency_locked;
     std::atomic_llong lock_freq;
     FrequencyDialog::FrequencyDialogTarget fdlgTarget;

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -37,6 +37,12 @@ public:
         std::lock_guard < std::recursive_mutex > lock(m_mutex);
         return refCount;
     }
+
+    // Access to the own mutex protecting the ReferenceCounter, i.e the monitor of the class
+     std::recursive_mutex& getMonitor() const {
+        return m_mutex;
+    }
+
 protected:
     //this is a basic mutex for all ReferenceCounter derivatives operations INCLUDING the counter itself for consistency !
    mutable std::recursive_mutex m_mutex;

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -20,7 +20,6 @@ public:
     float peak;
     int type;
     std::vector<float> data;
-    std::mutex busy_update;
 
     AudioThreadInput() :
             frequency(0), sampleRate(0), channels(0), peak(0) {

--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -53,7 +53,7 @@ public:
     long long frequency;
     long long sampleRate;
     std::vector<liquid_float_complex> data;
-    std::mutex busy_rw;
+   
 
     DemodulatorThreadIQData() :
             frequency(0), sampleRate(0) {

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -11,9 +11,9 @@ DemodulatorInstance::DemodulatorInstance() :
 #if ENABLE_DIGITAL_LAB
     activeOutput = nullptr;
 #endif
-    terminated.store(true);
+	terminated.store(true);
 	demodTerminated.store(true);
-    audioTerminated.store(true);
+	audioTerminated.store(true);
 	preDemodTerminated.store(true);
 	active.store(false);
 	squelch.store(false);

--- a/src/demod/DemodulatorMgr.h
+++ b/src/demod/DemodulatorMgr.h
@@ -72,7 +72,9 @@ private:
     bool lastMuted;
     bool lastDeltaLock;
     
-    std::mutex demods_busy;
+    //protects access to demods lists and such, need to be recursive
+    //because of the usage of public re-entrant methods 
+    std::recursive_mutex demods_busy;
     
     std::map<std::string, ModemSettings> lastModemSettings;
 };

--- a/src/process/SpectrumVisualProcessor.h
+++ b/src/process/SpectrumVisualProcessor.h
@@ -97,6 +97,7 @@ private:
     std::vector<liquid_float_complex> shiftBuffer;
     std::vector<liquid_float_complex> resampleBuffer;
     std::atomic_int desiredInputSize;
+   
     std::mutex busy_run;
     std::atomic_bool hideDC, peakHold;
     std::atomic_int peakReset;

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -27,9 +27,12 @@ SDRPostThread::~SDRPostThread() {
 }
 
 void SDRPostThread::bindDemodulator(DemodulatorInstance *demod) {
+    
     std::lock_guard < std::mutex > lock(busy_demod);
+
     demodulators.push_back(demod);
     doRefresh.store(true);
+   
 }
 
 void SDRPostThread::bindDemodulators(std::vector<DemodulatorInstance *> *demods) {
@@ -37,10 +40,12 @@ void SDRPostThread::bindDemodulators(std::vector<DemodulatorInstance *> *demods)
         return;
     }
     std::lock_guard < std::mutex > lock(busy_demod);
+
     for (std::vector<DemodulatorInstance *>::iterator di = demods->begin(); di != demods->end(); di++) {
         demodulators.push_back(*di);
         doRefresh.store(true);
     }
+   
 }
 
 void SDRPostThread::removeDemodulator(DemodulatorInstance *demod) {
@@ -49,12 +54,14 @@ void SDRPostThread::removeDemodulator(DemodulatorInstance *demod) {
     }
 
     std::lock_guard < std::mutex > lock(busy_demod);
+
     std::vector<DemodulatorInstance *>::iterator i = std::find(demodulators.begin(), demodulators.end(), demod);
     
     if (i != demodulators.end()) {
         demodulators.erase(i);
         doRefresh.store(true);
     }
+  
 }
 
 void SDRPostThread::initPFBChannelizer() {
@@ -79,7 +86,7 @@ void SDRPostThread::updateActiveDemodulators() {
     nRunDemods = 0;
     
     long long centerFreq = wxGetApp().getFrequency();
-    
+  
     for (demod_i = demodulators.begin(); demod_i != demodulators.end(); demod_i++) {
         DemodulatorInstance *demod = *demod_i;
         DemodulatorThreadInputQueue *demodQueue = demod->getIQInputDataPipe();

--- a/src/sdr/SDRPostThread.h
+++ b/src/sdr/SDRPostThread.h
@@ -29,10 +29,14 @@ protected:
     DemodulatorThreadInputQueue *iqVisualQueue;
     DemodulatorThreadInputQueue *iqActiveDemodVisualQueue;
     
+    //protects access to demodulators lists and such
     std::mutex busy_demod;
     std::vector<DemodulatorInstance *> demodulators;
 
+    
+
 private:
+
     void initPFBChannelizer();
     void updateActiveDemodulators();
     void updateChannels();

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -83,7 +83,7 @@ void WaterfallCanvas::attachSpectrumCanvas(SpectrumCanvas *canvas_in) {
 }
 
 void WaterfallCanvas::processInputQueue() {
-    tex_update.lock();
+    std::lock_guard < std::mutex > lock(tex_update);
     
     gTimer.update();
     
@@ -118,11 +118,11 @@ void WaterfallCanvas::processInputQueue() {
         glContext->SetCurrent(*this);
         waterfallPanel.update();
     }
-    tex_update.unlock();
+   
 }
 
 void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
-    tex_update.lock();
+    std::lock_guard < std::mutex > lock(tex_update);
     wxPaintDC dc(this);
     
     const wxSize ClientSize = GetClientSize();
@@ -341,7 +341,6 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     glContext->EndDraw();
 
     SwapBuffers();
-    tex_update.unlock();
 }
 
 void WaterfallCanvas::OnKeyUp(wxKeyEvent& event) {
@@ -905,17 +904,16 @@ void WaterfallCanvas::updateCenterFrequency(long long freq) {
 }
 
 void WaterfallCanvas::setLinesPerSecond(int lps) {
-    tex_update.lock();
+    std::lock_guard < std::mutex > lock(tex_update);
     linesPerSecond = lps;
     while (!visualDataQueue.empty()) {
         SpectrumVisualData *vData;
         visualDataQueue.pop(vData);
-        
+
         if (vData) {
             vData->decRefCount();
         }
     }
-    tex_update.unlock();
 }
 
 void WaterfallCanvas::setMinBandwidth(int min) {


### PR DESCRIPTION
@cjcliffe  Hi, another pedantic cleanup from me:
Locks / Unlock mutex pairs in code are quite noisy to use, and std::lock_guard can replace them almost everywhere:
-  Less code clutter
-  Less error prone
-  Exception safe
-  Garanteed unlocking order for nested guards
-  The real reason: raw mutexes are so 1990 !  

So I scanned the code for unlock() and replaced them with guards at the right places. (or so I hope)

I've also put additional guards at some places where the existing locking didn't seemed sufficient to protect the whole class consistency.
