### PR TITLE
Fix for large dB values displayed with truncation on the left if > Normal zoom level, and misc.

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -103,8 +103,8 @@ AppFrame::AppFrame() :
     demodModeSelectorAdv->addChoice("QAM");
     demodModeSelectorAdv->addChoice("QPSK");
     demodModeSelectorAdv->setHelpTip("Choose advanced modulation types.");
-    demodModeSelectorAdv->SetMinSize(wxSize(44,-1));
-    demodModeSelectorAdv->SetMaxSize(wxSize(44,-1));
+    demodModeSelectorAdv->SetMinSize(wxSize(50,-1));
+    demodModeSelectorAdv->SetMaxSize(wxSize(50,-1));
     demodTray->Add(demodModeSelectorAdv, 3, wxEXPAND | wxALL, 0);
 #endif
             

--- a/src/panel/SpectrumPanel.cpp
+++ b/src/panel/SpectrumPanel.cpp
@@ -267,7 +267,7 @@ void SpectrumPanel::drawPanelContents() {
     glLineWidth(1.0);
 
     if (showDb) {
-        float dbPanelWidth = (1.0 / viewWidth)*75.0 * GLFont::getScaleFactor();
+        float dbPanelWidth = (1.0 / viewWidth)*88.0 * GLFont::getScaleFactor();
         float dbPanelHeight = (1.0/viewHeight)*14.0 * GLFont::getScaleFactor();
         
         
@@ -282,7 +282,7 @@ void SpectrumPanel::drawPanelContents() {
         
         ssLabel.str("");
         if (getCeilValue() != getFloorValue() && fftSize) {
-            ssLabel << (20.0 * log10(2.0*(getFloorValue())/(double)fftSize)) << "dB";
+            ssLabel <<  (20.0 * log10(2.0*(getFloorValue())/(double)fftSize)) << "dB";
         }
 
         dbPanelFloor.setText(ssLabel.str(), GLFont::GLFONT_ALIGN_RIGHT);

--- a/src/ui/GLPanel.cpp
+++ b/src/ui/GLPanel.cpp
@@ -404,16 +404,29 @@ void GLTextPanel::drawPanelContents() {
     //pdimy is considered un-scaled 
     pdimy = round(pdimy / appliedScaleFactor);
  
-    //target font size: a bit smaller than pdimy:
-    int sz = 12;
+    int size = 12;
 
-    if (pdimy > 14) {
-        //make the font a little smaller that the TextPanel
-        sz = pdimy - 2;
+    if (pdimy <= 16) {
+    
+        size = 12;
+    } else if (pdimy <= 18) {
+      
+        size = 16;
+    } else if(pdimy <= 24) {
+      
+        size = 18;
+    } else if(pdimy <= 32) {
+      
+        size = 24;
+    } else if(pdimy <= 48) {
+      
+        size = 32;
+    } else {
+     
+        size = 48;
+    }
 
-    } 
-
-    GLFont::getFont(sz, appliedScaleFactor).drawString(textVal, mid, mid, horizAlign, vertAlign, (int)pdim.x, (int)pdim.y);
+    GLFont::getFont(size, appliedScaleFactor).drawString(textVal, mid, mid, horizAlign, vertAlign, (int)pdim.x, (int)pdim.y);
 }
 
 void GLTextPanel::setText(std::string text, GLFont::Align hAlign, GLFont::Align vAlign, bool useNative) {

--- a/src/util/GLFont.cpp
+++ b/src/util/GLFont.cpp
@@ -851,7 +851,8 @@ GLFont::Drawer::Drawer(int basicFontSize, double scaleFactor) {
     //final font size of  basicFontSize* scaleFactor:
     renderingFontIndex = 0;
 
-    double targetSize = basicFontSize * scaleFactor;
+    //try to align on an integer pixel size if the targetSize font is available
+    int targetSize = round(basicFontSize * scaleFactor);
 
     fonts[0].loadFontOnce();
 
@@ -869,10 +870,10 @@ GLFont::Drawer::Drawer(int basicFontSize, double scaleFactor) {
     } //end for
 
       //
-    double rawSize = fonts[renderingFontIndex].pixHeight;
+    int rawSize = fonts[renderingFontIndex].pixHeight;
 
     //targetSize may not be reached yet, so the effective rendering font: fonts[renderingFontIndex] must be scaled up a bit.
-    renderingFontScaleFactor = targetSize / rawSize;
+    renderingFontScaleFactor = (double) targetSize / rawSize;
 }
 
 void GLFont::Drawer::drawString(const std::wstring& str, float xpos, float ypos, Align hAlign, Align vAlign, int vpx, int vpy, bool cacheable) {


### PR DESCRIPTION
@cjcliffe  This font-related PR is made of  2 things:
- A fix for especially long dB numbers (ex: -110.6dB) being clamped on the left side if Text size > Normal.
- A "rollback" of GLPanel dynamic font size choice, and restore the previous discrete choices so that the underneath fonts are at best used in their native resolution without additional scaling. 
I did this because although the scaling works, it looks consistently ugly :(  
Maybe some (bilinear/ trilinear ) texture filtering is needed while upscaling ?

As a side note, I tried the opposite before, that is downscaling a big font and it is also ugly in just another way.   
