### PR TITLE
wstring encode / decode fixes

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1562,8 +1562,6 @@ void AppFrame::saveSession(std::string fileName) {
         *demod->newChild("frequency") = (*instance_i)->getFrequency();
         *demod->newChild("type") = (*instance_i)->getDemodulatorType();
 
-        //TODO: now we can only 7 bit strings properly, so convert back to Ascii...
-//        wxString intermediate((*instance_i)->getDemodulatorUserLabel());
         demod->newChild("user_label")->element()->set((*instance_i)->getDemodulatorUserLabel());
 
         *demod->newChild("squelch_level") = (*instance_i)->getSquelchLevel();
@@ -1700,11 +1698,7 @@ bool AppFrame::loadSession(std::string fileName) {
             DataNode *demodUserLabel = demod->hasAnother("user_label") ? demod->getNext("user_label") : nullptr;
 
             if (demodUserLabel) {
-                //toString() re-formats strings recognized as numerals, but at least it works for
-                //all kind of data.
-                //TODO: DataTree do not support 16 bit strings, so...
-//                std::string rawStr = demodUserLabel->element()->toString();
-//                user_label.assign(rawStr.begin(), rawStr.end());
+              
                 demodUserLabel->element()->get(user_label);
             }
            

--- a/src/util/DataTree.h
+++ b/src/util/DataTree.h
@@ -332,8 +332,8 @@ class DataTree
 private:
     DataNode dn_root;
     
-    string wsEncode(const wstring wstr);
-    wstring wsDecode(const string str);
+    string wsEncode(const wstring& wstr);
+    wstring wsDecode(const string& str);
 
 public:
     DataTree(const char *name_in);


### PR DESCRIPTION
@cjcliffe Hi, I've noticed that the encode/decode/storage in DataTree was quite fucked up, with desappearing symbols and so on...

I think it should be OK now, even if we are system / codepage dependent with mbstowcs() / wcstombs(). 
For instance, on my Win7x64 French, these functions are not enable to convert the euro symbol: '€' even if all specific characters are now OK, at least as far as a French keyboard is concerned.

Well, we have opened the Pandora box of characters encoding, but for me I'll stop at that if you don't mind :)


 