### PR TITLE
Device Sample Rate improvements: UI, rates handled as long, misc... 

### DIFF
--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -55,6 +55,7 @@
 #define wxID_DISPLAY_BOOKMARKS 2107
 
 #define wxID_BANDWIDTH_BASE 2150
+#define wxID_BANDWIDTH_MANUAL_DIALOG 2199
 #define wxID_BANDWIDTH_MANUAL 2200
 
 #define wxID_DISPLAY_BASE 2250
@@ -118,6 +119,12 @@ public:
     
     BookmarkView *getBookmarkView();
     void disableSave(bool state);
+
+    //call this in case the main UI is not 
+    //the origin of device changes / sample rate by operator,
+    //and must be notified back to update its UI elements
+    //(ex: SDR Devices dialog changing the configuration)
+    void notifyDeviceChanged();
     
 #ifdef _WIN32
 	bool canFocus();
@@ -174,6 +181,7 @@ private:
     SoapySDR::ArgInfoList settingArgs;
     int settingsIdMax;
     std::vector<long> sampleRates;
+    long manualSampleRate = -1;
     
     std::string currentSessionFile;
     

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -917,6 +917,10 @@ bool CubicSDR::areDevicesReady() {
     return devicesReady.load();
 }
 
+void CubicSDR::notifyMainUIOfDeviceChange() {
+    appframe->notifyDeviceChanged();
+}
+
 bool CubicSDR::areDevicesEnumerating() {
     return !sdrEnum->isTerminated();
 }

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -138,6 +138,8 @@ public:
     bool areDevicesEnumerating();
     bool areModulesMissing();
     std::string getNotification();
+
+    void notifyMainUIOfDeviceChange();
     
     void addRemote(std::string remoteAddr);
     void removeRemote(std::string remoteAddr);

--- a/src/CubicSDRDefs.h
+++ b/src/CubicSDRDefs.h
@@ -40,4 +40,6 @@ const char filePathSeparator =
 
 #define CHANNELIZER_RATE_MAX 500000
 
+#define MANUAL_SAMPLE_RATE_MIN 2000000 // 2MHz
+#define MANUAL_SAMPLE_RATE_MAX 200000000 // 200MHz (We are 2017+ after all)
 

