### PR TITLE
Crash with non-empty ModemArgInfoList (in FM Stereo)

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1496,8 +1496,12 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
     demod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
     
     if (modemPropertiesUpdated.load() && demod && demod->isModemInitialized()) {
-        modemProps->initProperties(demod->getModemArgs());
+        
+        //reset notification flag
         modemPropertiesUpdated.store(false);
+
+        modemProps->initProperties(demod->getModemArgs());
+       
         demodTray->Layout();
         modemProps->fitColumns();
 #if ENABLE_DIGITAL_LAB
@@ -1509,7 +1513,7 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
             }
             demod->showOutput();
         }
-#endif
+#endif       
     }
     
     if (modemProps->isCollapsed() && modemProps->GetMinWidth() > 22) {
@@ -1873,8 +1877,8 @@ FFTVisualDataThread *AppFrame::getWaterfallDataThread() {
     return waterfallDataThread;
 }
 
-void AppFrame::updateModemProperties(ModemArgInfoList args) {
-    newModemArgs = args;
+void AppFrame::notifyUpdateModemProperties() {
+   
     modemPropertiesUpdated.store(true);
 }
 

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -83,7 +83,7 @@ public:
 
     FFTVisualDataThread *getWaterfallDataThread();
 
-    void updateModemProperties(ModemArgInfoList args);
+    void notifyUpdateModemProperties();
     void setMainWaterfallFFTSize(int fftSize);
 
     void gkNudgeLeft(DemodulatorInstance *demod, int snap);
@@ -163,7 +163,6 @@ private:
     
     ModemProperties *modemProps;
     std::atomic_bool modemPropertiesUpdated;
-    ModemArgInfoList newModemArgs;
 	wxMenuItem *showTipMenuItem;
 
     bool lowPerfMode;

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -61,7 +61,7 @@ void DemodulatorWorkerThread::run() {
                     cModem->writeSettings(demodCommand.settings);
                 }
                 result.sampleRate = demodCommand.sampleRate;
-                wxGetApp().getAppFrame()->updateModemProperties(cModem->getSettings());
+                wxGetApp().getAppFrame()->notifyUpdateModemProperties();
             }
             result.modem = cModem;
 


### PR DESCRIPTION
@cjcliffe Hello, back from holidays ! 
Since FM deemphasis has been added, we have actually non-empty ModemArgInfoList showing up in regular build (i.e. excluding Digital Lab modems). When loading alternatively session files with FMS and NFM modems, a crash occurr after 2-3 session loads max.
VisualStudio reported some horrible 'corrupted memory' somewhere in 
``````cpp
void AppFrame::updateModemProperties(ModemArgInfoList args) {
    newModemArgs = args; ==> something wrong goes there, in assignement/deletion/ of std::vector<ModemArgInfo>
....
`````` 
So since the `std::vector<ModemArgInfo>` do not contain any fancy structures, the problem couldn't happen from wrong assignment code. On the other hand, AppFrame::updateModemProperties() is called by any DemodulatorWorkerThread, so it may be an unprotected concurrent access problem.

Luckily AppFrame::newModemArgs looks actually unsed because settings are read per-Modem in DemodulatorInstance::getModemArgs() if I'm right, so I simply removed AppFrame::newModemArgs entirely and the crashes actually disappeared.