### PR TITLE
FIX: wrong directive placement prevent building without HAMLIB

### DIFF
--- a/src/AppConfig.h
+++ b/src/AppConfig.h
@@ -179,9 +179,10 @@ private:
     std::atomic<float> spectrumAvgSpeed, mainSplit, visSplit, bookmarkSplit;
     std::atomic_int dbOffset;
     std::vector<SDRManualDef> manualDevices;
+    std::atomic_bool bookmarksVisible;
 #if USE_HAMLIB
     std::atomic_int rigModel, rigRate;
     std::string rigPort;
-    std::atomic_bool rigEnabled, rigFollowMode, rigControlMode, rigCenterLock, rigFollowModem, bookmarksVisible;
+    std::atomic_bool rigEnabled, rigFollowMode, rigControlMode, rigCenterLock, rigFollowModem;
 #endif
 };

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -189,6 +189,9 @@ private:
 
     bool lowPerfMode;
 
+    wxMenuItem *hideBookmarksItem;
+    bool saveDisabled;
+
 #ifdef USE_HAMLIB
     void enableRig();
     void disableRig();
@@ -201,7 +204,7 @@ private:
     wxMenuItem *rigCenterLockMenuItem;
     wxMenuItem *rigFollowModemMenuItem;
     wxMenuItem *sdrIFMenuItem;
-    wxMenuItem *hideBookmarksItem;
+    
     std::map<int, wxMenuItem *> rigSerialMenuItems;
     std::map<int, wxMenuItem *> rigModelMenuItems;
     int rigModel;
@@ -211,7 +214,6 @@ private:
     std::string rigPort;
     int numRigs;
     bool rigInit;
-    bool saveDisabled;
 #endif
 
     wxDECLARE_EVENT_TABLE();

--- a/src/demod/DemodulatorMgr.cpp
+++ b/src/demod/DemodulatorMgr.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include "DemodulatorMgr.h"
+#include "CubicSDR.h"
 
 #if USE_HAMLIB
 #include "RigThread.h"


### PR DESCRIPTION
@cjcliffe I wish you a Happy New Year ! I've started to test your Bookmarks enhancement, it looks really good:)
Still, I've encountered some problems on Win64   
- This fixes the wrong placement of some declared variables placed within #if USE_HAMLIB / #endif, preventing compilation without HAMLIB enabled. Problem was reported in #483 . 

I've got another problem: Demod Spectrum and Waterfall remains empty, I've not started to investigate this one yet (Reproducible with your Win64 021alpha build) I suspect the DEMOD_VISIBLE option is at play here... Since you can't have missed this on OSX, I would say it is a non-initialized flag beahaving differently on Windows somewhere. Image: 
![2017-01-03_205850_small_cr](https://cloud.githubusercontent.com/assets/5152742/21621512/a0000fc4-d1f9-11e6-95de-20e9b194ac60.jpg)



