### PR TITLE
Replace ThreadQueue by a full blocking queue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,7 @@ SET (cubicsdr_headers
     src/util/Gradient.h
     src/util/Timer.h
     src/util/ThreadQueue.h
+	src/util/ThreadBlockingQueue.h
     src/util/MouseTracker.h
     src/util/GLExt.h
     src/util/GLFont.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,7 +441,6 @@ SET (cubicsdr_headers
     src/audio/AudioThread.h
     src/util/Gradient.h
     src/util/Timer.h
-    src/util/ThreadQueue.h
 	src/util/ThreadBlockingQueue.h
     src/util/MouseTracker.h
     src/util/GLExt.h

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -12,7 +12,7 @@
 #include "GLExt.h"
 #include "PrimaryGLContext.h"
 
-#include "ThreadQueue.h"
+#include "ThreadBlockingQueue.h"
 #include "SoapySDRThread.h"
 #include "SDREnumerator.h"
 #include "SDRPostThread.h"

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <thread>
 
-#include "ThreadQueue.h"
+#include "ThreadBlockingQueue.h"
 #include "Timer.h"
 
 struct map_string_less : public std::binary_function<std::string,std::string,bool>

--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -282,6 +282,7 @@ void AudioThread::setDeviceSampleRate(int deviceId, int sampleRate) {
         AudioThreadCommand refreshDevice;
         refreshDevice.cmd = AudioThreadCommand::AUDIO_THREAD_CMD_SET_SAMPLE_RATE;
         refreshDevice.int_value = sampleRate;
+        //VSO : blocking push !
         deviceController[deviceId]->getCommandQueue()->push(refreshDevice);
     }
 }
@@ -479,6 +480,7 @@ void AudioThread::run() {
 void AudioThread::terminate() {
     IOThread::terminate();
     AudioThreadCommand endCond;   // push an empty input to bump the queue
+    //VSO: blocking push
     cmdQueue.push(endCond);
 }
 

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <atomic>
 
-#include "AudioThread.h"
 #include "ThreadBlockingQueue.h"
 #include "RtAudio.h"
 #include "DemodDefs.h"

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -10,7 +10,7 @@
 #include <atomic>
 
 #include "AudioThread.h"
-#include "ThreadQueue.h"
+#include "ThreadBlockingQueue.h"
 #include "RtAudio.h"
 #include "DemodDefs.h"
 
@@ -48,8 +48,8 @@ public:
     int int_value;
 };
 
-typedef ThreadQueue<AudioThreadInput *> AudioThreadInputQueue;
-typedef ThreadQueue<AudioThreadCommand> AudioThreadCommandQueue;
+typedef ThreadBlockingQueue<AudioThreadInput *> AudioThreadInputQueue;
+typedef ThreadBlockingQueue<AudioThreadCommand> AudioThreadCommandQueue;
 
 class AudioThread : public IOThread {
 public:

--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include "ThreadQueue.h"
+#include "ThreadBlockingQueue.h"
 #include "CubicSDRDefs.h"
 #include "liquid/liquid.h"
-
+#include <vector>
 #include <atomic>
 #include <mutex>
 
@@ -100,6 +100,6 @@ public:
     }
 };
 
