### PR TITLE
FIX: missing demod displays due to wrong input/queue setups order

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -281,7 +281,7 @@ AppFrame::AppFrame() :
 
 //    vbox->Add(demodTray, 12, wxEXPAND | wxALL, 0);
 //    vbox->AddSpacer(1);
-    bookmarkSplitter = new wxSplitterWindow( mainSplitter, wxID_BM_SPLITTER, wxDefaultPosition, wxDefaultSize, wxSP_3DSASH | wxSP_LIVE_UPDATE );
+    bookmarkSplitter = new wxSplitterWindow(mainSplitter, wxID_BM_SPLITTER, wxDefaultPosition, wxDefaultSize, wxSP_3DSASH | wxSP_LIVE_UPDATE );
     bookmarkSplitter->SetMinimumPaneSize(1);
     bookmarkSplitter->SetSashGravity(1.0f / 20.0f);
         
@@ -1395,7 +1395,9 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
             demodGainMeter->setInputValue(demod->getGain());
             wxGetApp().getDemodMgr().setLastGain(demod->getGain());
             int outputDevice = demod->getOutputDevice();
-            if (scopeCanvas) scopeCanvas->setDeviceName(outputDevices[outputDevice].name);
+            if (scopeCanvas) {
+                scopeCanvas->setDeviceName(outputDevices[outputDevice].name);
+            }
 //            outputDeviceMenuItems[outputDevice]->Check(true);
             std::string dType = demod->getDemodulatorType();
             demodModeSelector->setSelection(dType);
@@ -1575,12 +1577,16 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
 
         if (demodWaterfallCanvas && wxGetApp().getFrequency() != demodWaterfallCanvas->getCenterFrequency()) {
             demodWaterfallCanvas->setCenterFrequency(wxGetApp().getFrequency());
-            if (demodSpectrumCanvas) demodSpectrumCanvas->setCenterFrequency(wxGetApp().getFrequency());
+            if (demodSpectrumCanvas) {
+                demodSpectrumCanvas->setCenterFrequency(wxGetApp().getFrequency());
+            }
         }
+
         if (spectrumCanvas->getViewState() && abs(wxGetApp().getFrequency()-spectrumCanvas->getCenterFrequency()) > (wxGetApp().getSampleRate()/2)) {
             spectrumCanvas->setCenterFrequency(wxGetApp().getFrequency());
             waterfallCanvas->setCenterFrequency(wxGetApp().getFrequency());
         }
