### PR TITLE
Menu Refactoring

### DIFF
--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -289,6 +289,7 @@ AppConfig::AppConfig() : configName("") {
     centerFreq.store(100000000);
     waterfallLinesPerSec.store(DEFAULT_WATERFALL_LPS);
     spectrumAvgSpeed.store(0.65f);
+    modemPropsCollapsed.store(false);
 #ifdef USE_HAMLIB
     rigEnabled.store(false);
     rigModel.store(1);
@@ -340,6 +341,14 @@ void AppConfig::setWindowMaximized(bool max) {
 
 bool AppConfig::getWindowMaximized() {
     return winMax.load();
+}
+
+void AppConfig::setModemPropsCollapsed(bool collapse) {
+    modemPropsCollapsed.store(collapse);
+}
+
+bool AppConfig::getModemPropsCollapsed() {
+    return modemPropsCollapsed.load();
 }
 
 void AppConfig::setShowTips(bool show) {
@@ -468,6 +477,7 @@ bool AppConfig::save() {
         *window_node->newChild("center_freq") = centerFreq.load();
         *window_node->newChild("waterfall_lps") = waterfallLinesPerSec.load();
         *window_node->newChild("spectrum_avg") = spectrumAvgSpeed.load();
+        *window_node->newChild("modemprops_collapsed") = modemPropsCollapsed.load();;
     }
     
     DataNode *devices_node = cfg.rootNode()->newChild("devices");
@@ -547,7 +557,7 @@ bool AppConfig::load() {
 
     if (cfg.rootNode()->hasAnother("window")) {
         int x,y,w,h;
-        int max,tips,lpm;
+        int max,tips,lpm,mpc;
         
         DataNode *win_node = cfg.rootNode()->getNext("window");
         
@@ -612,6 +622,11 @@ bool AppConfig::load() {
             float avgVal;
             win_node->getNext("spectrum_avg")->element()->get(avgVal);
             spectrumAvgSpeed.store(avgVal);
+        }
+
+        if (win_node->hasAnother("modemprops_collapsed")) {
+            win_node->getNext("modemprops_collapsed")->element()->get(mpc);
+            modemPropsCollapsed.store(mpc?true:false);
         }
     }
     

--- a/src/AppConfig.h
+++ b/src/AppConfig.h
@@ -85,6 +85,9 @@ public:
     void setWindowMaximized(bool max);
     bool getWindowMaximized();
 
+    void setModemPropsCollapsed(bool collapse);
+    bool getModemPropsCollapsed();
+
     void setShowTips(bool show);
     bool getShowTips();
 
@@ -148,7 +151,7 @@ private:
     std::string configName;
     std::map<std::string, DeviceConfig *> deviceConfig;
     std::atomic_int winX,winY,winW,winH;
-    std::atomic_bool winMax, showTips, lowPerfMode;
+    std::atomic_bool winMax, showTips, lowPerfMode, modemPropsCollapsed;
     std::atomic_int themeId;
     std::atomic_int fontScale;
     std::atomic_llong snap;

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -378,21 +378,11 @@ AppFrame::AppFrame() :
     }
 
     menuBar->Append(menu, wxT("Audio &Output"));
-
-    menu = new wxMenu;
-
-    int themeId = wxGetApp().getConfig()->getTheme();
             
-    menu->AppendRadioItem(wxID_THEME_DEFAULT, "Default")->Check(themeId==COLOR_THEME_DEFAULT);
-    menu->AppendRadioItem(wxID_THEME_RADAR, "RADAR")->Check(themeId==COLOR_THEME_RADAR);
-    menu->AppendRadioItem(wxID_THEME_BW, "Black & White")->Check(themeId==COLOR_THEME_BW);
-    menu->AppendRadioItem(wxID_THEME_SHARP, "Sharp")->Check(themeId==COLOR_THEME_SHARP);
-    menu->AppendRadioItem(wxID_THEME_RAD, "Rad")->Check(themeId==COLOR_THEME_RAD);
-    menu->AppendRadioItem(wxID_THEME_TOUCH, "Touch")->Check(themeId==COLOR_THEME_TOUCH);
-    menu->AppendRadioItem(wxID_THEME_HD, "HD")->Check(themeId==COLOR_THEME_HD);
+    sampleRateMenu = new wxMenu;
+    menuBar->Append(sampleRateMenu, wxT("Sample &Rate"));
 
-    menuBar->Append(menu, wxT("&Color Scheme"));
-
+    // Audio Sample Rates
     menu = new wxMenu;
 
 #define NUM_RATES_DEFAULT 4
@@ -441,23 +431,37 @@ AppFrame::AppFrame() :
         }
     }
 
-    sampleRateMenu = new wxMenu;
-
-    menuBar->Append(sampleRateMenu, wxT("Sample &Rate"));
-
     menuBar->Append(menu, wxT("Audio &Sample Rate"));
-
 
     //Add Display menu
     displayMenu = new wxMenu;
+        
+    wxMenu *fontMenu = new wxMenu;
 
-    menuBar->Append(displayMenu, wxT("&Display"));
     int fontScale = wxGetApp().getConfig()->getFontScale();
 
-    displayMenu->AppendRadioItem(wxID_DISPLAY_BASE, "Text Size: Normal")->Check(GLFont::GLFONT_SCALE_NORMAL == fontScale);
-    displayMenu->AppendRadioItem(wxID_DISPLAY_BASE + 1, "Text Size: 1.5x")->Check(GLFont::GLFONT_SCALE_MEDIUM == fontScale);
-    displayMenu->AppendRadioItem(wxID_DISPLAY_BASE + 2, "Text Size: 2.0x")->Check(GLFont::GLFONT_SCALE_LARGE == fontScale);
+    fontMenu->AppendRadioItem(wxID_DISPLAY_BASE, "Normal")->Check(GLFont::GLFONT_SCALE_NORMAL == fontScale);
+    fontMenu->AppendRadioItem(wxID_DISPLAY_BASE + 1, "1.5x")->Check(GLFont::GLFONT_SCALE_MEDIUM == fontScale);
+    fontMenu->AppendRadioItem(wxID_DISPLAY_BASE + 2, "2.0x")->Check(GLFont::GLFONT_SCALE_LARGE == fontScale);
 
+    displayMenu->AppendSubMenu(fontMenu, "&Text Size");
+            
+    wxMenu *themeMenu = new wxMenu;
+    
+    int themeId = wxGetApp().getConfig()->getTheme();
+    
+    themeMenu->AppendRadioItem(wxID_THEME_DEFAULT, "Default")->Check(themeId==COLOR_THEME_DEFAULT);
+    themeMenu->AppendRadioItem(wxID_THEME_RADAR, "RADAR")->Check(themeId==COLOR_THEME_RADAR);
+    themeMenu->AppendRadioItem(wxID_THEME_BW, "Black & White")->Check(themeId==COLOR_THEME_BW);
+    themeMenu->AppendRadioItem(wxID_THEME_SHARP, "Sharp")->Check(themeId==COLOR_THEME_SHARP);
+    themeMenu->AppendRadioItem(wxID_THEME_RAD, "Rad")->Check(themeId==COLOR_THEME_RAD);
+    themeMenu->AppendRadioItem(wxID_THEME_TOUCH, "Touch")->Check(themeId==COLOR_THEME_TOUCH);
+    themeMenu->AppendRadioItem(wxID_THEME_HD, "HD")->Check(themeId==COLOR_THEME_HD);
+
+    displayMenu->AppendSubMenu(themeMenu, wxT("&Color Scheme"));
+            
+    menuBar->Append(displayMenu, wxT("&Display"));
+            
     GLFont::setScale((GLFont::GLFontScale)fontScale);
 
 #ifdef USE_HAMLIB
@@ -721,7 +725,7 @@ void AppFrame::updateDeviceParams() {
         sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->Check(true);
     }
    
-    menuBar->Replace(4, newSampleRateMenu, wxT("Sample &Rate"));
+    menuBar->Replace(3, newSampleRateMenu, wxT("Sample &Rate"));
     sampleRateMenu = newSampleRateMenu;
 
     if (!wxGetApp().getAGCMode()) {

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -85,6 +85,7 @@ public:
 
     void notifyUpdateModemProperties();
     void setMainWaterfallFFTSize(int fftSize);
+    void setScopeDeviceName(std::string deviceName);
 
     void gkNudgeLeft(DemodulatorInstance *demod, int snap);
     void gkNudgeRight(DemodulatorInstance *demod, int snap);

--- a/src/ModemProperties.h
+++ b/src/ModemProperties.h
@@ -5,6 +5,7 @@
 #include <wx/propgrid/propgrid.h>
 #include <wx/propgrid/advprops.h>
 
+#include "DemodulatorInstance.h"
 #include "Modem.h"
 
 class ModemProperties : public wxPanel {
@@ -19,8 +20,10 @@ public:
     );
     ~ModemProperties();
     
-    void initProperties(ModemArgInfoList newArgs);
+    void initDefaultProperties();
+    void initProperties(ModemArgInfoList newArgs, DemodulatorInstance *demodInstance);
     bool isMouseInView();
+    void setCollapsed(bool state);
     bool isCollapsed();
     void fitColumns();
     
@@ -40,6 +43,15 @@ private:
     wxBoxSizer* bSizer;
     wxPropertyGrid* m_propertyGrid;
     ModemArgInfoList args;
+    DemodulatorInstance *demodContext;
     std::map<std::string, wxPGProperty *> props;
     bool mouseInView, collapsed;
+    
+    ModemArgInfoList defaultArgs;
+    ModemArgInfo outputArg;
+    std::map<std::string, wxPGProperty *> defaultProps;
+    
+    std::vector<RtAudio::DeviceInfo> audioDevices;
+    std::map<int,RtAudio::DeviceInfo> audioInputDevices;
+    std::map<int,RtAudio::DeviceInfo> audioOutputDevices;
 };


### PR DESCRIPTION
Refactor Menus
===
- [x] Move Theme to the Display sub-menu
- [x] Make the Font option a sub-menu of Display
- [x] Move Audio Output to be a default option the Modem Settings UI; it's per-modem and that's not really intuitive as a Menu interface you have to keep clicking to see.
- [x] Save Modem property collapse state on exit

Note: work out character issues for adding modem label option.