### PR TITLE
UI fixes: Theme set/change, B shortcut, add icon to SDR Devices dialog.

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -207,7 +207,7 @@ AppFrame::AppFrame() :
 
 #if CUBICSDR_ENABLE_VIEW_SCOPE
     scopeCanvas = new ScopeCanvas(demodPanel, attribList);
-    scopeCanvas->setHelpTip("Audio Visuals, drag left/right to toggle Scope or Spectrum.");
+    scopeCanvas->setHelpTip("Audio Visuals, drag left/right to toggle Scope or Spectrum, 'B' to toggle decibels display.");
     scopeCanvas->SetMinSize(wxSize(128,-1));
     demodScopeTray->Add(scopeCanvas, 8, wxEXPAND | wxALL, 0);
     wxGetApp().getScopeProcessor()->setup(1024);
@@ -1681,7 +1681,6 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
     if (scopeCanvas) {
         scopeCanvas->setPPMMode(demodTuner->isAltDown());
         
-        scopeCanvas->setShowDb(spectrumCanvas->getShowDb());
         wxGetApp().getScopeProcessor()->setScopeEnabled(scopeCanvas->scopeVisible());
         wxGetApp().getScopeProcessor()->setSpectrumEnabled(scopeCanvas->spectrumVisible());
         wxGetApp().getAudioVisualQueue()->set_max_num_items((scopeCanvas->scopeVisible()?1:0) + (scopeCanvas->spectrumVisible()?1:0));
@@ -2232,12 +2231,21 @@ int AppFrame::OnGlobalKeyDown(wxKeyEvent &event) {
             break;
     }
     
+    //Re-dispatch the key events if the mouse cursor is within a given
+    //widget region, effectively activating its specific key shortcuts,
+    //which else are overriden by this global key handler.
     if (demodTuner->getMouseTracker()->mouseInView()) {
         demodTuner->OnKeyDown(event);
     } else if (waterfallCanvas->getMouseTracker()->mouseInView()) {
         waterfallCanvas->OnKeyDown(event);
     }
-    
+    else if (spectrumCanvas->getMouseTracker()->mouseInView()) {
+        spectrumCanvas->OnKeyDown(event);
+    }
+    else if (scopeCanvas->getMouseTracker()->mouseInView()) {
+        scopeCanvas->OnKeyDown(event);
+    }
+
     return 1;
 }
 
@@ -2345,13 +2353,22 @@ int AppFrame::OnGlobalKeyUp(wxKeyEvent &event) {
         default:
             break;
     }
-    
+
+    //Re-dispatch the key events if the mouse cursor is within a given
+    //widget region, effectively activating its specific key shortcuts,
+    //which else are overriden by this global key handler.
     if (demodTuner->getMouseTracker()->mouseInView()) {
         demodTuner->OnKeyUp(event);
-    } else if (waterfallCanvas->getMouseTracker()->mouseInView()) {
+    }
+    else if (waterfallCanvas->getMouseTracker()->mouseInView()) {
         waterfallCanvas->OnKeyUp(event);
     }
-    
+    else if (spectrumCanvas->getMouseTracker()->mouseInView()) {
+        spectrumCanvas->OnKeyUp(event);
+    }
+    else if (scopeCanvas->getMouseTracker()->mouseInView()) {
+        scopeCanvas->OnKeyUp(event);
+    }
     
     // TODO: Catch key-ups outside of original target
 

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -929,6 +929,72 @@ void AppFrame::disableRig() {
 }
 #endif
 
