### PR TITLE
unnecessary frequency=0 check..

### DIFF
--- a/src/process/SpectrumVisualProcessor.cpp
+++ b/src/process/SpectrumVisualProcessor.cpp
@@ -286,7 +286,7 @@ void SpectrumVisualProcessor::process() {
         int bwDiff;
         
         if (is_view.load()) {
-            if (!iqData->frequency || !iqData->sampleRate) {
+            if (!iqData->sampleRate) {
                 iqData->decRefCount();
                
                 return;


### PR DESCRIPTION
Fixes spectrum visual processor issue when using pfb channelizer bank 0 on a zoomed view.