+
         if (demodMuteButton->modeChanged()) {
             int muteMode = demodMuteButton->getSelection();
             if (muteMode == -1) {
@@ -1685,7 +1691,9 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
         wxGetApp().getSpectrumProcessor()->setPeakHold(peakHoldMode == 1);
 
         //make the peak hold act on the current dmod also, like a zoomed-in version.
-        if (wxGetApp().getDemodSpectrumProcessor()) wxGetApp().getDemodSpectrumProcessor()->setPeakHold(peakHoldMode == 1);
+        if (wxGetApp().getDemodSpectrumProcessor()) {
+            wxGetApp().getDemodSpectrumProcessor()->setPeakHold(peakHoldMode == 1);
+        }
         peakHoldButton->clearModeChanged();
     }
     
@@ -1933,7 +1941,9 @@ void AppFrame::setMainWaterfallFFTSize(int fftSize) {
 }
 
 void AppFrame::setScopeDeviceName(std::string deviceName) {
-    if (scopeCanvas) scopeCanvas->setDeviceName(deviceName);
+    if (scopeCanvas) {
+        scopeCanvas->setDeviceName(deviceName);
+    }
 }
 
 
@@ -2199,7 +2209,9 @@ int AppFrame::OnGlobalKeyUp(wxKeyEvent &event) {
             break;
         case 'P':
             wxGetApp().getSpectrumProcessor()->setPeakHold(!wxGetApp().getSpectrumProcessor()->getPeakHold());
-            if (wxGetApp().getDemodSpectrumProcessor()) wxGetApp().getDemodSpectrumProcessor()->setPeakHold(wxGetApp().getSpectrumProcessor()->getPeakHold());
+            if (wxGetApp().getDemodSpectrumProcessor()) {
+                wxGetApp().getDemodSpectrumProcessor()->setPeakHold(wxGetApp().getSpectrumProcessor()->getPeakHold());
+            }
             peakHoldButton->setSelection(wxGetApp().getSpectrumProcessor()->getPeakHold()?1:0);
             peakHoldButton->clearModeChanged();
             break;

--- a/src/IOThread.cpp
+++ b/src/IOThread.cpp
@@ -72,7 +72,7 @@ void IOThread::terminate() {
 };
 
 void IOThread::onBindOutput(std::string /* name */, ThreadQueueBase* /* threadQueue */) {
-    
+   
 };
 
 void IOThread::onBindInput(std::string /* name */, ThreadQueueBase* /* threadQueue */) {
@@ -80,20 +80,24 @@ void IOThread::onBindInput(std::string /* name */, ThreadQueueBase* /* threadQue
 };
 
 void IOThread::setInputQueue(std::string qname, ThreadQueueBase *threadQueue) {
+    std::lock_guard < std::mutex > lock(m_queue_bindings_mutex);
     input_queues[qname] = threadQueue;
     this->onBindInput(qname, threadQueue);
 };
 
 ThreadQueueBase *IOThread::getInputQueue(std::string qname) {
+    std::lock_guard < std::mutex > lock(m_queue_bindings_mutex);
     return input_queues[qname];
 };
 
 void IOThread::setOutputQueue(std::string qname, ThreadQueueBase *threadQueue) {
+    std::lock_guard < std::mutex > lock(m_queue_bindings_mutex);
     output_queues[qname] = threadQueue;
     this->onBindOutput(qname, threadQueue);
 };
 
 ThreadQueueBase *IOThread::getOutputQueue(std::string qname) {
+    std::lock_guard < std::mutex > lock(m_queue_bindings_mutex);
     return output_queues[qname];
 };
 

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -221,7 +221,10 @@ public:
 protected:
     std::map<std::string, ThreadQueueBase *, map_string_less> input_queues;
     std::map<std::string, ThreadQueueBase *, map_string_less> output_queues;
-    
+
+    //this protects against concurrent changes in input/output bindings: get/set/Input/OutPutQueue
+    mutable std::mutex m_queue_bindings_mutex;
+
     //true when a termination is ordered
     std::atomic_bool stopping;
     Timer gTimer;
@@ -230,4 +233,5 @@ private:
     //true when the thread has really ended, i.e run() from threadMain() has returned.
     std::atomic_bool terminated;
 
+   
 };


### PR DESCRIPTION
@cjcliffe Hello ! I caught the missing demod wf/spectrum problem. It was cased by a change in initialization order between setInput/OutputQueue in CubicSDR.cpp vs. v0.20. We have now in the current version:
````cpp
t_PostSDR = new std::thread(&SDRPostThread::threadMain, sdrPostThread);
...
sdrPostThread->setOutputQueue("IQActiveDemodVisualDataOutput", pipeDemodIQVisualData);
````

This is indeed wrong, because like most of long-running threads, the loop is crafted like this:
 ````cpp
run() {
   // Retreive input/output queues pointers once... 
  while(!stopping) {
   // work with those pointers...
   }
}
````
This is OK as long as the input/output setup is completely done BEFORE the thread starts, which is not he case above.

So here are the changes :
-  CubicSDR.cpp: changed order so that threads are all started AFTER input/output plumbing,
-  IOThread: We may want to change queues dynamically, or just re-read by getInput/Output, (like in DemodulatorInstance) so the set/get must be cleanly protected against concurrent access.
-  AppFrame.cpp: completly useless ifs re-formating :)

I've checked the other usage patterns of set/get queues vs. threads, they look fine. 