### PR TITLE
Small cleanup squelsh and misc

### DIFF
--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -165,8 +165,11 @@ bool CubicSDR::OnInit() {
         return false;
     }
 
-    //	// console output for Windows: available in DEBUG or in case of ENABLE_DIGITAL_LAB
-#if (defined(WIN32) && (defined(ENABLE_DIGITAL_LAB) || defined(_DEBUG)))
+    //Deactivated code to allocate an explicit Console on Windows.
+    //This tends to hang the apllication on heavy demod (re)creation.
+    //To continue to debug with std::cout traces, simply run CubicSDR in a MINSYS2 compatble shell on Windows:
+    //ex: Cygwin shell, Git For Windows Bash shell....
+#if (0)
     	if (AllocConsole()) {
     		freopen("CONOUT$", "w", stdout);
     		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_RED);

--- a/src/demod/DemodulatorThread.h
+++ b/src/demod/DemodulatorThread.h
@@ -34,15 +34,14 @@ public:
     float getSignalFloor();
     void setSquelchLevel(float signal_level_in);
     float getSquelchLevel();
-
+   
     bool getSquelchBreak();
 
     static void releaseSquelchLock(DemodulatorInstance *inst);
-    
 protected:
     
-    float abMagnitude(double alpha, double beta, float inphase, float quadrature);
-    float linearToDb(float linear);
+    double abMagnitude(float inphase, float quadrature);
+    double linearToDb(double linear);
 
     DemodulatorInstance *demodInstance = nullptr;
     ReBuffer<AudioThreadInput> outputBuffers;


### PR DESCRIPTION
@cjcliffe it is a small simplification of the current squelch, including #423 changes:
__SMALL_SQUELCH_CLEANUP:__
-  in DemodulatorThread::abMagnitude(), remove the alpha-beta filtering by the real norm computation using sqrt() like everywhere else in code. On desktop CPU sqrt() is a free intrinsic for ages, no need to DSP approximations,
-  In squelch code, use double instead of floats to keep some precision when accumulating or computing magnitudes,


__WINDOWS_NO_SECONDARY_CONSOLE:__
This in unrelated to squelch, but I noticed that not-allocating an explicit Console on Windows made the application less hang prone when loading / reloading demodulators (through sessions, typically)
 
In addition, following my investigation about #411, I noticed that std::cout traces actually shows up when running the executable in a MINSYS2 environment like Cygwin or Git Bash for Windows, so there is no need to allocate an had-hoc Console to have debug traces.
This commit is just about disabling the Console allocation code entirely by an `#if 0` block.
 
  
 