-typedef ThreadQueue<DemodulatorThreadIQData *> DemodulatorThreadInputQueue;
-typedef ThreadQueue<DemodulatorThreadPostIQData *> DemodulatorThreadPostInputQueue;
-typedef ThreadQueue<DemodulatorThreadControlCommand> DemodulatorThreadControlCommandQueue;
+typedef ThreadBlockingQueue<DemodulatorThreadIQData *> DemodulatorThreadInputQueue;
+typedef ThreadBlockingQueue<DemodulatorThreadPostIQData *> DemodulatorThreadPostInputQueue;
+typedef ThreadBlockingQueue<DemodulatorThreadControlCommand> DemodulatorThreadControlCommandQueue;

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -53,7 +53,9 @@ DemodulatorInstance::DemodulatorInstance() {
     user_label.store(new std::wstring());
 
     pipeIQInputData = new DemodulatorThreadInputQueue;
+    pipeIQInputData->set_max_num_items(100);
     pipeIQDemodData = new DemodulatorThreadPostInputQueue;
+    pipeIQInputData->set_max_num_items(100);
     
     audioThread = new AudioThread();
             
@@ -62,7 +64,10 @@ DemodulatorInstance::DemodulatorInstance() {
     demodulatorPreThread->setOutputQueue("IQDataOutput",pipeIQDemodData);
             
     pipeAudioData = new AudioThreadInputQueue;
+    pipeAudioData->set_max_num_items(10);
+
     threadQueueControl = new DemodulatorThreadControlCommandQueue;
+    threadQueueControl->set_max_num_items(2);
 
     demodulatorThread = new DemodulatorThread(this);
     demodulatorThread->setInputQueue("IQDataInput",pipeIQDemodData);
@@ -241,6 +246,7 @@ void DemodulatorInstance::setActive(bool state) {
 void DemodulatorInstance::squelchAuto() {
     DemodulatorThreadControlCommand command;
     command.cmd = DemodulatorThreadControlCommand::DEMOD_THREAD_CMD_CTL_SQUELCH_ON;
+    //VSO: blocking push
     threadQueueControl->push(command);
     squelch = true;
 }
@@ -257,6 +263,7 @@ void DemodulatorInstance::setSquelchEnabled(bool state) {
     } else if (state && !squelch) {
         DemodulatorThreadControlCommand command;
         command.cmd = DemodulatorThreadControlCommand::DEMOD_THREAD_CMD_CTL_SQUELCH_ON;
+        //VSO: blocking push!
         threadQueueControl->push(command);
     }
 
@@ -292,6 +299,7 @@ void DemodulatorInstance::setOutputDevice(int device_id) {
         AudioThreadCommand command;
         command.cmd = AudioThreadCommand::AUDIO_THREAD_CMD_SET_DEVICE;
         command.int_value = device_id;
+        //VSO: blocking push
         audioThread->getCommandQueue()->push(command);
     }
     setAudioSampleRate(AudioThread::deviceSampleRate[device_id]);

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -298,13 +298,17 @@ void DemodulatorThread::run() {
                 ati_vis->type = 0;
             }
             
-            //non-blocking push for audio-out
-            localAudioVisOutputQueue->try_push(ati_vis);
+            if (!localAudioVisOutputQueue->try_push(ati_vis)) {
+                //non-blocking push for audio-out
+                ati_vis->setRefCount(0);
+                std::cout << "DemodulatorThread::run() cannot push ati_vis into localAudioVisOutputQueue, is full !" << std::endl;
+                std::this_thread::yield();
+            }
         }
 
         if (ati != nullptr) {
             if (!muted.load() && (!wxGetApp().getSoloMode() || (demodInstance == wxGetApp().getDemodMgr().getLastActiveDemodulator()))) {
-                //non-blocking push for audio-out
+                
                 audioOutputQueue->push(ati);
             } else {
                 ati->setRefCount(0);

--- a/src/demod/DemodulatorThread.h
+++ b/src/demod/DemodulatorThread.h
@@ -10,7 +10,7 @@
 #include "AudioThread.h"
 #include "Modem.h"
 
-typedef ThreadQueue<AudioThreadInput *> DemodulatorThreadOutputQueue;
+typedef ThreadBlockingQueue<AudioThreadInput *> DemodulatorThreadOutputQueue;
 
 #define DEMOD_VIS_SIZE 2048
 #define DEMOD_SIGNAL_MIN -30

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -101,11 +101,10 @@ void DemodulatorWorkerThread::run() {
             result.modemType = cModemType;
             result.modemName = cModemName;
             
+            //VSO: blocking push
             resultQueue->push(result);
         }
-
     }
-
 //    std::cout << "Demodulator worker thread done." << std::endl;
 }
 

--- a/src/demod/DemodulatorWorkerThread.h
+++ b/src/demod/DemodulatorWorkerThread.h
@@ -8,7 +8,7 @@
 
 #include "liquid/liquid.h"
 #include "AudioThread.h"
-#include "ThreadQueue.h"
+#include "ThreadBlockingQueue.h"
 #include "CubicSDRDefs.h"
 #include "Modem.h"
 
@@ -69,8 +69,8 @@ public:
     ModemSettings settings;
 };
 
-typedef ThreadQueue<DemodulatorWorkerThreadCommand> DemodulatorThreadWorkerCommandQueue;
-typedef ThreadQueue<DemodulatorWorkerThreadResult> DemodulatorThreadWorkerResultQueue;
+typedef ThreadBlockingQueue<DemodulatorWorkerThreadCommand> DemodulatorThreadWorkerCommandQueue;
+typedef ThreadBlockingQueue<DemodulatorWorkerThreadResult> DemodulatorThreadWorkerResultQueue;
 
 class DemodulatorWorkerThread : public IOThread {
 public:

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -3,6 +3,7 @@
 
 #include "FFTDataDistributor.h"
 #include <algorithm>
+#include <ThreadBlockingQueue.h>
 
 FFTDataDistributor::FFTDataDistributor() : outputBuffers("FFTDataDistributorBuffers"), fftSize(DEFAULT_FFT_SIZE), linesPerSecond(DEFAULT_WATERFALL_LPS), lineRateAccum(0.0) {
 
@@ -109,7 +110,8 @@ void FFTDataDistributor::process() {
 						outp->sampleRate = inputBuffer.sampleRate;
 						outp->data.assign(inputBuffer.data.begin()+bufferOffset+i,
                                           inputBuffer.data.begin()+bufferOffset+i+ fftSize);
-						distribute(outp);
+                        //authorize distribute with losses
+						distribute(outp, NON_BLOCKING_TIMEOUT);
 
 						while (lineRateAccum >= 1.0) {
 							lineRateAccum -= 1.0;

--- a/src/process/FFTVisualDataThread.cpp
+++ b/src/process/FFTVisualDataThread.cpp
@@ -53,7 +53,6 @@ void FFTVisualDataThread::run() {
         //this if fed by FFTDataDistributor which has a buffer of FFT_DISTRIBUTOR_BUFFER_IN_SECONDS
         //so sleep for << FFT_DISTRIBUTOR_BUFFER_IN_SECONDS not to be overflown
         std::this_thread::sleep_for(std::chrono::milliseconds((int)(FFT_DISTRIBUTOR_BUFFER_IN_SECONDS * 1000.0 / 25.0)));
-//        std::this_thread::yield();
         
         int fftSize = wproc.getDesiredInputSize();
         
@@ -65,7 +64,6 @@ void FFTVisualDataThread::run() {
     
         if (lpsChanged.load()) {
             fftDistrib.setLinesPerSecond(linesPerSecond.load());
-//            pipeIQDataIn->set_max_num_items(linesPerSecond.load());
             lpsChanged.store(false);
         }
         

--- a/src/process/ScopeVisualProcessor.h
+++ b/src/process/ScopeVisualProcessor.h
@@ -19,7 +19,7 @@ public:
     double fft_floor, fft_ceil;
 };
 
-typedef ThreadQueue<ScopeRenderData *> ScopeRenderDataQueue;
+typedef ThreadBlockingQueue<ScopeRenderData *> ScopeRenderDataQueue;
 
 class ScopeVisualProcessor : public VisualProcessor<AudioThreadInput, ScopeRenderData> {
 public:

--- a/src/process/SpectrumVisualDataThread.cpp
+++ b/src/process/SpectrumVisualDataThread.cpp
@@ -20,7 +20,7 @@ void SpectrumVisualDataThread::run() {
     while(!stopping) {
         //this if fed by FFTDataDistributor which has a buffer of FFT_DISTRIBUTOR_BUFFER_IN_SECONDS
         //so sleep for << FFT_DISTRIBUTOR_BUFFER_IN_SECONDS not to be overflown
-        std::this_thread::sleep_for(std::chrono::milliseconds((int)(FFT_DISTRIBUTOR_BUFFER_IN_SECONDS * 1000.0 / 25.0)));
+       std::this_thread::sleep_for(std::chrono::milliseconds((int)(FFT_DISTRIBUTOR_BUFFER_IN_SECONDS * 1000.0 / 25.0)));
 
         sproc.run();
     }

--- a/src/process/SpectrumVisualProcessor.h
+++ b/src/process/SpectrumVisualProcessor.h
@@ -19,7 +19,7 @@ public:
     int bandwidth;
 };
 
-typedef ThreadQueue<SpectrumVisualData *> SpectrumVisualDataQueue;
+typedef ThreadBlockingQueue<SpectrumVisualData *> SpectrumVisualDataQueue;
 
 class SpectrumVisualProcessor : public VisualProcessor<DemodulatorThreadIQData, SpectrumVisualData> {
 public:

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -142,7 +142,12 @@ protected:
             }
       
             if (inp) {
+                int previousRefCount = inp->getRefCount();
             	VisualProcessor<OutputDataType, OutputDataType>::distribute(inp);
+                //inp is now shared through the distribute(), which overwrite the previous ref count,
+                //so increment it properly.
+                int distributeRefCount = inp->getRefCount();
+                inp->setRefCount(previousRefCount + distributeRefCount);
             }
         }
     }

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -12,8 +12,8 @@
 template<typename InputDataType = ReferenceCounter, typename OutputDataType = ReferenceCounter>
 class VisualProcessor {
     //
-    typedef typename ThreadBlockingQueue<InputDataType*> VisualInputQueueType;
-    typedef typename ThreadBlockingQueue<OutputDataType*> VisualOutputQueueType;
+    typedef  ThreadBlockingQueue<InputDataType*> VisualInputQueueType;
+    typedef  ThreadBlockingQueue<OutputDataType*> VisualOutputQueueType;
     typedef typename std::vector< VisualOutputQueueType *>::iterator outputs_i;
 public:
 	virtual ~VisualProcessor() {

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -251,7 +251,7 @@ void SDRThread::readStream(SDRThreadIQDataQueue* iqDataOutQueue) {
         dataOut->dcCorrected = hasHardwareDC.load();
         dataOut->numChannels = numChannels.load();
         
-        if (!iqDataOutQueue->push(dataOut)) {
+        if (!iqDataOutQueue->try_push(dataOut)) {
             //The rest of the system saturates,
             //finally the push didn't suceeded, recycle dataOut immediatly.
             dataOut->setRefCount(0);

--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -5,7 +5,7 @@
 
 #include <atomic>
 
-#include "ThreadQueue.h"
+#include "ThreadBlockingQueue.h"
 #include "DemodulatorMgr.h"
 #include "SDRDeviceInfo.h"
 #include "AppConfig.h"
@@ -39,7 +39,7 @@ public:
     }
 };
 
-typedef ThreadQueue<SDRThreadIQData *> SDRThreadIQDataQueue;
+typedef ThreadBlockingQueue<SDRThreadIQData *> SDRThreadIQDataQueue;
 
 class SDRThread : public IOThread {
 private:

--- a/src/util/ThreadBlockingQueue.cpp
+++ b/src/util/ThreadBlockingQueue.cpp
@@ -1,0 +1,4 @@
+// Copyright (c) Charles J. Cliffe
+// SPDX-License-Identifier: GPL-2.0+
+
+#include <ThreadBlockingQueue.h>

--- a/src/util/ThreadBlockingQueue.h
+++ b/src/util/ThreadBlockingQueue.h
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <stddef.h>
 #include <condition_variable>
-#include <ThreadQueue.h>
+#include <typeinfo>
 
 #define MIN_ITEM_NB (1)
 
@@ -21,6 +21,9 @@
 //an indefnite timeout duration. 
 #define BLOCKING_INFINITE_TIMEOUT (0)
 
+class ThreadQueueBase {
+};
+
 /** A thread-safe asynchronous blocking queue */
 template<typename T>
 class ThreadBlockingQueue : public ThreadQueueBase {
@@ -29,7 +32,6 @@ class ThreadBlockingQueue : public ThreadQueueBase {
     typedef typename std::deque<T>::size_type size_type;
 
 public:
-    
 
     /*! Create safe blocking queue. */
     ThreadBlockingQueue() {
@@ -37,6 +39,7 @@ public:
         m_max_num_items = MIN_ITEM_NB;
     };
     
+    //Copy constructor
     ThreadBlockingQueue(const ThreadBlockingQueue& sq) {
         std::lock_guard < std::mutex > lock(sq.m_mutex);
         m_queue = sq.m_queue;
@@ -57,7 +60,7 @@ public:
         std::lock_guard < std::mutex > lock(m_mutex);
 
         if (max_num_items > m_max_num_items) {
-            //Only raise the existing max size, never squash it
+            //Only raise the existing max size, never reduce it
             //for simplification sake at runtime.
             m_max_num_items = max_num_items;
             m_cond_not_full.notify_all();

--- a/src/util/ThreadBlockingQueue.h
+++ b/src/util/ThreadBlockingQueue.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <condition_variable>
 #include <typeinfo>
+#include <iostream>
 
 #define MIN_ITEM_NB (1)
 
@@ -242,7 +243,7 @@ public:
             std::lock_guard < std::mutex > lock1(m_mutex);
             std::lock_guard < std::mutex > lock2(sq.m_mutex);
   
-            m_queue = sq.m_queue
+            m_queue = sq.m_queue;
             m_max_num_items = sq.m_max_num_items;
 
             if (!m_queue.empty()) {

--- a/src/util/ThreadBlockingQueue.h
+++ b/src/util/ThreadBlockingQueue.h
@@ -1,0 +1,268 @@
+// Copyright (c) Charles J. Cliffe
+// SPDX-License-Identifier: GPL-2.0+
+
+#pragma once 
+
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <cstdint>
+#include <stddef.h>
+#include <condition_variable>
+#include <ThreadQueue.h>
+
+#define MIN_ITEM_NB (1)
+
+//use this timeout constant in either pop() or push() calls to indicate 
+// a non-blocking operation, so respectively equivalent to try_pop() and try_push() 
+#define NON_BLOCKING_TIMEOUT (100)
+
+//use this timeout constant in either pop() or push() calls to indicate 
+//an indefnite timeout duration. 
+#define BLOCKING_INFINITE_TIMEOUT (0)
+
+/** A thread-safe asynchronous blocking queue */
+template<typename T>
+class ThreadBlockingQueue : public ThreadQueueBase {
+
+    typedef typename std::deque<T>::value_type value_type;
+    typedef typename std::deque<T>::size_type size_type;
+
+public:
+    
+
+    /*! Create safe blocking queue. */
+    ThreadBlockingQueue() {
+        //at least 1 (== Exchanger)
+        m_max_num_items = MIN_ITEM_NB;
+    };
+    
+    ThreadBlockingQueue(const ThreadBlockingQueue& sq) {
+        std::lock_guard < std::mutex > lock(sq.m_mutex);
+        m_queue = sq.m_queue;
+        m_max_num_items = sq.m_max_num_items;
+    }
+
+    /*! Destroy safe queue. */
+    ~ThreadBlockingQueue() {
+        std::lock_guard < std::mutex > lock(m_mutex);
+    }
+
+    /**
+     * Sets the maximum number of items in the queue. Real value is clamped
+     * to 1 on the lower bound. 
+     * \param[in] nb max of items
+     */
+    void set_max_num_items(unsigned int max_num_items) {
+        std::lock_guard < std::mutex > lock(m_mutex);
+
+        if (max_num_items > m_max_num_items) {
+            //Only raise the existing max size, never squash it
+            //for simplification sake at runtime.
+            m_max_num_items = max_num_items;
+            m_cond_not_full.notify_all();
+        }
+    }
+
+    /**
+     * Pushes the item into the queue. If the queue is full, waits until room
+     * is available, for at most timeout microseconds.
+     * \param[in] item An item.
+     * \param[in] timeout a max waiting timeout in microseconds for an item to be pushed. 
+     * by default, = 0 means indefinite wait.
+     * \param[in] errorMessage an error message written on std::cout in case of the timeout wait
+     * \return true if an item was pushed into the queue, else a timeout has occured.
+     */
+    bool push(const value_type& item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT,const char* errorMessage = "") {
+        std::unique_lock < std::mutex > lock(m_mutex);
+
+        if (timeout == BLOCKING_INFINITE_TIMEOUT) {
+            m_cond_not_full.wait(lock, [this]() // Lambda funct
+            {
+                return m_queue.size() < m_max_num_items;
+            });
+        } else if (timeout <= NON_BLOCKING_TIMEOUT && m_queue.size() >= m_max_num_items) {
+            // if the value is below a threshold, consider it is a try_push()
+            return false;
+        }
+        else if (false == m_cond_not_full.wait_for(lock, std::chrono::microseconds(timeout),
+           [this]() { return m_queue.size() < m_max_num_items; })) {
+            std::cout << "WARNING: Thread 0x" << std::hex << std::this_thread::get_id() << std::dec <<
+                " executing {" << typeid(*this).name() << "}.push() has failed with timeout > " <<
+                (timeout * 0.001) << " ms, message: " << errorMessage << std::endl;
+           return false;
+        }
+
+        m_queue.push_back(item);
+        m_cond_not_empty.notify_all();
+        return true;
+    }
+
+    /**
+    * Try to pushes the item into the queue, immediatly, without waiting. If the queue is full, the item
+    * is not inserted and the function returns false. 
+    * \param[in] item An item.
+    */
+    bool try_push(const value_type& item) {
+        std::lock_guard < std::mutex > lock(m_mutex);
+
+        if (m_queue.size() >= m_max_num_items) {
+            return false;
+        }
+
+        m_queue.push_back(item);
+        m_cond_not_empty.notify_all();
+        return true;
+    }
+
+    /**
+     * Pops item from the queue. If the queue is empty, blocks for timeout microseconds, or until item becomes available.
+     * \param[in] timeout The number of microseconds to wait. O (default) means indefinite wait.
+     * \param[in] errorMessage an error message written on std::cout in case of the timeout wait
+     * \return true if get an item from the queue, false if no item is received before the timeout.
+     */
+    bool pop(value_type& item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT, const char* errorMessage = "") {
+        std::unique_lock < std::mutex > lock(m_mutex);
+
+        if (timeout == BLOCKING_INFINITE_TIMEOUT) {
+            m_cond_not_empty.wait(lock, [this]() // Lambda funct
+            {
+                return !m_queue.empty();
+            });
+        } else if (timeout <= NON_BLOCKING_TIMEOUT && m_queue.empty()) {
+            // if the value is below a threshold, consider it is try_pop()
+            return false;
+        }
+        else if (false == m_cond_not_empty.wait_for(lock, std::chrono::microseconds(timeout),
+            [this]() { return !m_queue.empty(); })) {
+            std::cout << "WARNING: Thread 0x" << std::hex << std::this_thread::get_id() << std::dec << 
+                         " executing {" << typeid(*this).name() << "}.pop() has failed with timeout > " << 
+                         (timeout * 0.001) << " ms, message: " << errorMessage << std::endl;
+            return false;
+        }
+
+        item = m_queue.front();
+        m_queue.pop_front();
+        m_cond_not_full.notify_all();
+        return true;
+    }
+
+    /**
+     *  Tries to pop item from the queue.
+     * \param[out] item The item.
+     * \return False is returned if no item is available.
+     */
+    bool try_pop(value_type& item) {
+        std::lock_guard < std::mutex > lock(m_mutex);
+
+        if (m_queue.empty()) {
+            return false;
+        }
+
+        item = m_queue.front();
+        m_queue.pop_front();
+        m_cond_not_full.notify_all();
+        return true;
+    }
+
+
+    /**
+     *  Gets the number of items in the queue.
+     * \return Number of items in the queue.
+     */
+    size_type size() const {
+        std::lock_guard < std::mutex > lock(m_mutex);
+        return m_queue.size();
+    }
+
+    /**
+     *  Check if the queue is empty.
+     * \return true if queue is empty.
+     */
+    bool empty() const {
+        std::lock_guard < std::mutex > lock(m_mutex);
+        return m_queue.empty();
+    }
+
+    /**
+     *  Check if the queue is full.
+     * \return true if queue is full.
+     */
+    bool full() const {
+        std::lock_guard < std::mutex > lock(m_mutex);
+        return (m_queue.size() >= m_max_num_items);
+    }
+
+    /**
+     *  Remove any items in the queue.
+     */
+    void flush() {
+        std::lock_guard < std::mutex > lock(m_mutex);
+        m_queue.clear();
+        m_cond_not_full.notify_all();
+    }
+
+    /**
+     *  Swaps the contents.
+     * \param[out] sq The ThreadBlockingQueue to swap with 'this'.
+     */
+    void swap(ThreadBlockingQueue& sq) {
+        if (this != &sq) {
+            std::lock_guard < std::mutex > lock1(m_mutex);
+            std::lock_guard < std::mutex > lock2(sq.m_mutex);
+            m_queue.swap(sq.m_queue);
+            std::swap(m_max_num_items, sq.m_max_num_items);
+
+            if (!m_queue.empty()) {
+                m_cond_not_empty.notify_all();
+            }
+
+            if (!sq.m_queue.empty()) {
+                sq.m_cond_not_empty.notify_all();
+            }
+
+            if (!m_queue.full()) {
+                m_cond_not_full.notify_all();
+            }
+
+            if (!sq.m_queue.full()) {
+                sq.m_cond_not_full.notify_all();
+            }
+        }
+    }
+
+    /*! The copy assignment operator */
+    ThreadBlockingQueue& operator=(const ThreadBlockingQueue& sq) {
+        if (this != &sq) {
+            std::lock_guard < std::mutex > lock1(m_mutex);
+            std::lock_guard < std::mutex > lock2(sq.m_mutex);
+  
+            m_queue = sq.m_queue
+            m_max_num_items = sq.m_max_num_items;
+
+            if (!m_queue.empty()) {
+                m_cond_not_empty.notify_all();
+            }
+
+            if (!m_queue.full()) {
+                m_cond_not_full.notify_all();
+            }
+        }
+        return *this;
+    }
+
+private:
+    //TODO: use a circular buffer structure ? (fixed array + modulo)
+    std::deque<T> m_queue;
+
+    mutable std::mutex m_mutex;
+    std::condition_variable m_cond_not_empty;
+    std::condition_variable m_cond_not_full;
+    size_t m_max_num_items = MIN_ITEM_NB;
+};
+
+/*! Swaps the contents of two ThreadBlockingQueue objects. (external operator) */
+template<typename T>
+void swap(ThreadBlockingQueue<T>& q1, ThreadBlockingQueue<T>& q2) {
+    q1.swap(q2);
+}

--- a/src/util/ThreadBlockingQueue.h
+++ b/src/util/ThreadBlockingQueue.h
@@ -90,8 +90,9 @@ public:
         }
         else if (false == m_cond_not_full.wait_for(lock, std::chrono::microseconds(timeout),
            [this]() { return m_queue.size() < m_max_num_items; })) {
-            std::cout << "WARNING: Thread 0x" << std::hex << std::this_thread::get_id() << std::dec <<
-                " executing {" << typeid(*this).name() << "}.push() has failed with timeout > " <<
+            std::thread::id currentThreadId = std::this_thread::get_id();
+            std::cout << "WARNING: Thread 0x" << std::hex << currentThreadId << std::dec <<
+                " (" << currentThreadId << ") executing {" << typeid(*this).name() << "}.push() has failed with timeout > " <<
                 (timeout * 0.001) << " ms, message: " << errorMessage << std::endl;
            return false;
         }
@@ -138,9 +139,10 @@ public:
         }
         else if (false == m_cond_not_empty.wait_for(lock, std::chrono::microseconds(timeout),
             [this]() { return !m_queue.empty(); })) {
-            std::cout << "WARNING: Thread 0x" << std::hex << std::this_thread::get_id() << std::dec << 
-                         " executing {" << typeid(*this).name() << "}.pop() has failed with timeout > " << 
-                         (timeout * 0.001) << " ms, message: " << errorMessage << std::endl;
+            std::thread::id currentThreadId = std::this_thread::get_id();
+            std::cout << "WARNING: Thread 0x" << std::hex << currentThreadId << std::dec <<
+                " (" << currentThreadId << ") executing {" << typeid(*this).name() << "}.pop() has failed with timeout > " <<
+                (timeout * 0.001) << " ms, message: " << errorMessage << std::endl;
             return false;
         }
 


### PR DESCRIPTION
@cjcliffe Helllo ! This one is an attempt to turn the ThreadQueue into a fully blocking queue, named ThreadBlockingQueue. It is more complete, because the producer ``push()`` calls are now blocking by default when the queue is full, just like ``pop()`` is when the queue is empty.

Indeed, until now ``ThreadQueue.push()`` wasn't blocking on a full queue, forcing us to either explicitly stop pushing elements or simply discarding them on the producer side of the producer-consumer duo.

With a blocking ``push()`` by default, the threads communicating by a cascading ``push()/pop()`` are able to self-regulate their processing flow, while simplifying the code because nothing is lost in case of blocking ``push()`` by definition.

As a first attempt, I then replaced every ``ThreadQueue``  by  ``ThreadBlockingQueue``, so turning auto-magically all non-blocking ````push()```` by blocking ones.
The important difference to note is now that ``set_max_num_items()`` is very important to set explicitly, because the default value is 1.
As for the behavior with such radical changes, I've got some freezes on exiting application, and waterfall/scope stop refreshing.
So I instrumented the code to turn ``push(item)`` calls into timed-out ones : 
``push(item, 50*1000, "specific error message")``
so that the contention points revealed themselves.

In the end after re-introducing non-blocking calls at the contention points, the amount of non-blocking calls in the whole application was limited to:
- ``SDRThread::readStream()`` : make sense, drop samples from device if we cannot keep up with the realtime processing. 
- ``DemodulatorThread.cpp(302):  localAudioVisOutputQueue->try_push(ati_vis)``
- ``FFTDataDistributor.cpp(114):  distribute(outp, NON_BLOCKING_TIMEOUT);``

Now about the result: unless I was extremely lucky, I didn't see any application freeze, crash, or anything else after several days of torture loading, unloading sessions files, or in general usage whatsoever.
So, as for me it is better than before where freezes were still present.

Note that with ``ThreadBlockingQueue.try_push()`` the new class can do what the previous ``ThreadQueue.push()`` did, so can replace it no matter how we decide to use it. 

So please give it a try and tell me what you think ! 