### PR TITLE
Remove font 42 declaration in CMakeLists, indeed not present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,7 +510,6 @@ SET (CUBICSDR_RESOURCES
     ${PROJECT_SOURCE_DIR}/font/vera_sans_mono27_0.png
     ${PROJECT_SOURCE_DIR}/font/vera_sans_mono32_0.png
     ${PROJECT_SOURCE_DIR}/font/vera_sans_mono36_0.png
-    ${PROJECT_SOURCE_DIR}/font/vera_sans_mono42_0.png
     ${PROJECT_SOURCE_DIR}/font/vera_sans_mono48_0.png
     ${PROJECT_SOURCE_DIR}/font/vera_sans_mono64_0.png
     ${PROJECT_SOURCE_DIR}/font/vera_sans_mono72_0.png


### PR DESCRIPTION
@cjcliffe  @guruofquality This is a fix for #381, there is really no 42pix font in the end. 
It was a leftover of the font resize dev.