+bool AppFrame::actionOnMenuDisplay(wxCommandEvent& event) {
+
+    //by default, is managed.
+    bool bManaged = true;
+
+    if (event.GetId() == wxID_THEME_DEFAULT) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_DEFAULT);
+    }
+    else if (event.GetId() == wxID_THEME_SHARP) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_SHARP);
+    }
+    else if (event.GetId() == wxID_THEME_BW) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_BW);
+    }
+    else if (event.GetId() == wxID_THEME_RAD) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_RAD);
+    }
+    else if (event.GetId() == wxID_THEME_TOUCH) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_TOUCH);
+    }
+    else if (event.GetId() == wxID_THEME_HD) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_HD);
+    }
+    else if (event.GetId() == wxID_THEME_RADAR) {
+        ThemeMgr::mgr.setTheme(COLOR_THEME_RADAR);
+    }
+    //Display : font sizes
+    else if (event.GetId() == wxID_DISPLAY_BASE) {
+        GLFont::setScale(GLFont::GLFONT_SCALE_NORMAL);
+    }
+    else if (event.GetId() == wxID_DISPLAY_BASE + 1) {
+        GLFont::setScale(GLFont::GLFONT_SCALE_MEDIUM);
+    }
+    else if (event.GetId() == wxID_DISPLAY_BASE + 2) {
+        GLFont::setScale(GLFont::GLFONT_SCALE_LARGE);
+    }
+    else if (event.GetId() == wxID_DISPLAY_BOOKMARKS) {
+        if (hideBookmarksItem->IsChecked()) {
+            bookmarkSplitter->Unsplit(bookmarkView);
+            bookmarkSplitter->Layout();
+        }
+        else {
+            bookmarkSplitter->SplitVertically(bookmarkView, mainVisSplitter, wxGetApp().getConfig()->getBookmarkSplit());
+            bookmarkSplitter->Layout();
+        }
+    }
+    else {
+        bManaged = false;
+    }
+
+    //update theme choice in children elements:  
+    if (event.GetId() >= wxID_THEME_DEFAULT && event.GetId() <= wxID_THEME_RADAR) {
+       
+        gainCanvas->setThemeColors();
+        modemProps->updateTheme();
+        bookmarkView->updateTheme();
+    }
+
+    //force all windows refresh
+    if (bManaged) {
+        Refresh();
+    }
+
+    return bManaged;
+}
+
 void AppFrame::OnMenu(wxCommandEvent& event) {
 
 //    if (event.GetId() >= wxID_RT_AUDIO_DEVICE && event.GetId() < wxID_RT_AUDIO_DEVICE + (int)devices.size()) {
@@ -1057,56 +1123,23 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
         waterfallSpeedMeter->setLevel(sqrt(DEFAULT_WATERFALL_LPS));
         wxGetApp().getSpectrumProcessor()->setFFTAverageRate(0.65f);
         spectrumAvgMeter->setLevel(0.65f);
-        demodModeSelector->Refresh();
-        demodTuner->Refresh();
+ 
         SetTitle(CUBICSDR_TITLE);
         currentSessionFile = "";
         bookmarkSplitter->Unsplit(bookmarkView);
         bookmarkSplitter->SplitVertically( bookmarkView, mainVisSplitter, wxGetApp().getConfig()->getBookmarkSplit() );
         hideBookmarksItem->Check(false);
+        //force all windows refresh
+        Refresh();
+
     } else if (event.GetId() == wxID_CLOSE || event.GetId() == wxID_EXIT) {
         Close(false);
-    } else if (event.GetId() == wxID_THEME_DEFAULT) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_DEFAULT);
-    } else if (event.GetId() == wxID_THEME_SHARP) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_SHARP);
-    } else if (event.GetId() == wxID_THEME_BW) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_BW);
-    } else if (event.GetId() == wxID_THEME_RAD) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_RAD);
-    } else if (event.GetId() == wxID_THEME_TOUCH) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_TOUCH);
-    } else if (event.GetId() == wxID_THEME_HD) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_HD);
-    } else if (event.GetId() == wxID_THEME_RADAR) {
-        ThemeMgr::mgr.setTheme(COLOR_THEME_RADAR);
     }