--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -260,7 +260,7 @@ void AudioThread::enumerateDevices(std::vector<RtAudio::DeviceInfo> &devs) {
             std::cout << "\t\t32-bit float normalized between plus/minus 1.0." << std::endl;
         }
         if (nFormats & RTAUDIO_FLOAT64) {
-            std::cout << "\t\t32-bit float normalized between plus/minus 1.0." << std::endl;
+            std::cout << "\t\t64-bit float normalized between plus/minus 1.0." << std::endl;
         }
 
         std::vector<unsigned int>::iterator srate;

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -116,8 +116,8 @@ void SDRDevicesDialog::refreshDeviceProperties() {
         devSettings["name"] = m_propertyGrid->Append( new wxStringProperty("Name", wxPG_LABEL, devConfig->getDeviceName()) );
         devSettings["offset"] = m_propertyGrid->Append( new wxIntProperty("Offset (Hz)", wxPG_LABEL, devConfig->getOffset()) );
         
-        int currentSampleRate = wxGetApp().getSampleRate();
-        int deviceSampleRate = devConfig->getSampleRate();
+        long currentSampleRate = wxGetApp().getSampleRate();
+        long deviceSampleRate = devConfig->getSampleRate();
         
         if (!deviceSampleRate) {
             deviceSampleRate = selDev->getSampleRateNear(SOAPY_SDR_RX, 0, currentSampleRate);
@@ -318,7 +318,7 @@ void SDRDevicesDialog::OnUseSelected( wxMouseEvent& event) {
         wxGetApp().setDeviceArgs(settingArgs);
         wxGetApp().setStreamArgs(streamArgs);
         wxGetApp().setDevice(dev,0);
-                
+        wxGetApp().notifyMainUIOfDeviceChange();
         Close();
     }
     event.Skip();
@@ -438,13 +438,14 @@ void SDRDevicesDialog::OnPropGridChanged( wxPropertyGridEvent& event ) {
         DeviceConfig *devConfig = wxGetApp().getConfig()->getDevice(dev->getDeviceId());
         
         std::string strRate = deviceArgs["sample_rate"].options[event.GetPropertyValue().GetInteger()];
-        int srate = 0;
+        long srate = 0;
         try {
-            srate = std::stoi(strRate);
+            srate = std::stol(strRate);
             devConfig->setSampleRate(srate);
             
             if (dev->isActive() || !wxGetApp().getDevice()) {
                 wxGetApp().setSampleRate(srate);
+                wxGetApp().notifyMainUIOfDeviceChange();
             }            
         } catch (std::invalid_argument e) {
             // nop

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -208,7 +208,12 @@ void SDRThread::readStream(SDRThreadIQDataQueue* iqDataOutQueue) {
         int n_stream_read = device->readStream(stream, buffs, mtElems, flags, timeNs);
 
         //if the n_stream_read <= 0, bail out from reading. 
-        if (n_stream_read <= 0) {
+        if (n_stream_read == 0) {
+             std::cout << "SDRThread::readStream(): read blocking..." << std::endl;
+             break;
+        }
+        else if (n_stream_read < 0) {
+            std::cout << "SDRThread::readStream(): read failed with code: " << n_stream_read << std::endl;
             break;
         }
 
@@ -226,7 +231,7 @@ void SDRThread::readStream(SDRThreadIQDataQueue* iqDataOutQueue) {
         } else {
             break;
         }
-    }
+    } //end while
     
     if (n_read > 0 && !stopping && !iqDataOutQueue->full()) {
         SDRThreadIQData *dataOut = buffers.getBuffer();
@@ -515,7 +520,7 @@ long long SDRThread::getOffset() {
     return offset.load();
 }
 
-void SDRThread::setSampleRate(int rate) {
+void SDRThread::setSampleRate(long rate) {
     sampleRate.store(rate);
     rate_changed = true;
     DeviceConfig *devConfig = deviceConfig.load();
@@ -524,7 +529,7 @@ void SDRThread::setSampleRate(int rate) {
     }
 //    std::cout << "Set sample rate: " << sampleRate.load() << std::endl;
 }
-int SDRThread::getSampleRate() {
+long SDRThread::getSampleRate() {
     return sampleRate.load();
 }
 

--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -70,8 +70,8 @@ public:
     void setOffset(long long ofs);
     long long getOffset();
     
-    void setSampleRate(int rate);
-    int getSampleRate();
+    void setSampleRate(long rate);
+    long getSampleRate();
 
     void setPPM(int ppm);
     int getPPM();
@@ -109,7 +109,7 @@ protected:
     std::map<std::string, std::string> settings;
     std::map<std::string, bool> settingChanged;
 
-    std::atomic<uint32_t> sampleRate;
+    std::atomic_llong sampleRate;
     std::atomic_llong frequency, offset, lock_freq;
     std::atomic_int ppm, numElems, mtuElems, numChannels;
     std::atomic_bool hasPPM, hasHardwareDC;

--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -170,6 +170,13 @@ void GainCanvas::setHelpTip(std::string tip) {
 
 void GainCanvas::updateGainUI() {
     SDRDeviceInfo *devInfo = wxGetApp().getDevice();
+
+    //possible if we 'Refresh Devices' then devInfo becomes null
+    //until a new device is selected.
+    if (devInfo == nullptr) {
+        return;
+    }
+
     DeviceConfig *devConfig = wxGetApp().getConfig()->getDevice(devInfo->getDeviceId());
     
     gains = devInfo->getGains(SOAPY_SDR_RX, 0);

--- a/src/visual/InteractiveCanvas.cpp
+++ b/src/visual/InteractiveCanvas.cpp
@@ -30,7 +30,7 @@ InteractiveCanvas::InteractiveCanvas(wxWindow *parent, int *dispAttrs) :
 InteractiveCanvas::~InteractiveCanvas() {
 }
 
-void InteractiveCanvas::setView(long long center_freq_in, int bandwidth_in) {
+void InteractiveCanvas::setView(long long center_freq_in, long long bandwidth_in) {
     isView = true;
     centerFreq = center_freq_in;
     bandwidth = bandwidth_in;
@@ -74,11 +74,11 @@ long long InteractiveCanvas::getCenterFrequency() {
     }
 }
 
-void InteractiveCanvas::setBandwidth(unsigned int bandwidth_in) {
+void InteractiveCanvas::setBandwidth(long long bandwidth_in) {
     bandwidth = bandwidth_in;
 }
 
-unsigned int InteractiveCanvas::getBandwidth() {
+long long InteractiveCanvas::getBandwidth() {
     if (isView) {
         return bandwidth;
     } else {

--- a/src/visual/InteractiveCanvas.h
+++ b/src/visual/InteractiveCanvas.h
@@ -17,15 +17,15 @@ public:
     long long getFrequencyAt(float x);
     long long getFrequencyAt(float x, long long iqCenterFreq, long long iqBandwidth);
     
-    virtual void setView(long long center_freq_in, int bandwidth_in);
+    virtual void setView(long long center_freq_in, long long bandwidth_in);
     virtual void disableView();
     bool getViewState();
 
     void setCenterFrequency(long long center_freq_in);
     long long getCenterFrequency();
 
-    void setBandwidth(unsigned int bandwidth_in);
-    unsigned int getBandwidth();
+    void setBandwidth(long long bandwidth_in);
+    long long getBandwidth();
 
     MouseTracker *getMouseTracker();
     bool isMouseInView();
@@ -59,8 +59,8 @@ protected:
     bool ctrlDown;
 
     long long centerFreq;
-    unsigned int bandwidth;
-    unsigned int lastBandwidth;
+    long long bandwidth;
+    long long lastBandwidth;
 
     bool isView;
 	std::string lastToolTip;


### PR DESCRIPTION
@cjcliffe Good day ! This introduce small changes in handling of device sample rate, mainly to help with UI freindlness. It fixes in particular:
-  Select Manual Entry, set a frequency. The radio button is now checked. Then, if you want to modify it again, you have to select another choice and get back to Manual Entry.
-  The sample_rate stored in session file is not restored at session load, another choice is made even if the saved one is perfectly compatible with the current device properties.
-  When selecting a sample rate in the SDR Device dialog and pressing Start, the AppFrame is not updated back, in the menus in particular, so that the displayed sample rate do not match the one actually applied. Take care now that AppFrame is updated in this case where it is not the origin of the changes. 
-  Following the path of  device ````setSampleRate()/getSampleRate()```` in the whole code, I saw that some were int, others long and long long mixed together. Mostly harmless unless going beyond 2**31 Hz, but well... I turned the int to long or long long.
      
In order to fix the first point, I had to modify the Sample Rate Menu a bit, because a single Radio Button couldn't handle the change (clicking on a already checked radio button triggers no event !)

So, I've added  a normal "Manual Entry ..." item dedicated to the update of  manual sample rate through the dialog, and modified the existing radio button into "Manual: [freq] Mhz" displaying the latest manual sample rate entered by the operator.
I think it works quite well you'll see.

Finally I couldn't stop myself adding some pedantic traces and coments here and there.
 