### PR TITLE
Modem factory funcs

### DIFF
--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -190,30 +190,30 @@ bool CubicSDR::OnInit() {
     RigThread::enumerate();
 #endif
 
-    Modem::addModemFactory(new ModemFM);
-    Modem::addModemFactory(new ModemNBFM);
-    Modem::addModemFactory(new ModemFMStereo);
-    Modem::addModemFactory(new ModemAM);
-    Modem::addModemFactory(new ModemLSB);
-    Modem::addModemFactory(new ModemUSB);
-    Modem::addModemFactory(new ModemDSB);
-    Modem::addModemFactory(new ModemIQ);
+    Modem::addModemFactory(ModemFM::factory, "FM", 200000);
+    Modem::addModemFactory(ModemNBFM::factory, "NBFM", 12500);
+    Modem::addModemFactory(ModemFMStereo::factory, "FMS", 200000);
+    Modem::addModemFactory(ModemAM::factory, "AM", 6000);
+    Modem::addModemFactory(ModemLSB::factory, "LSB", 5400);
+    Modem::addModemFactory(ModemUSB::factory, "USB", 5400);
+    Modem::addModemFactory(ModemDSB::factory, "DSB", 5400);
+    Modem::addModemFactory(ModemIQ::factory, "I/Q", 48000);
 
 #ifdef ENABLE_DIGITAL_LAB
-    Modem::addModemFactory(new ModemAPSK);
-    Modem::addModemFactory(new ModemASK);
-    Modem::addModemFactory(new ModemBPSK);
-    Modem::addModemFactory(new ModemDPSK);
+    Modem::addModemFactory(ModemAPSK::factory, "APSK", 200000);
+    Modem::addModemFactory(ModemASK::factory, "ASK", 200000);
+    Modem::addModemFactory(ModemBPSK::factory, "BPSK", 200000);
+    Modem::addModemFactory(ModemDPSK::factory, "DPSK", 200000);
 #if ENABLE_LIQUID_EXPERIMENTAL
-    Modem::addModemFactory(new ModemFSK);
+    Modem::addModemFactory(ModemFSK::factory, "FSK", 19200);
 #endif
-    Modem::addModemFactory(new ModemGMSK);
-    Modem::addModemFactory(new ModemOOK);
-    Modem::addModemFactory(new ModemPSK);
-    Modem::addModemFactory(new ModemQAM);
-    Modem::addModemFactory(new ModemQPSK);
-    Modem::addModemFactory(new ModemSQAM);
-    Modem::addModemFactory(new ModemST);
+    Modem::addModemFactory(ModemGMSK::factory, "GMSK", 19200);
+    Modem::addModemFactory(ModemOOK::factory, "OOK", 200000);
+    Modem::addModemFactory(ModemPSK::factory, "PSK", 200000);
+    Modem::addModemFactory(ModemQAM::factory, "QAM", 200000);
+    Modem::addModemFactory(ModemQPSK::factory, "QPSK", 200000);
+    Modem::addModemFactory(ModemSQAM::factory, "SQAM", 200000);
+    Modem::addModemFactory(ModemST::factory, "ST", 200000);
 #endif
     
     frequency = wxGetApp().getConfig()->getCenterFreq();

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -209,7 +209,7 @@ bool DemodulatorInstance::isActive() {
 void DemodulatorInstance::setActive(bool state) {
     if (active && !state) {
 #if ENABLE_DIGITAL_LAB
-        if (activeOutput && !isTerminated()) {
+        if (activeOutput) {
             activeOutput->Hide();
         }
 #endif

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -128,6 +128,13 @@ void DemodulatorInstance::updateLabel(long long freq) {
 }
 
 void DemodulatorInstance::terminate() {
+
+#if ENABLE_DIGITAL_LAB
+    if (activeOutput) {
+        closeOutput();
+    }
+#endif
+
 //    std::cout << "Terminating demodulator audio thread.." << std::endl;
     audioThread->terminate();
 //    std::cout << "Terminating demodulator thread.." << std::endl;
@@ -156,7 +163,6 @@ bool DemodulatorInstance::isTerminated() {
     if (audioTerminated) {
 
         if (t_Audio) {
-
             t_Audio->join();
 
             delete t_Audio;
@@ -175,11 +181,6 @@ bool DemodulatorInstance::isTerminated() {
 #endif
             t_Demod = nullptr;
         }
-#if ENABLE_DIGITAL_LAB
-        if (activeOutput) {
-            closeOutput();
-        }
-#endif
     }
 
     if (preDemodTerminated) {
@@ -314,7 +315,14 @@ void DemodulatorInstance::setDemodulatorType(std::string demod_type_in) {
         if (lastbw) {
             setBandwidth(lastbw);
         }
-    }
+
+#if ENABLE_DIGITAL_LAB
+        if (isModemInitialized() && getModemType() == "digital") {
+            ModemDigitalOutputConsole *outp = (ModemDigitalOutputConsole *)getOutput();
+            outp->setTitle(getDemodulatorType() + ": " + frequencyToStr(getFrequency()));
+        }
+#endif
+}
 }
 
 std::string DemodulatorInstance::getDemodulatorType() {

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -183,7 +183,7 @@ void DemodulatorThread::run() {
             localAudioVisOutputQueue = audioVisOutputQueue;
         }
 
-        if (ati && localAudioVisOutputQueue != nullptr && localAudioVisOutputQueue->empty()) {
+        if ((ati || modemDigital) && localAudioVisOutputQueue != nullptr && localAudioVisOutputQueue->empty()) {
             AudioThreadInput *ati_vis = new AudioThreadInput;
 
             ati_vis->sampleRate = inp->sampleRate;
@@ -191,6 +191,10 @@ void DemodulatorThread::run() {
             
             size_t num_vis = DEMOD_VIS_SIZE;
             if (modemDigital) {
+                if (ati) {  // TODO: handle digital modems with audio output
+                    ati->setRefCount(0);
+                    ati = nullptr;
+                }
                 ati_vis->data.resize(inputData->size());
                 ati_vis->channels = 2;
                 for (int i = 0, iMax = inputData->size() / 2; i < iMax; i++) {

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -136,6 +136,7 @@ void DemodulatorThread::run() {
             
             ati->sampleRate = cModemKit->sampleRate;
             ati->inputRate = inp->sampleRate;
+            ati->data.resize(0);
         }
 
         cModem->demodulate(cModemKit, &modemData, ati);
@@ -160,7 +161,7 @@ void DemodulatorThread::run() {
             }
         }
         
-        if (audioOutputQueue != nullptr && ati && !squelched) {
+        if (audioOutputQueue != nullptr && ati && ati->data.size() && !squelched) {
             std::vector<float>::iterator data_i;
             ati->peak = 0;
             for (data_i = ati->data.begin(); data_i != ati->data.end(); data_i++) {

--- a/src/modules/modem/Modem.cpp
+++ b/src/modules/modem/Modem.cpp
@@ -3,6 +3,7 @@
 
 
 ModemFactoryList Modem::modemFactories;
+DefaultRatesList Modem::modemDefaultRates;
 
 //! Create an empty range (0.0, 0.0)
 ModemRange::ModemRange(void) {
@@ -38,8 +39,9 @@ Modem::~Modem() {
     
 }
 
-void Modem::addModemFactory(Modem *factorySingle) {
-    modemFactories[factorySingle->getName()] = factorySingle;
+void Modem::addModemFactory(ModemFactoryFn factoryFunc, std::string modemName, int defaultRate) {
+    modemFactories[modemName] = factoryFunc;
+    modemDefaultRates[modemName] = defaultRate;
 }
 
 ModemFactoryList Modem::getFactories() {
@@ -48,15 +50,15 @@ ModemFactoryList Modem::getFactories() {
 
 Modem *Modem::makeModem(std::string modemName) {
     if (modemFactories.find(modemName) != modemFactories.end()) {
-        return modemFactories[modemName]->factory();
+        return (Modem *)modemFactories[modemName]();
     }
     
     return nullptr;
 }
 
 int Modem::getModemDefaultSampleRate(std::string modemName) {
-    if (modemFactories.find(modemName) != modemFactories.end()) {
-        return modemFactories[modemName]->getDefaultSampleRate();
+    if (modemDefaultRates.find(modemName) != modemDefaultRates.end()) {
+        return modemDefaultRates[modemName];
     }
     
     return 0;

--- a/src/modules/modem/Modem.h
+++ b/src/modules/modem/Modem.h
@@ -108,14 +108,21 @@ public:
 
 typedef std::vector<ModemArgInfo> ModemArgInfoList;
 
-class Modem;
-typedef std::map<std::string,Modem *> ModemFactoryList;
+class ModemBase {
+    
+};
+
+typedef ModemBase *(*ModemFactoryFn)();
+
+
+typedef std::map<std::string, ModemFactoryFn> ModemFactoryList;
+typedef std::map<std::string, int> DefaultRatesList;
 
 typedef std::map<std::string, std::string> ModemSettings;
 
-class Modem  {
+class Modem : public ModemBase  {
 public:
-    static void addModemFactory(Modem *factorySingle);
+    static void addModemFactory(ModemFactoryFn, std::string modemName, int defaultRate);
     static ModemFactoryList getFactories();
     
     static Modem *makeModem(std::string modemName);
@@ -124,8 +131,6 @@ public:
     virtual std::string getType() = 0;
     virtual std::string getName() = 0;
     
-    virtual Modem *factory() = 0;
-
     Modem();
     virtual ~Modem();
     
@@ -149,5 +154,6 @@ public:
     
 private:
     static ModemFactoryList modemFactories;
+    static DefaultRatesList modemDefaultRates;
     std::atomic_bool refreshKit;
 };

--- a/src/modules/modem/analog/ModemAM.cpp
+++ b/src/modules/modem/analog/ModemAM.cpp
@@ -8,7 +8,7 @@ ModemAM::~ModemAM() {
     ampmodem_destroy(demodAM);
 }
 
-Modem *ModemAM::factory() {
+ModemBase *ModemAM::factory() {
     return new ModemAM;
 }
 

--- a/src/modules/modem/analog/ModemAM.h
+++ b/src/modules/modem/analog/ModemAM.h
@@ -9,7 +9,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int getDefaultSampleRate();
 

--- a/src/modules/modem/analog/ModemDSB.cpp
+++ b/src/modules/modem/analog/ModemDSB.cpp
@@ -8,7 +8,7 @@ ModemDSB::~ModemDSB() {
     ampmodem_destroy(demodAM_DSB);
 }
 
-Modem *ModemDSB::factory() {
+ModemBase *ModemDSB::factory() {
     return new ModemDSB;
 }
 

--- a/src/modules/modem/analog/ModemDSB.h
+++ b/src/modules/modem/analog/ModemDSB.h
@@ -9,7 +9,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int getDefaultSampleRate();
 

--- a/src/modules/modem/analog/ModemFM.cpp
+++ b/src/modules/modem/analog/ModemFM.cpp
@@ -8,7 +8,7 @@ ModemFM::~ModemFM() {
     freqdem_destroy(demodFM);
 }
 
-Modem *ModemFM::factory() {
+ModemBase *ModemFM::factory() {
     return new ModemFM;
 }
 

--- a/src/modules/modem/analog/ModemFM.h
+++ b/src/modules/modem/analog/ModemFM.h
@@ -9,7 +9,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
 
     int getDefaultSampleRate();
 

--- a/src/modules/modem/analog/ModemFMStereo.cpp
+++ b/src/modules/modem/analog/ModemFMStereo.cpp
@@ -16,7 +16,7 @@ std::string ModemFMStereo::getName() {
     return "FMS";
 }
 
-Modem *ModemFMStereo::factory() {
+ModemBase *ModemFMStereo::factory() {
     return new ModemFMStereo;
 }
 

--- a/src/modules/modem/analog/ModemFMStereo.h
+++ b/src/modules/modem/analog/ModemFMStereo.h
@@ -29,7 +29,7 @@ public:
     std::string getType();
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int checkSampleRate(long long sampleRate, int audioSampleRate);
     int getDefaultSampleRate();

--- a/src/modules/modem/analog/ModemIQ.cpp
+++ b/src/modules/modem/analog/ModemIQ.cpp
@@ -12,7 +12,7 @@ std::string ModemIQ::getName() {
     return "I/Q";
 }
 
-Modem *ModemIQ::factory() {
+ModemBase *ModemIQ::factory() {
     return new ModemIQ;
 }
 

--- a/src/modules/modem/analog/ModemIQ.h
+++ b/src/modules/modem/analog/ModemIQ.h
@@ -8,7 +8,7 @@ public:
     std::string getType();
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
 
     int checkSampleRate(long long sampleRate, int audioSampleRate);
     int getDefaultSampleRate();

--- a/src/modules/modem/analog/ModemLSB.cpp
+++ b/src/modules/modem/analog/ModemLSB.cpp
@@ -13,7 +13,7 @@ ModemLSB::ModemLSB() : ModemAnalog() {
     c2rFilt = firhilbf_create(5, 90.0);
 }
 
-Modem *ModemLSB::factory() {
+ModemBase *ModemLSB::factory() {
     return new ModemLSB;
 }
 

--- a/src/modules/modem/analog/ModemLSB.h
+++ b/src/modules/modem/analog/ModemLSB.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int checkSampleRate(long long sampleRate, int audioSampleRate);
     int getDefaultSampleRate();

--- a/src/modules/modem/analog/ModemNBFM.cpp
+++ b/src/modules/modem/analog/ModemNBFM.cpp
@@ -8,7 +8,7 @@ ModemNBFM::~ModemNBFM() {
     freqdem_destroy(demodFM);
 }
 
-Modem *ModemNBFM::factory() {
+ModemBase *ModemNBFM::factory() {
     return new ModemNBFM;
 }
 

--- a/src/modules/modem/analog/ModemNBFM.h
+++ b/src/modules/modem/analog/ModemNBFM.h
@@ -9,7 +9,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
 
     int getDefaultSampleRate();
 

--- a/src/modules/modem/analog/ModemUSB.cpp
+++ b/src/modules/modem/analog/ModemUSB.cpp
@@ -13,7 +13,7 @@ ModemUSB::ModemUSB() : ModemAnalog() {
     c2rFilt = firhilbf_create(5, 90.0);
 }
 
-Modem *ModemUSB::factory() {
+ModemBase *ModemUSB::factory() {
     return new ModemUSB;
 }
 

--- a/src/modules/modem/analog/ModemUSB.h
+++ b/src/modules/modem/analog/ModemUSB.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int checkSampleRate(long long sampleRate, int audioSampleRate);
     int getDefaultSampleRate();

--- a/src/modules/modem/digital/ModemAPSK.cpp
+++ b/src/modules/modem/digital/ModemAPSK.cpp
@@ -12,7 +12,7 @@ ModemAPSK::ModemAPSK() : ModemDigital() {
     cons = 4;
 }
 
-Modem *ModemAPSK::factory() {
+ModemBase *ModemAPSK::factory() {
     return new ModemAPSK;
 }
 

--- a/src/modules/modem/digital/ModemAPSK.h
+++ b/src/modules/modem/digital/ModemAPSK.h
@@ -8,7 +8,7 @@ public:
 
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
 
     ModemArgInfoList getSettings();
     void writeSetting(std::string setting, std::string value);

--- a/src/modules/modem/digital/ModemASK.cpp
+++ b/src/modules/modem/digital/ModemASK.cpp
@@ -13,7 +13,7 @@ ModemASK::ModemASK() : ModemDigital()  {
     cons = 2;
 }
 
-Modem *ModemASK::factory() {
+ModemBase *ModemASK::factory() {
     return new ModemASK;
 }
 

--- a/src/modules/modem/digital/ModemASK.h
+++ b/src/modules/modem/digital/ModemASK.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     ModemArgInfoList getSettings();
     void writeSetting(std::string setting, std::string value);

--- a/src/modules/modem/digital/ModemBPSK.cpp
+++ b/src/modules/modem/digital/ModemBPSK.cpp
@@ -4,7 +4,7 @@ ModemBPSK::ModemBPSK() : ModemDigital()  {
     demodBPSK = modem_create(LIQUID_MODEM_BPSK);
 }
 
-Modem *ModemBPSK::factory() {
+ModemBase *ModemBPSK::factory() {
     return new ModemBPSK;
 }
 

--- a/src/modules/modem/digital/ModemBPSK.h
+++ b/src/modules/modem/digital/ModemBPSK.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
 
     void demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *audioOut);
     

--- a/src/modules/modem/digital/ModemDPSK.cpp
+++ b/src/modules/modem/digital/ModemDPSK.cpp
@@ -13,7 +13,7 @@ ModemDPSK::ModemDPSK() : ModemDigital() {
     cons = 2;
 }
 
-Modem *ModemDPSK::factory() {
+ModemBase *ModemDPSK::factory() {
     return new ModemDPSK;
 }
 

--- a/src/modules/modem/digital/ModemDPSK.h
+++ b/src/modules/modem/digital/ModemDPSK.h
@@ -8,7 +8,7 @@ public:
 
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     ModemArgInfoList getSettings();
     void writeSetting(std::string setting, std::string value);

--- a/src/modules/modem/digital/ModemFSK.cpp
+++ b/src/modules/modem/digital/ModemFSK.cpp
@@ -9,7 +9,7 @@ ModemFSK::ModemFSK() : ModemDigital()  {
     outStream << std::hex;
 }
 
-Modem *ModemFSK::factory() {
+ModemBase *ModemFSK::factory() {
     return new ModemFSK;
 }
 

--- a/src/modules/modem/digital/ModemFSK.h
+++ b/src/modules/modem/digital/ModemFSK.h
@@ -19,7 +19,7 @@ public:
 
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int checkSampleRate(long long sampleRate, int audioSampleRate);
     int getDefaultSampleRate();

--- a/src/modules/modem/digital/ModemGMSK.cpp
+++ b/src/modules/modem/digital/ModemGMSK.cpp
@@ -16,7 +16,7 @@ std::string ModemGMSK::getName() {
     return "GMSK";
 }
 
-Modem *ModemGMSK::factory() {
+ModemBase *ModemGMSK::factory() {
     return new ModemGMSK;
 }
 

--- a/src/modules/modem/digital/ModemGMSK.h
+++ b/src/modules/modem/digital/ModemGMSK.h
@@ -19,7 +19,7 @@ public:
 
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int checkSampleRate(long long sampleRate, int audioSampleRate);
     int getDefaultSampleRate();

--- a/src/modules/modem/digital/ModemOOK.cpp
+++ b/src/modules/modem/digital/ModemOOK.cpp
@@ -12,7 +12,7 @@ std::string ModemOOK::getName() {
     return "OOK";
 }
 
-Modem *ModemOOK::factory() {
+ModemBase *ModemOOK::factory() {
     return new ModemOOK;
 }
 

--- a/src/modules/modem/digital/ModemOOK.h
+++ b/src/modules/modem/digital/ModemOOK.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     int checkSampleRate(long long sampleRate, int audioSampleRate);
 

--- a/src/modules/modem/digital/ModemPSK.cpp
+++ b/src/modules/modem/digital/ModemPSK.cpp
@@ -13,7 +13,7 @@ ModemPSK::ModemPSK() : ModemDigital()  {
     cons = 2;
 }
 
-Modem *ModemPSK::factory() {
+ModemBase *ModemPSK::factory() {
     return new ModemPSK;
 }
 

--- a/src/modules/modem/digital/ModemPSK.h
+++ b/src/modules/modem/digital/ModemPSK.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     ModemArgInfoList getSettings();
     void writeSetting(std::string setting, std::string value);

--- a/src/modules/modem/digital/ModemQAM.cpp
+++ b/src/modules/modem/digital/ModemQAM.cpp
@@ -12,7 +12,7 @@ ModemQAM::ModemQAM() : ModemDigital()  {
     cons = 4;
 }
 
-Modem *ModemQAM::factory() {
+ModemBase *ModemQAM::factory() {
     return new ModemQAM;
 }
 

--- a/src/modules/modem/digital/ModemQAM.h
+++ b/src/modules/modem/digital/ModemQAM.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     ModemArgInfoList getSettings();
     void writeSetting(std::string setting, std::string value);

--- a/src/modules/modem/digital/ModemQPSK.cpp
+++ b/src/modules/modem/digital/ModemQPSK.cpp
@@ -4,7 +4,7 @@ ModemQPSK::ModemQPSK() : ModemDigital()  {
     demodQPSK = modem_create(LIQUID_MODEM_QPSK);
 }
 
-Modem *ModemQPSK::factory() {
+ModemBase *ModemQPSK::factory() {
     return new ModemQPSK;
 }
 

--- a/src/modules/modem/digital/ModemQPSK.h
+++ b/src/modules/modem/digital/ModemQPSK.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
 
     void demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *audioOut);
     

--- a/src/modules/modem/digital/ModemSQAM.cpp
+++ b/src/modules/modem/digital/ModemSQAM.cpp
@@ -7,7 +7,7 @@ ModemSQAM::ModemSQAM() : ModemDigital()  {
     cons = 32;
 }
 
-Modem *ModemSQAM::factory() {
+ModemBase *ModemSQAM::factory() {
     return new ModemSQAM;
 }
 

--- a/src/modules/modem/digital/ModemSQAM.h
+++ b/src/modules/modem/digital/ModemSQAM.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     ModemArgInfoList getSettings();
     void writeSetting(std::string setting, std::string value);

--- a/src/modules/modem/digital/ModemST.cpp
+++ b/src/modules/modem/digital/ModemST.cpp
@@ -4,7 +4,7 @@ ModemST::ModemST() : ModemDigital()  {
     demodST = modem_create(LIQUID_MODEM_V29);
 }
 
-Modem *ModemST::factory() {
+ModemBase *ModemST::factory() {
     return new ModemST;
 }
 

--- a/src/modules/modem/digital/ModemST.h
+++ b/src/modules/modem/digital/ModemST.h
@@ -8,7 +8,7 @@ public:
     
     std::string getName();
     
-    Modem *factory();
+    static ModemBase *factory();
     
     void demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *audioOut);
     

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -91,7 +91,7 @@ void SDRThread::init() {
     device->setSampleRate(SOAPY_SDR_RX,0,sampleRate.load());
     
     // TODO: explore bandwidth setting option to see if this is necessary for others
-    if (device->getDriverKey() == "bladerf") {
+    if (device->getDriverKey() == "bladeRF") {
         device->setBandwidth(SOAPY_SDR_RX, 0, sampleRate.load());
     }
         
@@ -287,7 +287,7 @@ void SDRThread::updateSettings() {
     if (rate_changed.load()) {
         device->setSampleRate(SOAPY_SDR_RX,0,sampleRate.load());
         // TODO: explore bandwidth setting option to see if this is necessary for others
-        if (device->getDriverKey() == "bladerf") {
+        if (device->getDriverKey() == "bladeRF") {
             device->setBandwidth(SOAPY_SDR_RX, 0, sampleRate.load());
         }
         sampleRate.store(device->getSampleRate(SOAPY_SDR_RX,0));

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -89,6 +89,12 @@ void SDRThread::init() {
     
     wxGetApp().sdrEnumThreadNotify(SDREnumerator::SDR_ENUM_MESSAGE, std::string("Activating stream."));
     device->setSampleRate(SOAPY_SDR_RX,0,sampleRate.load());
+    
+    // TODO: explore bandwidth setting option to see if this is necessary for others
+    if (device->getDriverKey() == "bladerf") {
+        device->setBandwidth(SOAPY_SDR_RX, 0, sampleRate.load());
+    }
+        
     device->setFrequency(SOAPY_SDR_RX,0,"RF",frequency - offset.load());
     device->activateStream(stream);
     if (devInfo->hasCORR(SOAPY_SDR_RX, 0)) {
@@ -280,6 +286,10 @@ void SDRThread::updateSettings() {
     
     if (rate_changed.load()) {
         device->setSampleRate(SOAPY_SDR_RX,0,sampleRate.load());
+        // TODO: explore bandwidth setting option to see if this is necessary for others
+        if (device->getDriverKey() == "bladerf") {
+            device->setBandwidth(SOAPY_SDR_RX, 0, sampleRate.load());
+        }
         sampleRate.store(device->getSampleRate(SOAPY_SDR_RX,0));
         numChannels.store(getOptimalChannelCount(sampleRate.load()));
         numElems.store(getOptimalElementCount(sampleRate.load(), 60));

--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -40,7 +40,7 @@ typedef ThreadQueue<SDRThreadIQData *> SDRThreadIQDataQueue;
 
 class SDRThread : public IOThread {
 private:
-    void init();
+    bool init();
     void deinit();
     void readStream(SDRThreadIQDataQueue* iqDataOutQueue);
     void readLoop();

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -128,17 +128,18 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
 
     glViewport(0, 0, ClientSize.x, ClientSize.y);
     
-    if (scopePanel.getMode() == ScopePanel::SCOPE_MODE_XY && !spectrumVisible()) {
-        glDrawBuffer(GL_FRONT);
-        glContext->DrawBegin(false);
-    } else {
-        glDrawBuffer(GL_BACK);
+    // TODO: find out why frontbuffer drawing has stopped working in wx 3.1.0?
+//    if (scopePanel.getMode() == ScopePanel::SCOPE_MODE_XY && !spectrumVisible()) {
+//        glDrawBuffer(GL_FRONT);
+//        glContext->DrawBegin(false);
+//    } else {
+//        glDrawBuffer(GL_BACK);
         glContext->DrawBegin();
-        
+
         bgPanel.setFillColor(ThemeMgr::mgr.currentTheme->scopeBackground * 3.0, RGBA4f(0,0,0,1));
         bgPanel.calcTransform(CubicVR::mat4::identity());
         bgPanel.draw();
-    }
+//    }
     
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
@@ -216,9 +217,9 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     glContext->DrawTunerTitles(ppmMode);
     glContext->DrawEnd();
 
-    if (scopePanel.getMode() != ScopePanel::SCOPE_MODE_XY || spectrumVisible()) {
+//    if (scopePanel.getMode() != ScopePanel::SCOPE_MODE_XY || spectrumVisible()) {
         SwapBuffers();
-    }
+//    }
 }
 
 


### PR DESCRIPTION
- Also fix:
  - digital output title change with modem type
  - possible leak in digital modem audio option
  - close output window before terminating modem since it accesses the threads
  - catch stream init exceptions
  - temporary: set bandwidth for bladeRF on sample rate change
  - make digital scope work again; blur is disabled for now
