### PR TITLE
Rewrite GLFont loading routine with correct paths computation for resource dir loading

### DIFF
--- a/src/util/GLFont.h
+++ b/src/util/GLFont.h
@@ -159,9 +159,15 @@ private:
     std::vector<float> gl_vertices;
     std::vector<float> gl_uv;
 
+    //The font name as written in the def file.
     std::wstring fontName;
+
+    //The full path font PNG filename
     std::wstring imageFile;
-    std::wstring fontFileSource;
+
+    //the real path location of the font definition file
+    std::wstring fontDefFileSource;
+
     GLuint texId;
     int gcCounter;
     std::mutex cache_busy;


### PR DESCRIPTION
@cjcliffe @avsa242 I actually broke the loading by resource dir since I moved the fonts to 'fonts' subdir. The trouble came from that I only tested a "Windows-like" install where the fonts dir is found in the same dir as the executable. 

I so re-wrote GLFont::loadFontOnce() hopfully OK now. 