### PR TITLE
CLEANUP: some compiler and static analysis warnings

### DIFF
--- a/src/AppConfig.cpp
+++ b/src/AppConfig.cpp
@@ -84,7 +84,7 @@ void DeviceConfig::save(DataNode *node) {
     std::lock_guard < std::mutex > lock(busy_lock);
     *node->newChild("id") = deviceId;
     *node->newChild("name") = deviceName;
-    *node->newChild("ppm") = (int)ppm.load();
+    *node->newChild("ppm") = ppm.load();
     *node->newChild("offset") = offset.load();
     *node->newChild("sample_rate") = sampleRate.load();
     *node->newChild("agc_mode") = agcMode.load()?1:0;
@@ -611,12 +611,13 @@ bool AppConfig::load() {
     }
 
     if (cfg.rootNode()->hasAnother("window")) {
-        int x,y,w,h;
-        int max,tips,lpm,mpc;
+        int x = 0 ,y = 0 ,w = 0 ,h = 0;
+        int max = 0 ,tips = 0 ,lpm = 0 ,mpc = 0;
         
         DataNode *win_node = cfg.rootNode()->getNext("window");
         
         if (win_node->hasAnother("w") && win_node->hasAnother("h") && win_node->hasAnother("x") && win_node->hasAnother("y")) {
+
             win_node->getNext("x")->element()->get(x);
             win_node->getNext("y")->element()->get(y);
             win_node->getNext("w")->element()->get(w);

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -66,7 +66,7 @@ AppFrame::AppFrame() :
     wxBoxSizer *demodScopeTray = new wxBoxSizer(wxVERTICAL);
     wxBoxSizer *demodTunerTray = new wxBoxSizer(wxHORIZONTAL);
 
-    int attribList[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, 0 };
+    std::vector<int> attribList = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, 0 };
     //wxGLAttributes attribList;
     //attribList.PlatformDefaults().RGBA().DoubleBuffer().EndList();
     //attribList.PlatformDefaults().MinRGBA(8, 8, 8, 8).DoubleBuffer().Depth(16).EndList();
@@ -104,9 +104,8 @@ AppFrame::AppFrame() :
     gainSpacerItem = demodTray->AddSpacer(1);
     gainSpacerItem->Show(false);
             
-    std::string modemListArr[] = { "FM", "FMS", "NBFM", "AM", "LSB", "USB", "DSB", "I/Q" };
-    std::vector<std::string> modemList( modemListArr, modemListArr + 8 );
-
+    std::vector<std::string> modemList = { "FM", "FMS", "NBFM", "AM", "LSB", "USB", "DSB", "I/Q" };
+  
 #ifdef CUBICSDR_MODEM_EXCLUDE
     std::string excludeListStr = "" CUBICSDR_MODEM_EXCLUDE;
     std::vector<std::string> excludeList = str_explode(",",excludeListStr);
@@ -1197,7 +1196,7 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
     }
     else if (event.GetId() == wxID_BANDWIDTH_MANUAL_DIALOG) {
 
-        int rateHigh, rateLow;
+        int rateHigh = 0, rateLow = 0;
 
         SDRDeviceInfo *dev = wxGetApp().getDevice();
         if (dev != nullptr) {

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -175,12 +175,12 @@ private:
     std::map<int, wxMenuItem *> directSamplingMenuItems;
     wxMenuBar *menuBar;
     
-    wxMenu *sampleRateMenu;
-    wxMenu *displayMenu;
-    wxMenuItem *agcMenuItem;
-    wxMenuItem *iqSwapMenuItem;
-    wxMenuItem *lowPerfMenuItem;
-    wxMenu *settingsMenu;
+    wxMenu *sampleRateMenu = nullptr;
+    wxMenu *displayMenu = nullptr;
+    wxMenuItem *agcMenuItem = nullptr;
+    wxMenuItem *iqSwapMenuItem = nullptr;
+    wxMenuItem *lowPerfMenuItem = nullptr;
+    wxMenu *settingsMenu = nullptr;
     
     SoapySDR::ArgInfoList settingArgs;
     int settingsIdMax;

--- a/src/modules/modem/ModemAnalog.cpp
+++ b/src/modules/modem/ModemAnalog.cpp
@@ -15,7 +15,7 @@ int ModemAnalog::checkSampleRate(long long sampleRate, int /* audioSampleRate */
     if (sampleRate < MIN_BANDWIDTH) {
         return MIN_BANDWIDTH;
     }
-    return sampleRate;
+    return (int)sampleRate;
 }
 
 ModemKit *ModemAnalog::buildKit(long long sampleRate, int audioSampleRate) {
@@ -27,7 +27,7 @@ ModemKit *ModemAnalog::buildKit(long long sampleRate, int audioSampleRate) {
     akit->sampleRate = sampleRate;
     akit->audioSampleRate = audioSampleRate;
     akit->audioResampleRatio = double(audioSampleRate) / double(sampleRate);
-    akit->audioResampler = msresamp_rrrf_create(akit->audioResampleRatio, As);
+    akit->audioResampler = msresamp_rrrf_create((float)akit->audioResampleRatio, As);
     
     return akit;
 }
@@ -85,7 +85,7 @@ void ModemAnalog::buildAudioOutput(ModemKitAnalog *akit, AudioThreadInput *audio
         }
     }
     
-    msresamp_rrrf_execute(akit->audioResampler, &demodOutputData[0], demodOutputData.size(), &resampledOutputData[0], &numAudioWritten);
+    msresamp_rrrf_execute(akit->audioResampler, &demodOutputData[0], (int)demodOutputData.size(), &resampledOutputData[0], &numAudioWritten);
     
     audioOut->channels = 1;
     audioOut->sampleRate = akit->audioSampleRate;

--- a/src/modules/modem/ModemDigital.cpp
+++ b/src/modules/modem/ModemDigital.cpp
@@ -26,7 +26,7 @@ int ModemDigital::checkSampleRate(long long sampleRate, int /* audioSampleRate *
     if (sampleRate < MIN_BANDWIDTH) {
         return MIN_BANDWIDTH;
     }
-    return sampleRate;
+    return (int)sampleRate;
 }
 
 ModemKit *ModemDigital::buildKit(long long sampleRate, int audioSampleRate) {

--- a/src/modules/modem/analog/ModemFM.cpp
+++ b/src/modules/modem/analog/ModemFM.cpp
@@ -33,7 +33,7 @@ void ModemFM::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *au
         return;
     }
     
-    freqdem_demodulate_block(demodFM, &input->data[0], bufSize, &demodOutputData[0]);
+    freqdem_demodulate_block(demodFM, &input->data[0], (int)bufSize, &demodOutputData[0]);
 
     buildAudioOutput(fmkit, audioOut, false);
 }

--- a/src/modules/modem/analog/ModemLSB.cpp
+++ b/src/modules/modem/analog/ModemLSB.cpp
@@ -12,7 +12,7 @@ ModemLSB::ModemLSB() : ModemAnalog() {
     ssbFilt = iirfilt_crcf_create_lowpass(6, 0.25);
 #endif
 	ssbShift = nco_crcf_create(LIQUID_NCO);
-    nco_crcf_set_frequency(ssbShift,  (2.0 * M_PI) * 0.25);
+    nco_crcf_set_frequency(ssbShift,  (float)((2.0 * M_PI) * 0.25));
     c2rFilt = firhilbf_create(5, 90.0);
     useSignalOutput(true);
 }
@@ -41,9 +41,9 @@ int ModemLSB::checkSampleRate(long long sampleRate, int /* audioSampleRate */) {
         return MIN_BANDWIDTH;
     }
     if (sampleRate % 2 == 0) {
-        return sampleRate;
+        return (int)sampleRate;
     }
-    return sampleRate+1;
+    return (int)(sampleRate+1);
 }
 
 int ModemLSB::getDefaultSampleRate() {

--- a/src/modules/modem/analog/ModemNBFM.cpp
+++ b/src/modules/modem/analog/ModemNBFM.cpp
@@ -33,7 +33,7 @@ void ModemNBFM::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *
         return;
     }
     
-    freqdem_demodulate_block(demodFM, &input->data[0], bufSize, &demodOutputData[0]);
+    freqdem_demodulate_block(demodFM, &input->data[0], (unsigned int)bufSize, &demodOutputData[0]);
 
     buildAudioOutput(fmkit, audioOut, false);
 }

--- a/src/modules/modem/analog/ModemUSB.cpp
+++ b/src/modules/modem/analog/ModemUSB.cpp
@@ -12,7 +12,7 @@ ModemUSB::ModemUSB() : ModemAnalog() {
 	ssbFilt = iirfilt_crcf_create_lowpass(6, 0.25);
 #endif
 	ssbShift = nco_crcf_create(LIQUID_NCO);
-    nco_crcf_set_frequency(ssbShift,  (2.0f * M_PI) * 0.25f);
+    nco_crcf_set_frequency(ssbShift,  (float)((2.0 * M_PI) * 0.25));
     c2rFilt = firhilbf_create(5, 90.0);
     useSignalOutput(true);
 }
@@ -41,9 +41,9 @@ int ModemUSB::checkSampleRate(long long sampleRate, int /* audioSampleRate */) {
         return MIN_BANDWIDTH;
     }
     if (sampleRate % 2 == 0) {
-        return sampleRate;
+        return (int)sampleRate;
     }
-    return sampleRate+1;
+    return (int)(sampleRate+1);
 }
 
 int ModemUSB::getDefaultSampleRate() {

--- a/src/modules/modem/digital/ModemFSK.cpp
+++ b/src/modules/modem/digital/ModemFSK.cpp
@@ -8,7 +8,7 @@ ModemFSK::ModemFSK() : ModemDigital()  {
     // DMR defaults?
     bps = 1;
     sps = 9600;
-    bw = 0.45;
+    bw = 0.45f;
     outStream << std::hex;
 }
 
@@ -17,12 +17,12 @@ ModemBase *ModemFSK::factory() {
 }
 
 int ModemFSK::checkSampleRate(long long sampleRate, int audioSampleRate) {
-    float minSps = pow(2.0,bps);
-    float nextSps = (float(sampleRate) / float(sps));
+    double minSps = pow(2.0,bps);
+    double nextSps = (double(sampleRate) / double(sps));
     if (nextSps < minSps) {
         return 2 * bps * sps;
     } else {
-        return sampleRate;
+        return (int)sampleRate;
     }
 }
 
@@ -101,7 +101,7 @@ std::string ModemFSK::readSetting(std::string setting) {
 ModemKit *ModemFSK::buildKit(long long sampleRate, int audioSampleRate) {
     ModemKitFSK *dkit = new ModemKitFSK;
     dkit->m           = bps;
-    dkit->k           = sampleRate / sps;
+    dkit->k           = (unsigned int)(sampleRate / sps);
     dkit->bw          = bw;
 
     dkit->demodFSK = fskdem_create(dkit->m, dkit->k, dkit->bw);

--- a/src/modules/modem/digital/ModemGMSK.cpp
+++ b/src/modules/modem/digital/ModemGMSK.cpp
@@ -7,7 +7,7 @@
 ModemGMSK::ModemGMSK() : ModemDigital()  {
     _sps = 4;
     _fdelay = 3;
-    _ebf = 0.3;
+    _ebf = 0.3f;
     outStream << std::hex;
 }
 
@@ -27,7 +27,7 @@ int ModemGMSK::checkSampleRate(long long sampleRate, int audioSampleRate) {
     if (sampleRate < MIN_BANDWIDTH) {
         return MIN_BANDWIDTH;
     }
-    return sampleRate;
+    return (int)sampleRate;
 }
 
 int ModemGMSK::getDefaultSampleRate() {

--- a/src/modules/modem/digital/ModemOOK.cpp
+++ b/src/modules/modem/digital/ModemOOK.cpp
@@ -23,7 +23,7 @@ int ModemOOK::checkSampleRate(long long sampleRate, int audioSampleRate) {
     if (sampleRate < 100) {
         return 100;
     }
-    return sampleRate;
+    return (int)sampleRate;
 }
 
 void ModemOOK::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *audioOut) {

--- a/src/panel/MeterPanel.cpp
+++ b/src/panel/MeterPanel.cpp
@@ -42,14 +42,14 @@ MeterPanel::MeterPanel(std::string name, float low, float high, float current) {
     
     addChild(&bgPanel);
     
-    labelPanel.setSize(1.0, 0.1);
+    labelPanel.setSize(1.0f, 0.1f);
     labelPanel.setPosition(0.0, 1.0);
     labelPanel.setText(name,GLFont::GLFONT_ALIGN_CENTER, GLFont::GLFONT_ALIGN_CENTER, true);
     labelPanel.setFill(GLPanel::GLPANEL_FILL_NONE);
     
     addChild(&labelPanel);
     
-    valuePanel.setSize(1.0, 0.1);
+    valuePanel.setSize(1.0f, 0.1f);
     valuePanel.setPosition(0.0, -1.0);
     
     setValueLabel(std::to_string(int(current)));

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -4,7 +4,7 @@
 #include "FFTDataDistributor.h"
 
 FFTDataDistributor::FFTDataDistributor() : outputBuffers("FFTDataDistributorBuffers"), fftSize(DEFAULT_FFT_SIZE), linesPerSecond(DEFAULT_WATERFALL_LPS), lineRateAccum(0.0) {
-    bufferedItems = 0;
+
 }
 
 void FFTDataDistributor::setFFTSize(unsigned int fftSize) {
@@ -60,14 +60,14 @@ void FFTDataDistributor::process() {
 		double lineRateStep = ((double)linesPerSecond * inputTime)/(double)inputLines;
 
 		if (bufferedItems >= fftSize) {
-			int numProcessed = 0;
+			size_t numProcessed = 0;
 
 			if (lineRateAccum + (lineRateStep * ((double)bufferedItems/(double)fftSize)) < 1.0) {
 				// move along, nothing to see here..
 				lineRateAccum += (lineRateStep * ((double)bufferedItems/(double)fftSize));
 				numProcessed = bufferedItems;
 			} else {
-				for (unsigned int i = 0, iMax = bufferedItems; i < iMax; i += fftSize) {
+				for (size_t i = 0, iMax = bufferedItems; i < iMax; i += fftSize) {
 					if ((i + fftSize) > iMax) {
 						break;
 					}

--- a/src/process/FFTDataDistributor.h
+++ b/src/process/FFTDataDistributor.h
@@ -23,5 +23,7 @@ protected:
     unsigned int fftSize;
     unsigned int linesPerSecond;
     double lineRateAccum;
-    size_t bufferMax, bufferOffset, bufferedItems;
+    size_t bufferMax = 0;
+    size_t bufferOffset = 0;
+    size_t bufferedItems = 0;
 };

--- a/src/process/ScopeVisualProcessor.h
+++ b/src/process/ScopeVisualProcessor.h
@@ -10,7 +10,7 @@
 class ScopeRenderData: public ReferenceCounter {
 public:
 	std::vector<float> waveform_points;
-    ScopePanel::ScopeMode mode;
+    ScopePanel::ScopeMode mode = ScopePanel::SCOPE_MODE_Y;
     int inputRate;
     int sampleRate;
 	int channels;
@@ -39,7 +39,7 @@ protected:
     std::vector<liquid_float_complex> fftOutput;
     fftplan fftPlan;
     
-    unsigned int fftSize;
+    unsigned int fftSize = 0;
     int desiredInputSize;
     unsigned int maxScopeSamples;
     

--- a/src/process/SpectrumVisualProcessor.cpp
+++ b/src/process/SpectrumVisualProcessor.cpp
@@ -29,6 +29,7 @@ SpectrumVisualProcessor::SpectrumVisualProcessor() : outputBuffers("SpectrumVisu
     
     fft_ceil_ma = fft_ceil_maa = 100.0;
     fft_floor_ma = fft_floor_maa = 0.0;
+    fft_floor_peak = 0.0;
     desiredInputSize.store(0);
     fft_average_rate = 0.65f;
     scaleFactor.store(1.0);

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -87,7 +87,7 @@ protected:
         // distribute outputs
         std::lock_guard < std::recursive_mutex > busy_lock(busy_update);
 
-        output->setRefCount(outputs.size());
+        output->setRefCount((int)outputs.size());
         for (outputs_i = outputs.begin(); outputs_i != outputs.end(); outputs_i++) {
 
         	if (!(*outputs_i)->push(output)) {
@@ -96,7 +96,7 @@ protected:
         }
     }
 
-    ThreadQueue<InputDataType *> *input;
+    ThreadQueue<InputDataType *> *input = nullptr;
     std::vector<ThreadQueue<OutputDataType *> *> outputs;
 	typename std::vector<ThreadQueue<OutputDataType *> *>::iterator outputs_i;
 

--- a/src/sdr/SDRDeviceInfo.h
+++ b/src/sdr/SDRDeviceInfo.h
@@ -89,7 +89,7 @@ public:
     SDRRangeMap getGains(int direction, size_t channel);
 
 private:
-    int index;
+    int index = 0;
     std::string name, serial, product, manufacturer, tuner;
     std::string driver, hardware, manual_params;
     bool timestamps, available, remote, manual;

--- a/src/sdr/SDRPostThread.h
+++ b/src/sdr/SDRPostThread.h
@@ -45,7 +45,7 @@ private:
     std::vector<liquid_float_complex> fpData;
     std::vector<liquid_float_complex> dataOut;
     std::vector<long long> chanCenters;
-    long long chanBw;
+    long long chanBw = 0;
     
     size_t nRunDemods;
     std::vector<DemodulatorInstance *> runDemods;

--- a/src/ui/GLPanel.h
+++ b/src/ui/GLPanel.h
@@ -38,10 +38,10 @@ private:
 public:
     typedef enum GLPanelFillType { GLPANEL_FILL_NONE, GLPANEL_FILL_SOLID, GLPANEL_FILL_GRAD_X, GLPANEL_FILL_GRAD_Y, GLPANEL_FILL_GRAD_BAR_X, GLPANEL_FILL_GRAD_BAR_Y } GLPanelFillType;
     typedef enum GLPanelCoordinateSystem { GLPANEL_Y_DOWN_ZERO_ONE, GLPANEL_Y_UP_ZERO_ONE, GLPANEL_Y_UP, GLPANEL_Y_DOWN } GLPanelCoordinateSystem;
-    float pos[2];
-    float rot[3];
-    float size[2];
-    float view[2];
+    float pos[2] = {0.0f,0.0f};
+    float rot[3] = { 0.0f,0.0f,0.0f };
+    float size[2] = { 0.0f,0.0f };
+    float view[2] = { 0.0f,0.0f };
     GLPanelFillType fillType;
     GLPanelCoordinateSystem coord;
     float marginPx;

--- a/src/ui/UITestCanvas.cpp
+++ b/src/ui/UITestCanvas.cpp
@@ -27,7 +27,7 @@ EVT_LEAVE_WINDOW(UITestCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(UITestCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-UITestCanvas::UITestCanvas(wxWindow *parent, int *dispAttrs) :
+UITestCanvas::UITestCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
 InteractiveCanvas(parent, dispAttrs) {
     
     glContext = new UITestContext(this, &wxGetApp().GetContext(this));

--- a/src/ui/UITestCanvas.h
+++ b/src/ui/UITestCanvas.h
@@ -17,7 +17,7 @@
 
 class UITestCanvas: public InteractiveCanvas {
 public:
-    UITestCanvas(wxWindow *parent, int *dispAttrs);
+    UITestCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~UITestCanvas();
     
 private:

--- a/src/ui/UITestContext.cpp
+++ b/src/ui/UITestContext.cpp
@@ -45,7 +45,7 @@ PrimaryGLContext(canvas, sharedContext), testMeter("TEST",0,100,50) {
 //    testPanel.addChild(&testChildPanel);
 //    testPanel.addChild(&testChildPanel2);
 //    testPanel.addChild(&testChildPanel3);
-    testMeter.setSize(0.1,0.9);
+    testMeter.setSize(0.1f,0.9f);
     testPanel.addChild(&testMeter);
 }
 

--- a/src/util/GLFont.h
+++ b/src/util/GLFont.h
@@ -18,8 +18,8 @@ public:
     GLFontStringCache();
     int drawlen;
     int vpx, vpy;
-    int pxHeight;
-    float msgWidth;
+    int pxHeight = 0;
+    float msgWidth = 0.0f;
     std::atomic_int gc;
     std::vector<float> gl_vertices;
     std::vector<float> gl_uv;

--- a/src/util/Gradient.cpp
+++ b/src/util/Gradient.cpp
@@ -24,19 +24,19 @@ std::vector<float> &Gradient::getBlue() {
 }
 
 void Gradient::generate(unsigned int len) {
-    unsigned int chunk_size = len / (colors.size() - 1);
+    size_t chunk_size = len / (colors.size() - 1);
 
-    unsigned int p = 0;
+    size_t p = 0;
     r_val.resize(len);
     g_val.resize(len);
     b_val.resize(len);
 
-    for (unsigned int j = 0, jMax = colors.size() - 1; j < jMax; j++) {
+    for (size_t j = 0, jMax = colors.size() - 1; j < jMax; j++) {
         if ((chunk_size * (jMax)) < len && (j == jMax - 1)) {
             chunk_size += len - chunk_size * (jMax);
         }
 
-        for (unsigned int i = 0; i < chunk_size; i++) {
+        for (size_t i = 0; i < chunk_size; i++) {
             float idx = (float) (i) / (float) chunk_size;
 
             float r1 = colors[j].r;

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -56,7 +56,7 @@ void Timer::unlock()
 
 	update();
 	
-	last_update = system_milliseconds-lock_rate;
+	last_update = system_milliseconds-(unsigned long)lock_rate;
 	
 	offset += msec_tmp-system_milliseconds;
 	

--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -28,7 +28,7 @@ EVT_ENTER_WINDOW(GainCanvas::OnMouseEnterWindow)
 EVT_MOUSEWHEEL(GainCanvas::OnMouseWheelMoved)
 wxEND_EVENT_TABLE()
 
-GainCanvas::GainCanvas(wxWindow *parent, int *dispAttrs) :
+GainCanvas::GainCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
         InteractiveCanvas(parent, dispAttrs) {
 
     glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this));

--- a/src/visual/GainCanvas.h
+++ b/src/visual/GainCanvas.h
@@ -20,7 +20,7 @@
 
 class GainCanvas: public InteractiveCanvas {
 public:
-    GainCanvas(wxWindow *parent, int *dispAttrs);
+    GainCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~GainCanvas();
 
     void setHelpTip(std::string tip);

--- a/src/visual/InteractiveCanvas.cpp
+++ b/src/visual/InteractiveCanvas.cpp
@@ -20,8 +20,8 @@
 
 #include <wx/numformatter.h>
 
-InteractiveCanvas::InteractiveCanvas(wxWindow *parent, int *dispAttrs) :
-        wxGLCanvas(parent, wxID_ANY, dispAttrs, wxDefaultPosition, wxDefaultSize,
+InteractiveCanvas::InteractiveCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+        wxGLCanvas(parent, wxID_ANY, dispAttrs.data(), wxDefaultPosition, wxDefaultSize,
         wxFULL_REPAINT_ON_RESIZE), parent(parent), shiftDown(false), altDown(false), ctrlDown(false), centerFreq(0), bandwidth(0), lastBandwidth(0), isView(
         false) {
     mouseTracker.setTarget(this);

--- a/src/visual/InteractiveCanvas.h
+++ b/src/visual/InteractiveCanvas.h
@@ -8,10 +8,11 @@
 
 #include "MouseTracker.h"
 #include <string>
+#include <vector>
 
 class InteractiveCanvas: public wxGLCanvas {
 public:
-    InteractiveCanvas(wxWindow *parent, int *dispAttrs);
+    InteractiveCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~InteractiveCanvas();
 
     long long getFrequencyAt(float x);

--- a/src/visual/MeterCanvas.cpp
+++ b/src/visual/MeterCanvas.cpp
@@ -30,7 +30,7 @@ EVT_LEAVE_WINDOW(MeterCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(MeterCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-MeterCanvas::MeterCanvas(wxWindow *parent, int *dispAttrs) :
+MeterCanvas::MeterCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), level(0), level_min(0), level_max(1), inputValue(0), userInputValue(0), showUserInput(true) {
 
     glContext = new MeterContext(this, &wxGetApp().GetContext(this));

--- a/src/visual/MeterCanvas.h
+++ b/src/visual/MeterCanvas.h
@@ -17,7 +17,7 @@
 
 class MeterCanvas: public InteractiveCanvas {
 public:
-    MeterCanvas(wxWindow *parent, int *dispAttrs);
+    MeterCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~MeterCanvas();
 
     void setLevel(float level_in);

--- a/src/visual/ModeSelectorCanvas.cpp
+++ b/src/visual/ModeSelectorCanvas.cpp
@@ -27,7 +27,7 @@ EVT_LEAVE_WINDOW(ModeSelectorCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(ModeSelectorCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-ModeSelectorCanvas::ModeSelectorCanvas(wxWindow *parent, int *dispAttrs) :
+ModeSelectorCanvas::ModeSelectorCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
 InteractiveCanvas(parent, dispAttrs), numChoices(0), currentSelection(-1), toggleMode(false), inputChanged(false), padX(4.0), padY(4.0), highlightOverride(false) {
 
     glContext = new ModeSelectorContext(this, &wxGetApp().GetContext(this));

--- a/src/visual/ModeSelectorCanvas.h
+++ b/src/visual/ModeSelectorCanvas.h
@@ -27,7 +27,7 @@ public:
 
 class ModeSelectorCanvas: public InteractiveCanvas {
 public:
-    ModeSelectorCanvas(wxWindow *parent, int *dispAttrs);
+    ModeSelectorCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~ModeSelectorCanvas();
 
     int getHoveredSelection();

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -31,7 +31,7 @@ EVT_LEAVE_WINDOW(ScopeCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(ScopeCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-ScopeCanvas::ScopeCanvas(wxWindow *parent, int *dispAttrs) : InteractiveCanvas(parent, dispAttrs), ppmMode(false), ctr(0), ctrTarget(0), dragAccel(0), helpTip("") {
+ScopeCanvas::ScopeCanvas(wxWindow *parent, std::vector<int> dispAttrs) : InteractiveCanvas(parent, dispAttrs), ppmMode(false), ctr(0), ctrTarget(0), dragAccel(0), helpTip("") {
 
     glContext = new ScopeContext(this, &wxGetApp().GetContext(this));
     inputData.set_max_num_items(2);

--- a/src/visual/ScopeCanvas.h
+++ b/src/visual/ScopeCanvas.h
@@ -17,7 +17,7 @@
 
 class ScopeCanvas: public InteractiveCanvas {
 public:
-    ScopeCanvas(wxWindow *parent, int *dispAttrs);
+    ScopeCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~ScopeCanvas();
 
     //This is public because it is indeed forwarded from

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -32,7 +32,7 @@ EVT_RIGHT_DOWN(SpectrumCanvas::OnMouseRightDown)
 EVT_RIGHT_UP(SpectrumCanvas::OnMouseRightReleased)
 wxEND_EVENT_TABLE()
 
-SpectrumCanvas::SpectrumCanvas(wxWindow *parent, int *dispAttrs) :
+SpectrumCanvas::SpectrumCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), waterfallCanvas(NULL) {
 
     glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this));

--- a/src/visual/SpectrumCanvas.h
+++ b/src/visual/SpectrumCanvas.h
@@ -16,7 +16,7 @@ class WaterfallCanvas;
 
 class SpectrumCanvas: public InteractiveCanvas {
 public:
-    SpectrumCanvas(wxWindow *parent, int *dispAttrs);
+    SpectrumCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~SpectrumCanvas();
 
     //This is public because it is indeed forwarded from

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -33,7 +33,7 @@ EVT_MOUSEWHEEL(TuningCanvas::OnMouseWheelMoved)
 //EVT_KEY_UP(TuningCanvas::OnKeyUp)
 wxEND_EVENT_TABLE()
 
-TuningCanvas::TuningCanvas(wxWindow *parent, int *dispAttrs) :
+TuningCanvas::TuningCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), dragAccum(0), uxDown(0), top(false), bottom(false), freq(-1), bw(-1), center(-1), halfBand(false) {
 
     glContext = new TuningContext(this, &wxGetApp().GetContext(this));

--- a/src/visual/TuningCanvas.h
+++ b/src/visual/TuningCanvas.h
@@ -20,7 +20,7 @@ public:
     enum ActiveState {
         TUNING_HOVER_NONE, TUNING_HOVER_FREQ, TUNING_HOVER_BW, TUNING_HOVER_PPM, TUNING_HOVER_CENTER
     };
-    TuningCanvas(wxWindow *parent, int *dispAttrs);
+    TuningCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     ~TuningCanvas();
 
     void setHelpTip(std::string tip);

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -37,7 +37,7 @@ EVT_ENTER_WINDOW(WaterfallCanvas::OnMouseEnterWindow)
 EVT_MOUSEWHEEL(WaterfallCanvas::OnMouseWheelMoved)
 wxEND_EVENT_TABLE()
 
-WaterfallCanvas::WaterfallCanvas(wxWindow *parent, int *dispAttrs) :
+WaterfallCanvas::WaterfallCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), dragState(WF_DRAG_NONE), nextDragState(WF_DRAG_NONE), fft_size(0), new_fft_size(0), waterfall_lines(0),
         dragOfs(0), mouseZoom(1), zoom(1), freqMoving(false), freqMove(0.0), hoverAlpha(1.0) {
 

--- a/src/visual/WaterfallCanvas.h
+++ b/src/visual/WaterfallCanvas.h
@@ -21,7 +21,7 @@ public:
         WF_DRAG_NONE, WF_DRAG_BANDWIDTH_LEFT, WF_DRAG_BANDWIDTH_RIGHT, WF_DRAG_FREQUENCY, WF_DRAG_RANGE
     };
 
-    WaterfallCanvas(wxWindow *parent, int *dispAttrs);
+    WaterfallCanvas(wxWindow *parent, std::vector<int> dispAttrs);
     void setup(unsigned int fft_size_in, int waterfall_lines_in);
     void setFFTSize(unsigned int fft_size_in);
     ~WaterfallCanvas();
@@ -69,8 +69,8 @@ private:
     
     std::vector<float> spectrum_points;
 
-    SpectrumCanvas *spectrumCanvas;
-    PrimaryGLContext *glContext;
+    SpectrumCanvas *spectrumCanvas = nullptr;
+    PrimaryGLContext *glContext = nullptr;
     WaterfallPanel waterfallPanel;
 
     DragState dragState;


### PR DESCRIPTION
@cjcliffe This a pass over some compiler warnings: type conversions, uninitialized variables...
No problem was found, but that allows to reduce the compiler warning clutter so that real errors will show up more clearly in the future. 
For type conversions, applying explicit casts make those conversions visible in code which is often a good thing.
Hope I don't break anything, ssince I'll merge that by myself :) 