### PR TITLE
thread_clean_3: Multithreading AudioThread hardening, use of try_pop() and more. 

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -806,11 +806,11 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
 #endif
     else if (event.GetId() == wxID_SDR_START_STOP) {
         if (!wxGetApp().getSDRThread()->isTerminated()) {
-            wxGetApp().stopDevice(true);
+            wxGetApp().stopDevice(true, 2000);
         } else {
             SDRDeviceInfo *dev = wxGetApp().getDevice();
             if (dev != nullptr) {
-                wxGetApp().setDevice(dev);
+                wxGetApp().setDevice(dev, 0);
             }
         }
     } else if (event.GetId() == wxID_LOW_PERF) {

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1645,6 +1645,7 @@ bool AppFrame::loadSession(std::string fileName) {
     }
 
 	wxGetApp().getDemodMgr().setActiveDemodulator(nullptr, false);
+
     wxGetApp().getDemodMgr().terminateAll();
 
     try {

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -254,6 +254,7 @@ bool CubicSDR::OnInit() {
 
     sdrPostThread = new SDRPostThread();
     sdrPostThread->setInputQueue("IQDataInput", pipeSDRIQData);
+
     sdrPostThread->setOutputQueue("IQVisualDataOutput", pipeIQVisualData);
     sdrPostThread->setOutputQueue("IQDataOutput", pipeWaterfallIQVisualData);
     sdrPostThread->setOutputQueue("IQActiveDemodVisualDataOutput", pipeDemodIQVisualData);

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -133,8 +133,8 @@ long long strToFrequency(std::string freqStr) {
 }
 
 
-CubicSDR::CubicSDR() : appframe(NULL), m_glContext(NULL), frequency(0), offset(0), ppm(0), snap(1), sampleRate(DEFAULT_SAMPLE_RATE),
-    sdrThread(NULL), sdrPostThread(NULL), spectrumVisualThread(NULL), demodVisualThread(NULL), pipeSDRIQData(NULL), pipeIQVisualData(NULL), pipeAudioVisualData(NULL), t_SDR(NULL), t_PostSDR(NULL) {
+CubicSDR::CubicSDR() : frequency(0), offset(0), ppm(0), snap(1), sampleRate(DEFAULT_SAMPLE_RATE),agcMode(false)
+       {
         sampleRateInitialized.store(false);
         agcMode.store(true);
         soloMode.store(false);
@@ -289,22 +289,24 @@ int CubicSDR::OnExit() {
         stopRig();
     }
 #endif
-    
-    demodMgr.terminateAll();
-    
+
+    //The thread feeding them all should be terminated first, so: 
     std::cout << "Terminating SDR thread.." << std::endl;
     sdrThread->terminate();
-    sdrThread->isTerminated(1000);
+    sdrThread->isTerminated(3000);
    
     if (t_SDR) {
        t_SDR->join();
        delete t_SDR;
        t_SDR = nullptr;
     }
-   
+
     std::cout << "Terminating SDR post-processing thread.." << std::endl;
     sdrPostThread->terminate();
-    
+
+    std::cout << "Terminating All Demodulators.." << std::endl;
+    demodMgr.terminateAll();
+   
     std::cout << "Terminating Visual Processor threads.." << std::endl;
     spectrumVisualThread->terminate();
     demodVisualThread->terminate();
@@ -542,16 +544,11 @@ void CubicSDR::setSampleRate(long long rate_in) {
     }
 }
 
-void CubicSDR::stopDevice(bool store) {
-    if (store) {
-        stoppedDev = sdrThread->getDevice();
-    } else {
-        stoppedDev = nullptr;
-    }
-    sdrThread->setDevice(nullptr);
-
+void CubicSDR::stopDevice(bool store, int waitMsForTermination) {
+    
+    //Firt we must stop the threads
     sdrThread->terminate();
-    sdrThread->isTerminated(1000);
+    sdrThread->isTerminated(waitMsForTermination);
 
     if (t_SDR) {
         t_SDR->join();
@@ -559,6 +556,15 @@ void CubicSDR::stopDevice(bool store) {
         t_SDR = nullptr;
     }
     
+    //Only now we can nullify devices
+    if (store) {
+        stoppedDev = sdrThread->getDevice();
+    }
+    else {
+        stoppedDev = nullptr;
+    }
+
+    sdrThread->setDevice(nullptr);
 }
 
 void CubicSDR::reEnumerateDevices() {
@@ -568,10 +574,10 @@ void CubicSDR::reEnumerateDevices() {
     t_SDREnum = new std::thread(&SDREnumerator::threadMain, sdrEnum);
 }
 
-void CubicSDR::setDevice(SDRDeviceInfo *dev) {
+void CubicSDR::setDevice(SDRDeviceInfo *dev, int waitMsForTermination) {
 
     sdrThread->terminate();
-    sdrThread->isTerminated(1000);
+    sdrThread->isTerminated(waitMsForTermination);
     
     if (t_SDR) {
        t_SDR->join();

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -98,8 +98,8 @@ public:
     long long getSampleRate();
 
     std::vector<SDRDeviceInfo *> *getDevices();
-    void setDevice(SDRDeviceInfo *dev);
-    void stopDevice(bool store);
+    void setDevice(SDRDeviceInfo *dev, int waitMsForTermination);
+    void stopDevice(bool store, int waitMsForTermination);
     SDRDeviceInfo * getDevice();
 
     ScopeVisualProcessor *getScopeProcessor();
@@ -173,10 +173,10 @@ public:
 private:
     int FilterEvent(wxEvent& event);
     
-    AppFrame *appframe;
+    AppFrame *appframe = nullptr;
     AppConfig config;
-    PrimaryGLContext *m_glContext;
-    std::vector<SDRDeviceInfo *> *devs;
+    PrimaryGLContext *m_glContext = nullptr;
+    std::vector<SDRDeviceInfo *> *devs = nullptr;
 
     DemodulatorMgr demodMgr;
 
@@ -186,27 +186,31 @@ private:
     std::atomic_llong sampleRate;
     std::atomic_bool agcMode;
 
-    SDRThread *sdrThread;
-    SDREnumerator *sdrEnum;
-    SDRPostThread *sdrPostThread;
-    SpectrumVisualDataThread *spectrumVisualThread;
-    SpectrumVisualDataThread *demodVisualThread;
+    SDRThread *sdrThread = nullptr;
+    SDREnumerator *sdrEnum = nullptr;
+    SDRPostThread *sdrPostThread = nullptr;
+    SpectrumVisualDataThread *spectrumVisualThread = nullptr;
+    SpectrumVisualDataThread *demodVisualThread = nullptr;
 
-    SDRThreadIQDataQueue* pipeSDRIQData;
-    DemodulatorThreadInputQueue* pipeIQVisualData;
-    DemodulatorThreadOutputQueue* pipeAudioVisualData;
-    DemodulatorThreadInputQueue* pipeDemodIQVisualData;
-    DemodulatorThreadInputQueue* pipeWaterfallIQVisualData;
-    DemodulatorThreadInputQueue* pipeActiveDemodIQVisualData;
+    SDRThreadIQDataQueue* pipeSDRIQData = nullptr;
+    DemodulatorThreadInputQueue* pipeIQVisualData = nullptr;
+    DemodulatorThreadOutputQueue* pipeAudioVisualData = nullptr;
+    DemodulatorThreadInputQueue* pipeDemodIQVisualData = nullptr;
+    DemodulatorThreadInputQueue* pipeWaterfallIQVisualData = nullptr;
+    DemodulatorThreadInputQueue* pipeActiveDemodIQVisualData = nullptr;
 
     ScopeVisualProcessor scopeProcessor;
     
-    SDRDevicesDialog *deviceSelectorDialog;
+    SDRDevicesDialog *deviceSelectorDialog = nullptr;
 
     SoapySDR::Kwargs streamArgs;
     SoapySDR::Kwargs settingArgs;
     
-    std::thread *t_SDR, *t_SDREnum, *t_PostSDR, *t_SpectrumVisual, *t_DemodVisual;
+    std::thread *t_SDR = nullptr;
+    std::thread *t_SDREnum = nullptr;
+    std::thread *t_PostSDR = nullptr;
+    std::thread *t_SpectrumVisual = nullptr;
+    std::thread *t_DemodVisual = nullptr;
     std::atomic_bool devicesReady;
     std::atomic_bool devicesFailed;
     std::atomic_bool deviceSelectorOpen;
@@ -224,8 +228,8 @@ private:
     std::atomic_bool soloMode;
     SDRDeviceInfo *stoppedDev;
 #ifdef USE_HAMLIB
-    RigThread* rigThread;
-    std::thread *t_Rig;
+    RigThread* rigThread = nullptr;
+    std::thread *t_Rig = nullptr;
 #endif
 };
 

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -88,7 +88,13 @@ private:
     AudioThreadCommandQueue cmdQueue;
     int sampleRate;
 
+    //The own m_mutex protecting this AudioThread
+    std::recursive_mutex m_mutex;
+
 public:
+    //give access to the this AudioThread lock
+    std::recursive_mutex& getMutex();
+
     void bindThread(AudioThread *other);
     void removeThread(AudioThread *other);
 

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -57,7 +57,7 @@ public:
     std::atomic_bool initialized;
     std::atomic_bool active;
     std::atomic_int outputDevice;
-    std::atomic<float> gain;
+    float gain;
 
     AudioThread();
     ~AudioThread();
@@ -88,7 +88,7 @@ private:
     AudioThreadCommandQueue cmdQueue;
     int sampleRate;
 
-    //The own m_mutex protecting this AudioThread
+    //The own m_mutex protecting this AudioThread, in particular boundThreads
     std::recursive_mutex m_mutex;
 
 public:
@@ -103,7 +103,8 @@ public:
     static std::map<int,std::thread *> deviceThread;
     static void deviceCleanup();
     static void setDeviceSampleRate(int deviceId, int sampleRate);
-    std::atomic<std::vector<AudioThread *> *> boundThreads;
-    std::vector<AudioThread *> *vBoundThreads;
+
+    //protected by m_mutex
+   std::vector<AudioThread *> boundThreads;
 };
 

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -152,7 +152,6 @@ bool DemodulatorInstance::isTerminated() {
     bool demodTerminated = demodulatorThread->isTerminated();
     bool preDemodTerminated = demodulatorPreThread->isTerminated();
 
-
     //Cleanup the worker threads, if the threads are indeed terminated
     if (audioTerminated) {
 
@@ -168,7 +167,6 @@ bool DemodulatorInstance::isTerminated() {
     if (demodTerminated) {
 
         if (t_Demod) {
-
 #ifdef __APPLE__
             pthread_join(t_Demod, nullptr);
 #else
@@ -185,8 +183,8 @@ bool DemodulatorInstance::isTerminated() {
     }
 
     if (preDemodTerminated) {
-
-        if (t_PreDemod) {
+        
+         if (t_PreDemod) {
 
 #ifdef __APPLE__
             pthread_join(t_PreDemod, NULL);
@@ -195,10 +193,9 @@ bool DemodulatorInstance::isTerminated() {
             delete t_PreDemod;
 #endif
             t_PreDemod = nullptr;
-        }
+         }
     }
 
-   
     bool terminated = audioTerminated && demodTerminated && preDemodTerminated;
 
     return terminated;

--- a/src/demod/DemodulatorMgr.h
+++ b/src/demod/DemodulatorMgr.h
@@ -53,15 +53,17 @@ public:
     void setLastModemSettings(std::string, ModemSettings);
 
     void updateLastState();
-
+    
 private:
+    
     void garbageCollect();
 
     std::vector<DemodulatorInstance *> demods;
     std::vector<DemodulatorInstance *> demods_deleted;
-    DemodulatorInstance *activeDemodulator;
-    DemodulatorInstance *lastActiveDemodulator;
-    DemodulatorInstance *activeVisualDemodulator;
+    
+    std::atomic<DemodulatorInstance *> activeDemodulator;
+    std::atomic<DemodulatorInstance *> lastActiveDemodulator;
+    std::atomic<DemodulatorInstance *> activeVisualDemodulator;
 
     int lastBandwidth;
     std::string lastDemodType;

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -74,6 +74,7 @@ void DemodulatorThread::run() {
     
     while (!stopping) {
         DemodulatorThreadPostIQData *inp;
+        
         iqInputQueue->pop(inp);
         //        std::lock_guard < std::mutex > lock(inp->m_mutex);
         
@@ -238,13 +239,23 @@ void DemodulatorThread::run() {
                 ati_vis->type = 0;
             }
             
-            localAudioVisOutputQueue->push(ati_vis);
+            if (!localAudioVisOutputQueue->push(ati_vis)) {
+                ati_vis->setRefCount(0);
+                std::cout << "DemodulatorThread::run() cannot push ati_vis into localAudioVisOutputQueue, is full !" << std::endl;
+                std::this_thread::yield();
+            }
         }
         
         
         if (ati != nullptr) {
             if (!muted.load() && (!wxGetApp().getSoloMode() || (demodInstance == wxGetApp().getDemodMgr().getLastActiveDemodulator()))) {
-                audioOutputQueue->push(ati);
+                
+                if (!audioOutputQueue->push(ati)) {
+                    ati->decRefCount();
+                    std::cout << "DemodulatorThread::run() cannot push ati into audioOutputQueue, is full !" << std::endl;
+                    std::this_thread::yield();
+                }
+
             } else {
                 ati->setRefCount(0);
             }
@@ -297,7 +308,9 @@ void DemodulatorThread::run() {
 void DemodulatorThread::terminate() {
     IOThread::terminate();
     DemodulatorThreadPostIQData *inp = new DemodulatorThreadPostIQData;    // push dummy to nudge queue
-    iqInputQueue->push(inp);
+    if (!iqInputQueue->push(inp)) {
+        delete inp;
+    }
 }
 
 bool DemodulatorThread::isMuted() {

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -24,8 +24,12 @@ void DemodulatorWorkerThread::run() {
         DemodulatorWorkerThreadCommand command;
 
         bool done = false;
+        //Beware of the subtility here,
+        //we are waiting for the first command to show up (blocking!)
+        //then consuming the commands until done. 
         while (!done) {
             commandQueue->pop(command);
+
             switch (command.cmd) {
                 case DemodulatorWorkerThreadCommand::DEMOD_WORKER_THREAD_CMD_BUILD_FILTERS:
                     filterChanged = true;

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -314,7 +314,7 @@ void SDRDevicesDialog::OnUseSelected( wxMouseEvent& event) {
         devConfig->setStreamOpts(streamArgs);
         wxGetApp().setDeviceArgs(settingArgs);
         wxGetApp().setStreamArgs(streamArgs);
-        wxGetApp().setDevice(dev);
+        wxGetApp().setDevice(dev,0);
                 
         Close();
     }
@@ -483,7 +483,7 @@ void SDRDevicesDialog::doRefreshDevices() {
     editId = nullptr;
     removeId = nullptr;
     dev = nullptr;
-    wxGetApp().stopDevice(false);
+    wxGetApp().stopDevice(false, 2000);
     devTree->DeleteAllItems();
     devTree->Disable();
     m_propertyGrid->Clear();

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -17,6 +17,7 @@ unsigned int FFTDataDistributor::getLinesPerSecond() {
 }
 
 void FFTDataDistributor::process() {
+
 	while (!input->empty()) {
 		if (!isAnyOutputEmpty()) {
 			return;

--- a/src/process/ScopeVisualProcessor.cpp
+++ b/src/process/ScopeVisualProcessor.cpp
@@ -68,10 +68,10 @@ void ScopeVisualProcessor::process() {
     if (!isOutputEmpty()) {
         return;
     }
-    if (!input->empty()) {
-        AudioThreadInput *audioInputData;
-        input->pop(audioInputData);
-        
+    AudioThreadInput *audioInputData;
+
+    if (input->try_pop(audioInputData)) {
+          
         if (!audioInputData) {
             return;
         }
@@ -271,5 +271,5 @@ void ScopeVisualProcessor::process() {
         } else {
             delete audioInputData; //->decRefCount();
         }
-    }
+    } //end if try_pop()
 }

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -86,11 +86,10 @@ protected:
 
         output->setRefCount(outputs.size());
         for (outputs_i = outputs.begin(); outputs_i != outputs.end(); outputs_i++) {
-        	if ((*outputs_i)->full()) {
+
+        	if (!(*outputs_i)->push(output)) {
         		output->decRefCount();
-        	} else {
-        		(*outputs_i)->push(output);
-        	}
+        	} 
         }
     }
 
@@ -107,12 +106,16 @@ template<class OutputDataType = ReferenceCounter>
 class VisualDataDistributor : public VisualProcessor<OutputDataType, OutputDataType> {
 protected:
     void process() {
-        while (!VisualProcessor<OutputDataType, OutputDataType>::input->empty()) {
+        OutputDataType *inp;
+        while (VisualProcessor<OutputDataType, OutputDataType>::input->try_pop(inp)) {
+            
             if (!VisualProcessor<OutputDataType, OutputDataType>::isAnyOutputEmpty()) {
+                if (inp) {
+            	    inp->decRefCount();
+                }
                 return;
             }
-        	OutputDataType *inp;
-        	VisualProcessor<OutputDataType, OutputDataType>::input->pop(inp);
+      
             if (inp) {
             	VisualProcessor<OutputDataType, OutputDataType>::distribute(inp);
             }
@@ -125,12 +128,15 @@ template<class OutputDataType = ReferenceCounter>
 class VisualDataReDistributor : public VisualProcessor<OutputDataType, OutputDataType> {
 protected:
     void process() {
-        while (!VisualProcessor<OutputDataType, OutputDataType>::input->empty()) {
+        OutputDataType *inp;
+        while (VisualProcessor<OutputDataType, OutputDataType>::input->try_pop(inp)) {
+            
             if (!VisualProcessor<OutputDataType, OutputDataType>::isAnyOutputEmpty()) {
+                if (inp) {
+            	    inp->decRefCount();
+                }
                 return;
             }
-            OutputDataType *inp;
-            VisualProcessor<OutputDataType, OutputDataType>::input->pop(inp);
             
             if (inp) {
                 OutputDataType *outp = buffers.getBuffer();

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -215,11 +215,14 @@ void SDRPostThread::run() {
         if (doUpdate) {
             updateActiveDemodulators();
         }
-    }
+    } //end while
     
-    if (iqVisualQueue && !iqVisualQueue->empty()) {
-        DemodulatorThreadIQData *visualDataDummy;
-        iqVisualQueue->pop(visualDataDummy);
+    //TODO: Why only 1 element was removed before ?
+    DemodulatorThreadIQData *visualDataDummy;
+    while (iqVisualQueue && iqVisualQueue->try_pop(visualDataDummy)) {
+        //nothing
+        //TODO: What about the refcounts ?
+        
     }
 
     //    buffers.purge();

--- a/src/util/ThreadQueue.h
+++ b/src/util/ThreadQueue.h
@@ -68,11 +68,13 @@ public:
     bool push(const value_type& item) {
         std::lock_guard < std::mutex > lock(m_mutex);
 
-        if (m_max_num_items.load() > 0 && m_queue.size() > m_max_num_items.load())
+        if (m_max_num_items.load() > 0 && m_queue.size() > m_max_num_items.load()) {
+            m_condition.notify_all();
             return false;
+        }
 
         m_queue.push(item);
-        m_condition.notify_one();
+        m_condition.notify_all();
         return true;
     }
 
@@ -84,11 +86,13 @@ public:
     bool push(const value_type&& item) {
         std::lock_guard < std::mutex > lock(m_mutex);
 
-        if (m_max_num_items.load() > 0 && m_queue.size() > m_max_num_items.load())
+        if (m_max_num_items.load() > 0 && m_queue.size() > m_max_num_items.load()) {
+            m_condition.notify_all();
             return false;
+        }
 
         m_queue.push(item);
-        m_condition.notify_one();
+        m_condition.notify_all();
         return true;
     }
 

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -97,11 +97,10 @@ bool ScopeCanvas::getShowDb() {
 void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     wxPaintDC dc(this);
     const wxSize ClientSize = GetClientSize();
-
-    while (!inputData.empty()) {
-        ScopeRenderData *avData;
-        inputData.pop(avData);
-
+    
+    ScopeRenderData *avData;
+    while (inputData.try_pop(avData)) {
+       
         
         if (!avData->spectrum) {
             scopePanel.setMode(avData->mode);

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -51,11 +51,9 @@ void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     wxPaintDC dc(this);
     const wxSize ClientSize = GetClientSize();
     
-    if (!visualDataQueue.empty()) {
-        SpectrumVisualData *vData;
-        
-        visualDataQueue.pop(vData);
-        
+    SpectrumVisualData *vData;
+    if (visualDataQueue.try_pop(vData)) {
+            
         if (vData) {
             spectrumPanel.setPoints(vData->spectrum_points);
             spectrumPanel.setPeakPoints(vData->spectrum_hold_points);

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -95,8 +95,8 @@ void WaterfallCanvas::processInputQueue() {
         if (lpsIndex >= targetVis) {
             while (lpsIndex >= targetVis) {
                 SpectrumVisualData *vData;
-                if (!visualDataQueue.empty()) {
-                    visualDataQueue.pop(vData);
+
+                if (visualDataQueue.try_pop(vData)) {
                     
                     if (vData) {
                         if (vData->spectrum_points.size() == fft_size * 2) {
@@ -912,11 +912,13 @@ void WaterfallCanvas::updateCenterFrequency(long long freq) {
 
 void WaterfallCanvas::setLinesPerSecond(int lps) {
     std::lock_guard < std::mutex > lock(tex_update);
+    
     linesPerSecond = lps;
-    while (!visualDataQueue.empty()) {
-        SpectrumVisualData *vData;
-        visualDataQueue.pop(vData);
 
+    //empty all
+    SpectrumVisualData *vData;
+    while (visualDataQueue.try_pop(vData)) {
+        
         if (vData) {
             vData->decRefCount();
         }


### PR DESCRIPTION
@cjcliffe This is the last PR before my holidays, I promise :)
This is made of:
-  AudioThread concurrent access hardening, in particular in order to protect the static audio callback.
As a result, the audio callback is also simpler and cleaner.
-  Replace the idiom `if/while (! ThreadQueue::empty() { ThreadQueue::pop()}` which is blocking and subject to races by simply `ThreadQueue::retry_pop()` because each time it is applied here is for consuming all elements, and not to have an actual blocking waiting pop().
-  Misc : SDRThread::readStream() sometimes returns <= 0 bytes, so bail out, change some thread termination order in CubicSDR method class, (SDRThread the source of all input, is shut down first) setDevice()/stopDevice() wait or not for termination depending on we are starting for the first time or not...
-  Some comments on how things are working for (my) understanding. Yes, I do love comments. 
-  Put some TODO on things I don't understand.

Tell me if it is better or worse than before! (in terms of crashes at least)
