### PR TITLE
Last string vs. wstring cleanups (hopefully)

### DIFF
--- a/src/DemodLabelDialog.cpp
+++ b/src/DemodLabelDialog.cpp
@@ -42,15 +42,17 @@ void DemodLabelDialog::OnChar(wxKeyEvent& event) {
     int c = event.GetKeyCode();
 
     //we support 16 bit strings for user labels internally.
-    std::wstring strValue = dialogText->GetValue().ToStdWstring();
+    wxString strValue = dialogText->GetValue();
 
     switch (c) {
     case WXK_RETURN:
     case WXK_NUMPAD_ENTER:
 
-        //No need to display the demodulator type twice if the user do not change the default value... 
-        if (strValue != activeDemod->getDemodulatorType()) {
-            activeDemod->setDemodulatorUserLabel(strValue);
+        //No need to display the demodulator type twice if the user do not change the default value...
+        //when comparing getDemodulatorType() std::string, take care of "upgrading" it to wxString which will 
+        //try to its best... 
+        if (strValue != wxString(activeDemod->getDemodulatorType())) {
+            activeDemod->setDemodulatorUserLabel(strValue.ToStdWstring());
         }
         else {
             activeDemod->setDemodulatorUserLabel(L"");

--- a/src/util/GLFont.cpp
+++ b/src/util/GLFont.cpp
@@ -128,18 +128,18 @@ std::wstring GLFont::nextParam(std::wistringstream &str) {
 
     str >> param_str;
 
-    if (param_str.find('"') != std::wstring::npos) {
+    if (param_str.find(L'"') != std::wstring::npos) {
         std::wstring rest;
-        while (!str.eof() && (std::count(param_str.begin(), param_str.end(), '"') % 2)) {
+        while (!str.eof() && (std::count(param_str.begin(), param_str.end(), L'"') % 2)) {
             str >> rest;
-            param_str.append(" " + rest);
+            param_str.append(L" " + rest);
         }
     }
 
     return param_str;
 }
 
-std::wstring GLFont::getParamKey(std::wstring param_str) {
+std::wstring GLFont::getParamKey(const std::wstring& param_str) {
     std::wstring keyName;
 
     size_t eqpos = param_str.find(L"=");
@@ -151,7 +151,7 @@ std::wstring GLFont::getParamKey(std::wstring param_str) {
     return keyName;
 }
 
-std::wstring GLFont::getParamValue(std::wstring param_str) {
+std::wstring GLFont::getParamValue(const std::wstring& param_str) {
     std::wstring value;
 
     size_t eqpos = param_str.find(L"=");
@@ -160,7 +160,7 @@ std::wstring GLFont::getParamValue(std::wstring param_str) {
         value = param_str.substr(eqpos + 1);
     }
 
-    if (value[0] == '"' && value[value.length() - 1] == '"') {
+    if (value[0] == L'"' && value[value.length() - 1] == L'"') {
         value = value.substr(1, value.length() - 2);
     }
 
@@ -215,7 +215,7 @@ void GLFont::loadFont(const std::wstring& fontFile) {
                 std::wstring paramKey = getParamKey(param);
                 std::wstring paramValue = getParamValue(param);
 
-                if (paramKey == "face") {
+                if (paramKey == L"face") {
                     fontName = paramValue;
                 }
 
@@ -546,7 +546,7 @@ void GLFont::drawString(const std::wstring& str, float xpos, float ypos, int pxH
         float advx = (float) fchar->getXAdvance() / (float) imageWidth;
 
         if (charId == 32) {
-            advx = characters['_']->getAspect();
+            advx = characters[L'_']->getAspect();
         }
 
         glTranslatef(ofsx, 0.0, 0.0);
@@ -569,17 +569,17 @@ void GLFont::drawString(const std::wstring& str, float xpos, float ypos, int pxH
 // Draw string, immediate, 8 bit version
 void GLFont::drawString(const std::string& str, float xpos, float ypos, int pxHeight, Align hAlign, Align vAlign, int vpx, int vpy, bool cacheable) {
 
+    //Displayed string is wstring, so use wxString to do the heavy lifting of converting  str...
 #ifdef WIN32
-    //This a thread-safe wsTmp buffer to convert to wstring, reusing the same memory, unsupported: OSX?
-    static thread_local std::wstring wsTmp;
+    //try to reuse the memory with thread_local, unsupported on OSX ? 
+    static thread_local wxString wsTmp;
 #else
-    std::wstring wsTmp;
+    wxString wsTmp;
 #endif
     
-    wsTmp.clear();
-    wsTmp.assign(str.begin(), str.end());
+    wsTmp.assign(str);
 
-    drawString(wsTmp, xpos, ypos, pxHeight, hAlign, vAlign, vpx, vpy, cacheable);
+    drawString(wsTmp.ToStdWstring(), xpos, ypos, pxHeight, hAlign, vAlign, vpx, vpy, cacheable);
 }
 
 // Draw cached GLFontCacheString
@@ -681,7 +681,7 @@ GLFontStringCache *GLFont::cacheString(const std::wstring& str, int pxHeight, in
         float advx = (float) fchar->getXAdvance() / (float) imageWidth;
         
         if (charId == 32) {
-            advx = characters['_']->getAspect();
+            advx = characters[L'_']->getAspect();
         }
         
         // freeze transform to buffer

--- a/src/util/GLFont.h
+++ b/src/util/GLFont.h
@@ -93,8 +93,8 @@ public:
 private:
    
     std::wstring nextParam(std::wistringstream &str);
-    std::wstring getParamKey(std::wstring param_str);
-    std::wstring getParamValue(std::wstring param_str);
+    std::wstring getParamKey(const std::wstring& param_str);
+    std::wstring getParamValue(const std::wstring& param_str);
 
    
     static GLFont fonts[GLFONT_MAX];

--- a/src/visual/PrimaryGLContext.cpp
+++ b/src/visual/PrimaryGLContext.cpp
@@ -353,10 +353,14 @@ void PrimaryGLContext::DrawDemod(DemodulatorInstance *demod, RGBA4f color, long 
 
     GLFont::Align demodAlign = GLFont::GLFONT_ALIGN_CENTER;
 
-    std::string demodStr = demod->getDemodulatorType();
-
-    //Displayed string is 16 bit, so fill from a 8bit character by charater...
-    std::wstring demodStrW(demodStr.begin(), demodStr.end());
+    //Displayed string is wstring, so use wxString to do the heavy lifting of converting  getDemodulatorType()...
+#ifdef WIN32
+    //try to reuse the memory with thread_local, unsupported on OSX ? 
+    static thread_local wxString demodStr;
+#else
+    wxString demodStr;
+#endif
+    demodStr.assign(demod->getDemodulatorType());
 
     demodAlign = GLFont::GLFONT_ALIGN_CENTER;
 
@@ -387,7 +391,7 @@ void PrimaryGLContext::DrawDemod(DemodulatorInstance *demod, RGBA4f color, long 
         hPos += 1.3 * labelHeight;
     }
 
-    drawSingleDemodLabel(demodStrW, uxPos, hPos, xOfs, yOfs, GLFont::GLFONT_ALIGN_CENTER);
+    drawSingleDemodLabel(demodStr.ToStdWstring(), uxPos, hPos, xOfs, yOfs, GLFont::GLFONT_ALIGN_CENTER);
 
     //revert...
     if (!demod->getDemodulatorUserLabel().empty()) {
@@ -399,12 +403,13 @@ void PrimaryGLContext::DrawDemod(DemodulatorInstance *demod, RGBA4f color, long 
 
 }
 
-void PrimaryGLContext::drawSingleDemodLabel(std::wstring demodStr, float uxPos, float hPos, float xOfs, float yOfs, GLFont::Align demodAlign) {
+void PrimaryGLContext::drawSingleDemodLabel(const std::wstring& demodStr, float uxPos, float hPos, float xOfs, float yOfs, GLFont::Align demodAlign) {
 
     glColor3f(0, 0, 0);
     GLFont::getFont(GLFont::GLFONT_SIZE16).drawString(demodStr, 2.0 * (uxPos - 0.5) + xOfs,
         -1.0 + hPos - yOfs, 16, demodAlign,
         GLFont::GLFONT_ALIGN_CENTER, 0, 0, true);
+    
     glColor3f(1, 1, 1);
     GLFont::getFont(GLFont::GLFONT_SIZE16).drawString(demodStr, 2.0 * (uxPos - 0.5),
         -1.0 + hPos, 16, demodAlign,

--- a/src/visual/PrimaryGLContext.h
+++ b/src/visual/PrimaryGLContext.h
@@ -32,5 +32,5 @@ public:
 
 private:
     float hoverAlpha;
-    void drawSingleDemodLabel(std::wstring demodStr, float uxPos, float hPos, float xOfs, float yOfs, GLFont::Align demodAlign);
+    void drawSingleDemodLabel(const std::wstring& demodStr, float uxPos, float hPos, float xOfs, float yOfs, GLFont::Align demodAlign);
 };


### PR DESCRIPTION
Well, I did a pass on wstring usage vs. string conversions, and found some inconsistencies, even if no bug had shown up.

However, this time I used wxString to do the proper handling, it was much easier than using mbstowcs() / wcstombs().
