### PR TITLE
Assure center of main Waterfall+Spectrum on active demod on session load

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1584,6 +1584,10 @@ void AppFrame::OnUnSplit(wxSplitterEvent& event)
 
 
 void AppFrame::saveSession(std::string fileName) {
+
+    //disable event processing the time of saving
+    wxEventBlocker disableEvents(this);
+
     DataTree s("cubicsdr_session");
     DataNode *header = s.rootNode()->newChild("header");
     *header->newChild("version") = std::string(CUBICSDR_VERSION);
@@ -1633,6 +1637,10 @@ void AppFrame::saveSession(std::string fileName) {
 }
 
 bool AppFrame::loadSession(std::string fileName) {
+
+    //disable event processing the time of loading
+    wxEventBlocker disableEvents(this);
+
     DataTree l;
     if (!l.LoadFromFileXML(fileName)) {
         return false;

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1294,6 +1294,7 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
                 demodWaterfallCanvas->setCenterFrequency(centerFreq);
                 demodSpectrumCanvas->setCenterFrequency(centerFreq);
             }
+
             std::string dSelection = demodModeSelector->getSelectionLabel();
 #ifdef ENABLE_DIGITAL_LAB
             std::string dSelectionadv = demodModeSelectorAdv->getSelectionLabel();
@@ -1811,6 +1812,13 @@ bool AppFrame::loadSession(std::string fileName) {
         if (focusDemod) {
             wxGetApp().bindDemodulators(&demodsLoaded);
             wxGetApp().getDemodMgr().setActiveDemodulator(focusDemod, false);
+
+            long long focusCenterFreq = focusDemod->getFrequency();
+            //on loading, force center of the main Waterfall / Spectrum on the active demodulator: 
+            waterfallCanvas->setCenterFrequency(focusCenterFreq);
+            spectrumCanvas->setCenterFrequency(focusCenterFreq);
+            
+
         }
         }
     } catch (DataTypeMismatchException &e) {


### PR DESCRIPTION
@cjcliffe Hello again!  This one is small, in order to fix something that irks me: 
When loading successive session files, the scope+waterfall demod correctly align itself on the `<active>` demod, but more often than not the Main Waterfall+Spectrum do not update w.r.t new frequency.
If I click on the Scope demod, then the Main Waterfall+Spectrum moves to present the active demod in range, often at some edge.

So this modification consist in setting explicitly the center frequency of Main Spectrum+Waterfall to be the `<active>` demod one at session loading. 

The effect is that now Main Spectrum+Waterfall is always centered on `<active>` demod when loading a session file, consistent with the demod one.
   