### PR TITLE
FIX not-initialized audio samples in mono causing out-of-bounds FFT causing non-displayed audio spectrum.

### DIFF
--- a/src/process/ScopeVisualProcessor.h
+++ b/src/process/ScopeVisualProcessor.h
@@ -37,12 +37,12 @@ protected:
     std::atomic_bool spectrumEnabled;
     
 #if USE_FFTW3
-    float *fftInData;
-    fftwf_complex *fftwOutput;
-    fftwf_plan fftw_plan;
+    std::vector<float> fftInData;
+    std::vector<fftwf_complex> fftwOutput;
+    std::vector<fftwf_plan> fftw_plan;
 #else
-    liquid_float_complex *fftInData;
-    liquid_float_complex *fftOutput;
+    std::vector<liquid_float_complex> fftInData;
+    std::vector<liquid_float_complex> fftOutput;
     fftplan fftPlan;
 #endif
     
@@ -52,7 +52,7 @@ protected:
     
     double fft_ceil_ma, fft_ceil_maa;
     double fft_floor_ma, fft_floor_maa;
-    float fft_average_rate;
+    double fft_average_rate;
     
     std::vector<double> fft_result;
     std::vector<double> fft_result_ma;


### PR DESCRIPTION
@cjcliffe Most of the time when I loaded a NFM session demod, the audio spectrum didn't showed up at all. Changing for another dmod didn't changed anything, I had to stop the application and retry.

I tracked it down in ScopeVisualProcessor to a not-initialized memory for fftInData[] for mono-audio channel cases.

I also added some pedantic changes as usual:
-  Use double at some places to limit errors,
-  I C++-ified the liquid buffers into vectors, later passing them as _vector::data()_ to the liquid functions:
```cpp
std::vector<liquid_float_complex> fftInData;
std::vector<liquid_float_complex> fftOutput;
```
They should be prettier in debuggers too.