-    //Display : font sizes
-    else if (event.GetId() == wxID_DISPLAY_BASE) {
-        GLFont::setScale(GLFont::GLFONT_SCALE_NORMAL);
-        //force all windows refresh
-        Refresh();
+    else if (actionOnMenuDisplay(event)) {
+        //done in actionOnMenuDisplay
+        return;
     }
-    else if (event.GetId() == wxID_DISPLAY_BASE + 1) {
-        GLFont::setScale(GLFont::GLFONT_SCALE_MEDIUM);
-        //force all windows refresh
-        Refresh();
-    }
-    else if (event.GetId() == wxID_DISPLAY_BASE + 2) {
-        GLFont::setScale(GLFont::GLFONT_SCALE_LARGE);
-        //force all windows refresh
-        Refresh();
-    } else if (event.GetId() == wxID_DISPLAY_BOOKMARKS) {
-        if (hideBookmarksItem->IsChecked()) {
-            bookmarkSplitter->Unsplit(bookmarkView);
-            bookmarkSplitter->Layout();
-        } else {
-            bookmarkSplitter->SplitVertically( bookmarkView, mainVisSplitter, wxGetApp().getConfig()->getBookmarkSplit() );
-            bookmarkSplitter->Layout();
-        }
-    }
-
-    if (event.GetId() >= wxID_SETTINGS_BASE && event.GetId() < settingsIdMax) {
+    else if (event.GetId() >= wxID_SETTINGS_BASE && event.GetId() < settingsIdMax) {
         int setIdx = event.GetId()-wxID_SETTINGS_BASE;
         int menuIdx = 0;
         for (std::vector<SoapySDR::ArgInfo>::iterator arg_i = settingArgs.begin(); arg_i != settingArgs.end(); arg_i++) {
@@ -1157,15 +1190,7 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
         }
     }
     
-    if (event.GetId() >= wxID_THEME_DEFAULT && event.GetId() <= wxID_THEME_RADAR) {
-    	demodTuner->Refresh();
-    	demodModeSelector->Refresh();
-        waterfallSpeedMeter->Refresh();
-        spectrumAvgMeter->Refresh();
-        gainCanvas->setThemeColors();
-        modemProps->updateTheme();
-        bookmarkView->updateTheme();
-    }
+   
 
     if (event.GetId() == wxID_BANDWIDTH_MANUAL) {
         wxGetApp().setSampleRate(manualSampleRate);

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -138,6 +138,10 @@ private:
     void OnDoubleClickSash(wxSplitterEvent& event);
     void OnUnSplit(wxSplitterEvent& event);
    
+    //manage Display menu actions, return true if the event has been
+    //treated.
+    bool actionOnMenuDisplay(wxCommandEvent& event);
+
     ScopeCanvas *scopeCanvas;
     SpectrumCanvas *spectrumCanvas;
     WaterfallCanvas *waterfallCanvas;

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -33,7 +33,6 @@ BookmarkViewVisualDragItem::BookmarkViewVisualDragItem(wxString labelValue) : wx
     sizer->Add(label, 1, wxALL | wxEXPAND, 5);
     
     SetSizerAndFit(sizer);
-    
     Show();
 }
 
@@ -192,9 +191,10 @@ void BookmarkView::updateTheme() {
     m_treeView->SetForegroundColour(textColor);
     
     m_propPanel->SetBackgroundColour(bgColor);
-    m_buttonPanel->SetBackgroundColour(bgColor);
-
     m_propPanel->SetForegroundColour(textColor);
+
+    m_buttonPanel->SetBackgroundColour(bgColor);
+    m_buttonPanel->SetForegroundColour(textColor);
     
     m_labelLabel->SetForegroundColour(textColor);
     m_frequencyVal->SetForegroundColour(textColor);
@@ -203,6 +203,7 @@ void BookmarkView::updateTheme() {
     m_bandwidthLabel->SetForegroundColour(textColor);
     m_modulationVal->SetForegroundColour(textColor);
     m_modulationLabel->SetForegroundColour(textColor);
+    
 
     refreshLayout();
 }
@@ -701,7 +702,12 @@ void BookmarkView::refreshLayout() {
 wxButton *BookmarkView::makeButton(wxWindow *parent, std::string labelVal, wxObjectEventFunction handler) {
     wxButton *nButton = new wxButton( m_buttonPanel, wxID_ANY, labelVal);
     nButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, handler, nullptr, this);
-    nButton->SetBackgroundColour(ThemeMgr::mgr.currentTheme->generalBackground);
+    
+    wxColour bgColor(ThemeMgr::mgr.currentTheme->generalBackground);
+    wxColour textColor(ThemeMgr::mgr.currentTheme->text);
+
+    nButton->SetBackgroundColour(bgColor);
+    nButton->SetForegroundColour(textColor);
     return nButton;
 }
 

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -8,6 +8,10 @@
 
 #include "CubicSDR.h"
 
+#ifdef __linux__
+#include "CubicSDR.xpm"
+#endif
+
 SDRDevicesDialog::SDRDevicesDialog( wxWindow* parent ): devFrame( parent, wxID_ANY, wxT(CUBICSDR_INSTALL_NAME " :: SDR Devices")) {
     refresh = true;
     failed = false;
@@ -20,6 +24,13 @@ SDRDevicesDialog::SDRDevicesDialog( wxWindow* parent ): devFrame( parent, wxID_A
     removeId = nullptr;
     devAddDialog = nullptr;
     dev = nullptr;
+
+#ifdef __linux__
+    SetIcon(wxICON(cubicsdr));
+#elif _WIN32
+    SetIcon(wxICON(frame_icon));
+#endif
+
 }
 
 void SDRDevicesDialog::OnClose( wxCloseEvent& /* event */) {

--- a/src/panel/SpectrumPanel.cpp
+++ b/src/panel/SpectrumPanel.cpp
@@ -13,8 +13,8 @@
 SpectrumPanel::SpectrumPanel() {
     floorValue = 0;
     ceilValue = 1;
-    showDb = false;
-    useDbOfs = false;
+    showDb = true;
+    useDbOfs = true;
     fftSize = DEFAULT_FFT_SIZE;
     bandwidth = DEFAULT_DEMOD_BW;
     freq = 0;

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -45,7 +45,10 @@ ScopeCanvas::ScopeCanvas(wxWindow *parent, int *dispAttrs) : InteractiveCanvas(p
     parentPanel.setFill(GLPanel::GLPANEL_FILL_NONE);
     scopePanel.setSize(1.0,-1.0);
     spectrumPanel.setSize(1.0,-1.0);
-    spectrumPanel.setShowDb(true);
+    showDb = true;
+    spectrumPanel.setShowDb(showDb);
+    //dB offset is a RF value, has no meaning in audio, disable it.
+    spectrumPanel.setUseDBOffset(false);
 }
 
 ScopeCanvas::~ScopeCanvas() {
@@ -89,8 +92,8 @@ bool ScopeCanvas::getPPMMode() {
     return ppmMode;
 }
 
-void ScopeCanvas::setShowDb(bool showDb) {
-    this->showDb = showDb;
+void ScopeCanvas::setShowDb(bool show) {
+    this->showDb = show;
 }
 
 bool ScopeCanvas::getShowDb() {
@@ -273,5 +276,22 @@ void ScopeCanvas::OnMouseLeftWindow(wxMouseEvent& event) {
 
 void ScopeCanvas::setHelpTip(std::string tip) {
     helpTip = tip;
+}
+
+void ScopeCanvas::OnKeyDown(wxKeyEvent& event) {
+    InteractiveCanvas::OnKeyDown(event);
+
+    switch (event.GetKeyCode()) {
+
+    case 'B':
+        setShowDb(!getShowDb());
+        break;
+    default:
+        event.Skip();
+    }
+}
+
+void ScopeCanvas::OnKeyUp(wxKeyEvent& event) {
+    InteractiveCanvas::OnKeyUp(event);
 }
 

--- a/src/visual/ScopeCanvas.h
+++ b/src/visual/ScopeCanvas.h
@@ -20,6 +20,16 @@ public:
     ScopeCanvas(wxWindow *parent, int *dispAttrs);
     ~ScopeCanvas();
 
+    //This is public because it is indeed forwarded from
+    //AppFrame::OnGlobalKeyDown, because global key handler intercepts 
+    //calls in all windows.
+    void OnKeyDown(wxKeyEvent& event);
+
+    //This is public because it is indeed forwarded from
+    //AppFrame::OnGlobalKeyUp, because global key handler intercepts 
+    //calls in all windows.
+    void OnKeyUp(wxKeyEvent& event);
+
     void setDeviceName(std::string device_name);
     void setPPMMode(bool ppmMode);
     bool getPPMMode();

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -310,3 +310,20 @@ void SpectrumCanvas::OnMouseRightReleased(wxMouseEvent& event) {
     }
     mouseTracker.OnMouseRightReleased(event);
 }
+
+void SpectrumCanvas::OnKeyDown(wxKeyEvent& event) {
+    InteractiveCanvas::OnKeyDown(event);
+
+    switch (event.GetKeyCode()) {
+  
+    case 'B':
+       setShowDb(!getShowDb());
+       break;
+    default:
+        event.Skip();
+    }
+}
+
+void SpectrumCanvas::OnKeyUp(wxKeyEvent& event) {
+    InteractiveCanvas::OnKeyUp(event);
+}

--- a/src/visual/SpectrumCanvas.h
+++ b/src/visual/SpectrumCanvas.h
@@ -19,6 +19,16 @@ public:
     SpectrumCanvas(wxWindow *parent, int *dispAttrs);
     ~SpectrumCanvas();
 
+    //This is public because it is indeed forwarded from
+    //AppFrame::OnGlobalKeyDown, because global key handler intercepts 
+    //calls in all windows.
+    void OnKeyDown(wxKeyEvent& event);
+
+    //This is public because it is indeed forwarded from
+    //AppFrame::OnGlobalKeyUp, because global key handler intercepts 
+    //calls in all windows.
+    void OnKeyUp(wxKeyEvent& event);
+
     void attachWaterfallCanvas(WaterfallCanvas *canvas_in);
     void moveCenterFrequency(long long freqChange);
 
@@ -50,6 +60,7 @@ private:
     void OnMouseRightDown(wxMouseEvent& event);
     void OnMouseRightReleased(wxMouseEvent& event);
 
+   
     void updateScaleFactor(float factor);
     
     PrimaryGLContext *glContext;

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -440,11 +440,6 @@ void WaterfallCanvas::OnKeyDown(wxKeyEvent& event) {
         wxGetApp().removeDemodulator(activeDemod);
         wxGetApp().getDemodMgr().deleteThread(activeDemod);
         break;
-    case 'B':
-        if (spectrumCanvas) {
-            spectrumCanvas->setShowDb(!spectrumCanvas->getShowDb());
-        }
-        break;
     case WXK_SPACE:
         wxGetApp().showFrequencyInput();
         break;

--- a/src/visual/WaterfallCanvas.h
+++ b/src/visual/WaterfallCanvas.h
@@ -36,9 +36,20 @@ public:
     void setLinesPerSecond(int lps);
     void setMinBandwidth(int min);
 
+    //This is public because it is indeed forwarded from
+    //AppFrame::OnGlobalKeyDown, because global key handler intercepts 
+    //calls in all windows.
     void OnKeyDown(wxKeyEvent& event);
+
+    //This is public because it is indeed forwarded from
+    //AppFrame::OnGlobalKeyUp, because global key handler intercepts 
+    //calls in all windows.
     void OnKeyUp(wxKeyEvent& event);
+
+    //public because called by SpectrumCanvas.
     void OnMouseWheelMoved(wxMouseEvent& event);
+    
+    
     
 private:
     void OnPaint(wxPaintEvent& event);


### PR DESCRIPTION
@cjcliffe Hello again, here is another batch of UI fixes:

-  First the real problem: text of bookmark buttons is black, on a very dark background, so almost invisible. Turns out the color theme was not applied to such buttons, which also leads to...
-  Fixing complete color theme setup: lack of (instant) repaint of Digital lab modem buttons, no (instant) repaint of modem properties dialog.  Every control is now correctly repaint immediatly with the new theme colors.
-  As cleanup, isolate the Display menu related code in its own function, because ``AppFrame::OnMenu()`` is large enough by now.

One limitiation of theme color application I won't try to overcome: ``wxButton`` colors can't be changed after construction (at least on Windows). 
So if the color theme is changed, the button colors remain the same no matter what. Fortunately since selecting another bookmark tree element destroys and re-creates the buttons, a color refresh occurs then.  

- 'B' (dB display toggle) is supposed to activate on Spectrum mouse hover, not Waterfall. Wonders for quite some time how the machinery worked, discovers what ``MouseTracker`` was  about :+1:  
So, I plugged the redispatch of events correctly to ``SpectrumCanvas`` and ``ScopeCanvas``, which were missing, then moved the code for 'B' key from ``WaterfallCanvas`` to ``SpectrumCanvas`` where it belongs.
-  Make the Audio spectrum have its own, independent 'B' handling to disable its dB display independently from the Spectrum one.
-  Give the SDR Devices dialog a proper icon as the main application has. 

That's is all for now, i wish you a nice week-end !
