### PR TITLE
Rough visual cue for demod instances, implement squelch break indicator

### DIFF
--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -5,6 +5,31 @@
 #include "RigThread.h"
 #endif
 
+DemodVisualCue::DemodVisualCue() {
+    squelchBreak.store(false);
+}
+
+DemodVisualCue::~DemodVisualCue() {
+    
+}
+
+void DemodVisualCue::triggerSquelchBreak(int counter) {
+    squelchBreak.store(counter);
+}
+
+int DemodVisualCue::getSquelchBreak() {
+    return squelchBreak.load();
+}
+
+void DemodVisualCue::step() {
+    if (squelchBreak.load()) {
+        squelchBreak--;
+        if (squelchBreak.load() < 0) {
+            squelchBreak.store(0);
+        }
+    }
+}
+
 DemodulatorInstance::DemodulatorInstance() :
         t_PreDemod(nullptr), t_Demod(nullptr), t_Audio(nullptr) {
 
@@ -416,6 +441,10 @@ void DemodulatorInstance::setMuted(bool muted) {
     this->muted = muted;
     demodulatorThread->setMuted(muted);
     wxGetApp().getDemodMgr().setLastMuted(muted);
+}
+
+DemodVisualCue *DemodulatorInstance::getVisualCue() {
+    return &visualCue;
 }
 
 DemodulatorThreadInputQueue *DemodulatorInstance::getIQInputDataPipe() {

--- a/src/demod/DemodulatorInstance.h
+++ b/src/demod/DemodulatorInstance.h
@@ -14,6 +14,20 @@
 #include "DigitalConsole.h"
 #endif
 
+class DemodVisualCue {
+public:
+    DemodVisualCue();
+    ~DemodVisualCue();
+    
+    void triggerSquelchBreak(int counter);
+    int getSquelchBreak();
+    
+    void step();
+private:
+    std::atomic_int squelchBreak;
+};
+
+
 class DemodulatorInstance {
 public:
 
@@ -89,6 +103,8 @@ public:
     bool isMuted();
     void setMuted(bool muted);
 
+    DemodVisualCue *getVisualCue();
+    
     DemodulatorThreadInputQueue *getIQInputDataPipe();
 
     ModemArgInfoList getModemArgs();
@@ -135,6 +151,7 @@ private:
     std::atomic_bool follow, tracking;
     std::map<std::string, ModemSettings> lastModemSettings;
     std::map<std::string, int> lastModemBandwidth;
+    DemodVisualCue visualCue;
 #if ENABLE_DIGITAL_LAB
     ModemDigitalOutput *activeOutput;
 #endif

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -157,6 +157,7 @@ void DemodulatorThread::run() {
                     wxGetApp().getDemodMgr().setActiveDemodulator(demodInstance, false);
                 }
                 squelchBreak = true;
+                demodInstance->getVisualCue()->triggerSquelchBreak(120);
             } else if (squelched && squelchBreak) {
                 squelchBreak = false;
             }

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -338,6 +338,16 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
         glContext->DrawDemod(demods[i], currentTheme->waterfallHighlight, currentCenterFreq, currentBandwidth);
     }
 
+    for (int i = 0, iMax = demods.size(); i < iMax; i++) {
+        demods[i]->getVisualCue()->step();
+
+        int squelchBreak = demods[i]->getVisualCue()->getSquelchBreak();
+        if (squelchBreak) {
+            glContext->setHoverAlpha((float(squelchBreak) / 60.0));
+            glContext->DrawDemod(demods[i], currentTheme->waterfallHover, currentCenterFreq, currentBandwidth);
+        }
+    }
+    
     glContext->EndDraw();
 
     SwapBuffers();


### PR DESCRIPTION
Squelch break will now cause a brief flash on the waterfall that will last a second or so.