### PR TITLE
Rebuffer automatic refcount management

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1612,6 +1612,9 @@ void AppFrame::OnIdle(wxIdleEvent& event) {
         updateDeviceParams();
     }
     
+    //try to garbage collect the retired demodulators.
+    wxGetApp().getDemodMgr().garbageCollect();
+
     DemodulatorInstance *demod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
 
     if (demod && demod->isModemInitialized()) {

--- a/src/IOThread.cpp
+++ b/src/IOThread.cpp
@@ -127,7 +127,7 @@ bool IOThread::isTerminated(int waitMs) {
         }
     }
 
-    std::cout << "ERROR: thread '" << typeid(*this).name() << "' has not terminated in time ! (> " << waitMs << " ms)" << std::endl;
+    std::cout << "ERROR: thread '" << typeid(*this).name() << "' has not terminated in time ! (> " << waitMs << " ms)" << std::endl << std::flush;
 
     return terminated.load();
 }

--- a/src/IOThread.cpp
+++ b/src/IOThread.cpp
@@ -4,9 +4,6 @@
 #include "IOThread.h"
 #include <typeinfo>
 
-std::mutex ReBufferGC::g_mutex;
-std::set<ReferenceCounter *> ReBufferGC::garbage;
-
 #define SPIN_WAIT_SLEEP_MS 5
 
 IOThread::IOThread() {

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -99,7 +99,7 @@ public:
         }
 
         if (outputBuffers.size() > REBUFFER_WARNING_THRESHOLD) {
-            std::cout << "Warning: ReBuffer '" << bufferId << "' count '" << outputBuffers.size() << "' exceeds threshold of '" << REBUFFER_WARNING_THRESHOLD << "'" << std::endl;
+            std::cout << "Warning: ReBuffer '" << bufferId << "' count '" << outputBuffers.size() << "' exceeds threshold of '" << REBUFFER_WARNING_THRESHOLD << "'" << std::endl << std::flush;
         }
         
         //3.We need to allocate a new buffer. 

--- a/src/IOThread.h
+++ b/src/IOThread.h
@@ -5,13 +5,14 @@
 
 #include <mutex>
 #include <atomic>
-#include <deque>
+#include <vector>
 #include <map>
 #include <set>
 #include <string>
 #include <iostream>
 #include <thread>
-
+#include <memory>
+#include <climits>
 #include "ThreadBlockingQueue.h"
 #include "Timer.h"
 
@@ -23,163 +24,122 @@ struct map_string_less : public std::binary_function<std::string,std::string,boo
     }
 };
 
-
-class ReferenceCounter {
-
+template <typename PtrType>
+class ReBufferAge {
 public:
+    PtrType ptr;
+    int age;
 
-    //default constructor, initialized with refcont 1, sounds very natural
-    ReferenceCounter() {
-        refCount = 1;
-    }
-    
-//    void setIndex(int idx) {
-//        std::lock_guard < std::recursive_mutex > lock(m_mutex);
-//        index = idx;
-//    }
-
-//    int getIndex() {
-//        std::lock_guard < std::recursive_mutex > lock(m_mutex);
-//        return index;
-//    }
-
-    void setRefCount(int rc) {
-        std::lock_guard < std::recursive_mutex > lock(m_mutex);
-        refCount = rc;
-    }
-    
-    void decRefCount() {
-        std::lock_guard < std::recursive_mutex > lock(m_mutex);
-        refCount--;
-    }
-    
-    int getRefCount() {
-        std::lock_guard < std::recursive_mutex > lock(m_mutex);
-        return refCount;
-    }
-
-    // Access to the own mutex protecting the ReferenceCounter, i.e the monitor of the class
-     std::recursive_mutex& getMonitor() const {
-        return m_mutex;
-    }
-
-protected:
-    //this is a basic mutex for all ReferenceCounter derivatives operations INCLUDING the counter itself for consistency !
-   mutable std::recursive_mutex m_mutex;
-
-private:
-   int refCount;
-//   int index;
+    virtual ~ReBufferAge() {};
 };
-
 
 #define REBUFFER_GC_LIMIT 100
+#define REBUFFER_WARNING_THRESHOLD 150
 
-class ReBufferGC {
-public:
-    static void garbageCollect() {
-        std::lock_guard < std::mutex > lock(g_mutex);
-        
-        std::deque<ReferenceCounter *> garbageRemoval;
-        for (typename std::set<ReferenceCounter *>::iterator i = garbage.begin(); i != garbage.end(); i++) {
-            if ((*i)->getRefCount() <= 0) {
-                garbageRemoval.push_back(*i);
-            }
-            else {
-//                std::cout << "Garbage in queue buffer idx #" << (*i)->getIndex() << ", " << (*i)->getRefCount() << " usage(s)" << std::endl;
-                std::cout << "Garbage in queue buffer with " << (*i)->getRefCount() << " usage(s)" << std::endl;
-            }
-        }
-        if ( garbageRemoval.size() ) {
-            std::cout << "Garbage collecting " << garbageRemoval.size() << " ReBuffer(s)" << std::endl;
-            while (!garbageRemoval.empty()) {
-                ReferenceCounter *ref = garbageRemoval.back();
-                garbageRemoval.pop_back();
-                garbage.erase(ref);
-                delete ref;
-            }
-        }
-    }
-    
-    static void addGarbage(ReferenceCounter *ref) {
-        std::lock_guard < std::mutex > lock(g_mutex);
-        garbage.insert(ref);
-    }
-    
-private:
-    static std::mutex g_mutex;
-    static std::set<ReferenceCounter *> garbage;
-};
-
-
-template<class BufferType = ReferenceCounter>
+template<typename BufferType>
 class ReBuffer {
     
+    typedef typename std::shared_ptr<BufferType> ReBufferPtr;
+   
 public:
     ReBuffer(std::string bufferId) : bufferId(bufferId) {
-//        indexCounter.store(0);
     }
     
-    BufferType *getBuffer() {
+    /// Return a new ReBuffer_ptr usable by the application.
+    ReBufferPtr getBuffer() {
+
         std::lock_guard < std::mutex > lock(m_mutex);
 
-        BufferType* buf = nullptr;
-        for (outputBuffersI = outputBuffers.begin(); outputBuffersI != outputBuffers.end(); outputBuffersI++) {
-            if (buf == nullptr && (*outputBuffersI)->getRefCount() <= 0) {
-                buf = (*outputBuffersI);
-                buf->setRefCount(1);
-            } else if ((*outputBuffersI)->getRefCount() <= 0) {
-                (*outputBuffersI)->decRefCount();
+        // iterate the ReBuffer_ptr list: if the std::shared_ptr count == 1, it means 
+        //it is only referenced in outputBuffers itself, so available for re-use.
+        //else if the std::shared_ptr count <= 1, make it age.
+        //else the ReBuffer_ptr is in use, don't use it.
+
+        ReBufferPtr buf = nullptr;
+
+        outputBuffersI it = outputBuffers.begin();
+
+       while (it != outputBuffers.end()) {
+
+           long use = it->ptr.use_count();
+            //1. If we encounter a shared_ptr with a use count of 0, this
+            //is a bug since it is supposed to be at least 1, because it is referenced here.
+            //in this case, purge it from here and trace.
+            if (use == 0) {
+                it = outputBuffers.erase(it);
+                std::cout << "Warning: in ReBuffer '" << bufferId << "' count '" << outputBuffers.size() << "', found 1 dangling buffer !" << std::endl << std::flush;
+            } 
+            else if (use == 1) {
+                if (buf == nullptr) {
+                    it->age = 1;  //select this one.
+                    buf = it->ptr;
+                    //std::cout << "**" << std::flush;
+                    it++;
+                }
+                else {
+                    //make the other unused buffers age
+                    it->age--;
+                    it++;
+                }
             }
-        }
-        
-        if (buf != nullptr) {
-            if (outputBuffers.back()->getRefCount() < -REBUFFER_GC_LIMIT) {
-                BufferType *ref = outputBuffers.back();
+            else {
+                it++;
+            }
+        } //end while
+
+       //2.1 Garbage collect the oldest (last element) if it aged too much, and return the buffer
+       if (buf != nullptr) {
+            
+           if (outputBuffers.back().age < -REBUFFER_GC_LIMIT) {
+                //by the nature of the shared_ptr, memory will ne deallocated automatically.           
                 outputBuffers.pop_back();
-                delete ref;
+                //std::cout << "--" << std::flush;
             }
-//            buf->setIndex(indexCounter++);
             return buf;
         }
-        
-#define REBUFFER_WARNING_THRESHOLD 100
+
         if (outputBuffers.size() > REBUFFER_WARNING_THRESHOLD) {
             std::cout << "Warning: ReBuffer '" << bufferId << "' count '" << outputBuffers.size() << "' exceeds threshold of '" << REBUFFER_WARNING_THRESHOLD << "'" << std::endl;
         }
-
-        //by default created with refcount = 1
-        buf = new BufferType();
-//        buf->setIndex(indexCounter++);
-        outputBuffers.push_back(buf);
         
-        return buf;
+        //3.We need to allocate a new buffer. 
+        ReBufferAge < ReBufferPtr > newBuffer;
+
+        //careful here: newBuffer.ptr is already constructed, so we need to set "in place" its
+        //ownership to a (new BufferType()).
+        newBuffer.ptr.reset(new BufferType());
+        newBuffer.age = 1;
+
+        outputBuffers.push_back(newBuffer);
+
+        //std::cout << "++" << std::flush;
+        
+        return newBuffer.ptr;
     }
     
+    /// Purge the cache.
     void purge() {
         std::lock_guard < std::mutex > lock(m_mutex);
-//        if (bufferId == "DemodulatorThreadBuffers") {
-//            std::cout << "'" << bufferId << "' purging.. total indexes: " << indexCounter.load() << std::endl;
-//        }
-        while (!outputBuffers.empty()) {
-            BufferType *ref = outputBuffers.front();
-            outputBuffers.pop_front();
-            if (ref->getRefCount() <= 0) {
-                delete ref;
-            } else {
-                // Something isn't done with it yet; throw it on the pile.. keep this as a bug indicator for now..
-                std::cout << "'" << bufferId << "' pushed garbage.." << std::endl;
-                ReBufferGC::addGarbage(ref);
-            }
-        }
+
+        // since outputBuffers are full std::shared_ptr,
+        //purging if will effectively loose the local reference,
+        // so the std::shared_ptr will naturally be deallocated
+        //when their time comes.  
+        outputBuffers.clear();
     }
 
-   private:
+private:
+
+    //name of the buffer cache kind
     std::string bufferId;
-    std::deque<BufferType*> outputBuffers;
-    typename std::deque<BufferType*>::iterator outputBuffersI;
+    
+    //the ReBuffer cache
+    std::vector< ReBufferAge < ReBufferPtr > > outputBuffers;
+
+    typedef typename std::vector< ReBufferAge < ReBufferPtr > >::iterator outputBuffersI;
+
+    //mutex protecting access to outputBuffers.
     mutable std::mutex m_mutex;
-//    std::atomic_int indexCounter;
 };
 
 

--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -11,6 +11,8 @@
 #include <memory.h>
 #include <mutex>
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
 
 std::map<int, AudioThread *> AudioThread::deviceController;
 std::map<int, int> AudioThread::deviceSampleRate;
@@ -429,7 +431,9 @@ void AudioThread::run() {
     while (!stopping) {
         AudioThreadCommand command;
 
-        cmdQueue.pop(command);
+        if (!cmdQueue.pop(command, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+            continue;
+        }
 
         if (command.cmd == AudioThreadCommand::AUDIO_THREAD_CMD_SET_DEVICE) {
             setupDevice(command.int_value);

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -8,12 +8,12 @@
 #include <map>
 #include <string>
 #include <atomic>
-
+#include <memory>
 #include "ThreadBlockingQueue.h"
 #include "RtAudio.h"
 #include "DemodDefs.h"
 
-class AudioThreadInput: public ReferenceCounter {
+class AudioThreadInput {
 public:
     long long frequency;
     int inputRate;
@@ -29,9 +29,11 @@ public:
     }
 
     ~AudioThreadInput() {
-        std::lock_guard < std::recursive_mutex > lock(m_mutex);
+       
     }
 };
+
+typedef std::shared_ptr<AudioThreadInput> AudioThreadInputPtr;
 
 class AudioThreadCommand {
 public:
@@ -47,12 +49,12 @@ public:
     int int_value;
 };
 
-typedef ThreadBlockingQueue<AudioThreadInput *> AudioThreadInputQueue;
+typedef ThreadBlockingQueue<AudioThreadInputPtr> AudioThreadInputQueue;
 typedef ThreadBlockingQueue<AudioThreadCommand> AudioThreadCommandQueue;
 
 class AudioThread : public IOThread {
 public:
-    AudioThreadInput *currentInput;
+    AudioThreadInputPtr currentInput;
     AudioThreadInputQueue *inputQueue;
     std::atomic_uint audioQueuePtr;
     std::atomic_uint underflowCount;

--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <atomic>
 #include <mutex>
+#include <memory>
 
 #include "IOThread.h"
 
@@ -29,7 +30,7 @@ public:
     std::string demodType;
 };
 
-class DemodulatorThreadIQData: public ReferenceCounter {
+class DemodulatorThreadIQData {
 public:
     long long frequency;
     long long sampleRate;
@@ -48,7 +49,7 @@ public:
         return *this;
     }
 
-    ~DemodulatorThreadIQData() {
+    virtual ~DemodulatorThreadIQData() {
 
     }
 };
@@ -56,7 +57,7 @@ public:
 class Modem;
 class ModemKit;
 
-class DemodulatorThreadPostIQData: public ReferenceCounter {
+class DemodulatorThreadPostIQData {
 public:
     std::vector<liquid_float_complex> data;
 
@@ -71,13 +72,13 @@ public:
 
     }
 
-    ~DemodulatorThreadPostIQData() {
-        std::lock_guard < std::recursive_mutex > lock(m_mutex);
+    virtual ~DemodulatorThreadPostIQData() {
+       
     }
 };
 
 
-class DemodulatorThreadAudioData: public ReferenceCounter {
+class DemodulatorThreadAudioData {
 public:
     long long frequency;
     unsigned int sampleRate;
@@ -95,11 +96,13 @@ public:
 
     }
 
-    ~DemodulatorThreadAudioData() {
+    virtual ~DemodulatorThreadAudioData() {
 
     }
 };
+typedef std::shared_ptr<DemodulatorThreadIQData> DemodulatorThreadIQDataPtr;
+typedef std::shared_ptr<DemodulatorThreadPostIQData> DemodulatorThreadPostIQDataPtr;
 
-typedef ThreadBlockingQueue<DemodulatorThreadIQData *> DemodulatorThreadInputQueue;
-typedef ThreadBlockingQueue<DemodulatorThreadPostIQData *> DemodulatorThreadPostInputQueue;
+typedef ThreadBlockingQueue< DemodulatorThreadIQDataPtr > DemodulatorThreadInputQueue;
+typedef ThreadBlockingQueue< DemodulatorThreadPostIQDataPtr > DemodulatorThreadPostInputQueue;
 typedef ThreadBlockingQueue<DemodulatorThreadControlCommand> DemodulatorThreadControlCommandQueue;

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -78,6 +78,7 @@ DemodulatorInstance::DemodulatorInstance() {
 }
 
 DemodulatorInstance::~DemodulatorInstance() {
+    std::lock_guard < std::mutex > lockData(m_thread_control_mutex);
 #if ENABLE_DIGITAL_LAB
     delete activeOutput;
 #endif
@@ -89,7 +90,7 @@ DemodulatorInstance::~DemodulatorInstance() {
     delete threadQueueControl;
     delete pipeAudioData;
     
-    wxGetApp().getBookmarkMgr().updateActiveList();
+   // wxGetApp().getBookmarkMgr().updateActiveList();
 }
 
 void DemodulatorInstance::setVisualOutputQueue(DemodulatorThreadOutputQueue *tQueue) {
@@ -97,6 +98,9 @@ void DemodulatorInstance::setVisualOutputQueue(DemodulatorThreadOutputQueue *tQu
 }
 
 void DemodulatorInstance::run() {
+
+    std::lock_guard < std::mutex > lockData(m_thread_control_mutex);
+
     if (active) {
         return;
     }
@@ -128,7 +132,7 @@ void DemodulatorInstance::run() {
 
     active = true;
 
-    wxGetApp().getBookmarkMgr().updateActiveList();
+ //   wxGetApp().getBookmarkMgr().updateActiveList();
 }
 
 void DemodulatorInstance::updateLabel(long long freq) {
@@ -166,7 +170,8 @@ void DemodulatorInstance::setLabel(std::string labelStr) {
 
 bool DemodulatorInstance::isTerminated() {
 
-    //
+    std::lock_guard < std::mutex > lockData(m_thread_control_mutex);
+
     bool audioTerminated = audioThread->isTerminated();
     bool demodTerminated = demodulatorThread->isTerminated();
     bool preDemodTerminated = demodulatorPreThread->isTerminated();

--- a/src/demod/DemodulatorInstance.h
+++ b/src/demod/DemodulatorInstance.h
@@ -130,7 +130,7 @@ public:
     void closeOutput();
 #endif
         
-protected:
+private:
     DemodulatorThreadInputQueue* pipeIQInputData;
     DemodulatorThreadPostInputQueue* pipeIQDemodData;
     AudioThreadInputQueue *pipeAudioData;
@@ -138,7 +138,8 @@ protected:
     DemodulatorThread *demodulatorThread;
     DemodulatorThreadControlCommandQueue *threadQueueControl;
 
-private:
+    //protects child thread creation and termination 
+    mutable std::mutex m_thread_control_mutex;
 
     std::atomic<std::string *> label; //
     // User editable buffer, 16 bit string.

--- a/src/demod/DemodulatorMgr.cpp
+++ b/src/demod/DemodulatorMgr.cpp
@@ -163,6 +163,7 @@ void DemodulatorMgr::deleteThread(DemodulatorInstance *demod) {
     demod->terminate();
 
     //Do not cleanup immediatly
+    std::lock_guard < std::mutex > lock_deleted(deleted_demods_busy);
     demods_deleted.push_back(demod);
 }
 
@@ -225,10 +226,7 @@ void DemodulatorMgr::setActiveDemodulator(DemodulatorInstance *demod, bool tempo
         }
 #endif
         wxGetApp().getBookmarkMgr().updateActiveList();
-    } else {
-        std::lock_guard < std::recursive_mutex > lock(demods_busy);
-        garbageCollect();
-    }
+    } 
 
     if (activeVisualDemodulator.load()) {
         activeVisualDemodulator.load()->setVisualOutputQueue(nullptr);
@@ -280,8 +278,9 @@ DemodulatorInstance *DemodulatorMgr::getLastDemodulatorWith(const std::string& t
 	return nullptr;
 }
 
-//Private internal method, no need to protect it with demods_busy
 void DemodulatorMgr::garbageCollect() {
+    
+    std::lock_guard < std::mutex > lock(deleted_demods_busy);
 
     std::vector<DemodulatorInstance *>::iterator it = demods_deleted.begin();
 
@@ -290,11 +289,13 @@ void DemodulatorMgr::garbageCollect() {
         if ((*it)->isTerminated()) {
            
             DemodulatorInstance *deleted = (*it);
+      
+            std::cout << "Garbage collected demodulator instance '" << deleted->getLabel() << "'... " << std::endl << std::flush;
+            demods_deleted.erase(it);
             delete deleted;
 
-            it = demods_deleted.erase(it);
-
-            std::cout << "Garbage collected demodulator instance '" << deleted->getLabel() << "'... " << std::endl << std::flush;
+            //only garbage collect 1 demod at a time.
+            return;
         }
         else {
             it++;
@@ -431,7 +432,6 @@ void DemodulatorMgr::saveInstance(DataNode *node, DemodulatorInstance *inst) {
             *settingsNode->newChild(msi->first.c_str()) = msi->second;
         }
     }
-
 }
 
 DemodulatorInstance *DemodulatorMgr::loadInstance(DataNode *node) {

--- a/src/demod/DemodulatorMgr.h
+++ b/src/demod/DemodulatorMgr.h
@@ -67,10 +67,11 @@ public:
     void saveInstance(DataNode *node, DemodulatorInstance *inst);
 	
     DemodulatorInstance *loadInstance(DataNode *node);
+
+    //to be called periodically to cleanup removed demodulators.
+    void garbageCollect();
     
 private:
-    
-    void garbageCollect();
 
     std::vector<DemodulatorInstance *> demods;
     std::vector<DemodulatorInstance *> demods_deleted;
@@ -91,6 +92,8 @@ private:
     //protects access to demods lists and such, need to be recursive
     //because of the usage of public re-entrant methods 
     std::recursive_mutex demods_busy;
+
+    mutable std::mutex deleted_demods_busy;
     
     std::map<std::string, ModemSettings> lastModemSettings;
     std::map<int,RtAudio::DeviceInfo> outputDevices;

--- a/src/demod/DemodulatorPreThread.cpp
+++ b/src/demod/DemodulatorPreThread.cpp
@@ -71,7 +71,7 @@ void DemodulatorPreThread::run() {
     t_Worker = new std::thread(&DemodulatorWorkerThread::threadMain, workerThread);
     
     while (!stopping) {
-        DemodulatorThreadIQData *inp;
+        DemodulatorThreadIQDataPtr inp;
 
         iqInputQueue->pop(inp);
         
@@ -157,7 +157,7 @@ void DemodulatorPreThread::run() {
         }
 
         if (cModem && cModemKit && abs(shiftFrequency) > (int) ((double) (inp->sampleRate / 2) * 1.5)) {
-            inp->decRefCount();
+          
             continue;
         }
 
@@ -192,7 +192,7 @@ void DemodulatorPreThread::run() {
                 out_buf = temp_buf;
             }
 
-            DemodulatorThreadPostIQData *resamp = buffers.getBuffer();
+            DemodulatorThreadPostIQDataPtr resamp = buffers.getBuffer();
 
             size_t out_size = ceil((double) (bufSize) * iqResampleRatio) + 512;
 
@@ -217,8 +217,6 @@ void DemodulatorPreThread::run() {
             //VSO: blocking push
             iqOutputQueue->push(resamp);   
         }
-
-        inp->decRefCount();
 
         DemodulatorWorkerThreadResult result;
         //process all worker results until 
@@ -277,11 +275,8 @@ void DemodulatorPreThread::run() {
         }
     } //end while stopping
 
-    DemodulatorThreadPostIQData *tmp;
-    while (iqOutputQueue->try_pop(tmp)) {
-        
-        tmp->decRefCount();
-    }
+   
+    iqOutputQueue->flush();
     buffers.purge();
 }
 
@@ -348,7 +343,7 @@ int DemodulatorPreThread::getAudioSampleRate() {
 
 void DemodulatorPreThread::terminate() {
     IOThread::terminate();
-    DemodulatorThreadIQData *inp = new DemodulatorThreadIQData;    // push dummy to nudge queue
+    DemodulatorThreadIQDataPtr inp(new DemodulatorThreadIQData);    // push dummy to nudge queue
     
     //VSO: blocking push :
     iqInputQueue->push(inp);

--- a/src/demod/DemodulatorPreThread.cpp
+++ b/src/demod/DemodulatorPreThread.cpp
@@ -12,6 +12,9 @@
 #include "CubicSDR.h"
 #include "DemodulatorInstance.h"
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
+
 DemodulatorPreThread::DemodulatorPreThread(DemodulatorInstance *parent) : IOThread(), iqResampler(NULL), iqResampleRatio(1), cModem(nullptr), cModemKit(nullptr), iqInputQueue(NULL), iqOutputQueue(NULL)
  {
 	initialized.store(false);
@@ -73,7 +76,9 @@ void DemodulatorPreThread::run() {
     while (!stopping) {
         DemodulatorThreadIQDataPtr inp;
 
-        iqInputQueue->pop(inp);
+        if (!iqInputQueue->pop(inp, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+            continue;
+        }
         
         if (frequencyChanged.load()) {
             currentFrequency.store(newFrequency);

--- a/src/demod/DemodulatorPreThread.h
+++ b/src/demod/DemodulatorPreThread.h
@@ -17,7 +17,7 @@ class DemodulatorPreThread : public IOThread {
 public:
 
     DemodulatorPreThread(DemodulatorInstance *parent);
-    ~DemodulatorPreThread();
+    virtual ~DemodulatorPreThread();
 
     virtual void run();
     

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -12,6 +12,9 @@
 #define M_PI        3.14159265358979323846
 #endif
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
+
 #ifdef __APPLE__
 #include <pthread.h>
 #endif
@@ -81,7 +84,9 @@ void DemodulatorThread::run() {
     while (!stopping) {
         DemodulatorThreadPostIQDataPtr inp;
         
-        iqInputQueue->pop(inp);
+        if (!iqInputQueue->pop(inp, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+            continue;
+        }
          
         size_t bufSize = inp->data.size();
         

--- a/src/demod/DemodulatorThread.h
+++ b/src/demod/DemodulatorThread.h
@@ -10,7 +10,7 @@
 #include "AudioThread.h"
 #include "Modem.h"
 
-typedef ThreadBlockingQueue<AudioThreadInput *> DemodulatorThreadOutputQueue;
+typedef ThreadBlockingQueue<AudioThreadInputPtr> DemodulatorThreadOutputQueue;
 
 #define DEMOD_VIS_SIZE 2048
 #define DEMOD_SIGNAL_MIN -30
@@ -22,7 +22,7 @@ class DemodulatorThread : public IOThread {
 public:
 
     DemodulatorThread(DemodulatorInstance *parent);
-    ~DemodulatorThread();
+    virtual ~DemodulatorThread();
 
     void onBindOutput(std::string name, ThreadQueueBase *threadQueue);
     

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -6,6 +6,9 @@
 #include "CubicSDR.h"
 #include <vector>
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
+
 DemodulatorWorkerThread::DemodulatorWorkerThread() : IOThread(),
         commandQueue(NULL), resultQueue(NULL), cModem(nullptr), cModemKit(nullptr) {
 }
@@ -31,7 +34,9 @@ void DemodulatorWorkerThread::run() {
         //we are waiting for the first command to show up (blocking!)
         //then consuming the commands until done. 
         while (!done) {
-            commandQueue->pop(command);
+            if (!commandQueue->pop(command, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+                continue;
+            }
 
             switch (command.cmd) {
                 case DemodulatorWorkerThreadCommand::DEMOD_WORKER_THREAD_CMD_BUILD_FILTERS:

--- a/src/demod/DemodulatorWorkerThread.h
+++ b/src/demod/DemodulatorWorkerThread.h
@@ -76,7 +76,7 @@ class DemodulatorWorkerThread : public IOThread {
 public:
 
     DemodulatorWorkerThread();
-    ~DemodulatorWorkerThread();
+    virtual ~DemodulatorWorkerThread();
 
     virtual void run();
 

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -1411,7 +1411,7 @@ void BookmarkView::onEnterWindow( wxMouseEvent&  event ) {
     }
 #endif
 
-    setStatusText("You can mouse-drag a bookmark entry from one category to the next..etc. TODO: add more Bookmarks descriptions");
+    setStatusText("Drag & Drop to create / move bookmarks, Group and arrange bookmarks, quick Search by keywords.");
 }
 
 

--- a/src/modules/modem/Modem.h
+++ b/src/modules/modem/Modem.h
@@ -8,6 +8,7 @@
 #include "AudioThread.h"
 #include <cmath>
 #include <atomic>
+#include <memory>
 
 #define MIN_BANDWIDTH 500
 
@@ -25,7 +26,7 @@ public:
     int audioSampleRate;
 };
 
-class ModemIQData: public ReferenceCounter {
+class ModemIQData {
 public:
     std::vector<liquid_float_complex> data;
     long long sampleRate;
@@ -34,10 +35,12 @@ public:
         
     }
     
-    ~ModemIQData() {
-        std::lock_guard < std::recursive_mutex > lock(m_mutex);
+    virtual ~ModemIQData() {
+        
     }
 };
+
+typedef std::shared_ptr<ModemIQData> ModemIQDataPtr;
 
 // Copy of SoapySDR::Range, original comments
 class ModemRange

--- a/src/modules/modem/analog/ModemAM.cpp
+++ b/src/modules/modem/analog/ModemAM.cpp
@@ -24,13 +24,13 @@ int ModemAM::getDefaultSampleRate() {
     return 6000;
 }
 
-void ModemAM::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *audioOut) {
+void ModemAM::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput* audioOut) {
     ModemKitAnalog *amkit = (ModemKitAnalog *)kit;
     
     initOutputBuffers(amkit,input);
     
     if (!bufSize) {
-        input->decRefCount();
+       
         return;
     }
     

--- a/src/modules/modem/analog/ModemDSB.cpp
+++ b/src/modules/modem/analog/ModemDSB.cpp
@@ -30,7 +30,7 @@ void ModemDSB::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *a
     initOutputBuffers(amkit, input);
     
     if (!bufSize) {
-        input->decRefCount();
+       
         return;
     }
     

--- a/src/modules/modem/analog/ModemFM.cpp
+++ b/src/modules/modem/analog/ModemFM.cpp
@@ -29,7 +29,7 @@ void ModemFM::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *au
     initOutputBuffers(fmkit, input);
     
     if (!bufSize) {
-        input->decRefCount();
+      
         return;
     }
     

--- a/src/modules/modem/analog/ModemIQ.cpp
+++ b/src/modules/modem/analog/ModemIQ.cpp
@@ -42,7 +42,7 @@ void ModemIQ::demodulate(ModemKit * /* kit */, ModemIQData *input, AudioThreadIn
     size_t bufSize = input->data.size();
     
     if (!bufSize) {
-        input->decRefCount();
+       
         return;
     }
     

--- a/src/modules/modem/analog/ModemLSB.cpp
+++ b/src/modules/modem/analog/ModemLSB.cpp
@@ -46,7 +46,7 @@ void ModemLSB::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *a
     initOutputBuffers(akit,input);
     
     if (!bufSize) {
-        input->decRefCount();
+       
         return;
     }
     

--- a/src/modules/modem/analog/ModemNBFM.cpp
+++ b/src/modules/modem/analog/ModemNBFM.cpp
@@ -29,7 +29,7 @@ void ModemNBFM::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *
     initOutputBuffers(fmkit, input);
     
     if (!bufSize) {
-        input->decRefCount();
+       
         return;
     }
     

--- a/src/modules/modem/analog/ModemUSB.cpp
+++ b/src/modules/modem/analog/ModemUSB.cpp
@@ -46,7 +46,7 @@ void ModemUSB::demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *a
     initOutputBuffers(akit,input);
     
     if (!bufSize) {
-        input->decRefCount();
+       
         return;
     }
     

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -28,7 +28,7 @@ void FFTDataDistributor::process() {
 		if (!isAnyOutputEmpty()) {
 			return;
 		}
-		DemodulatorThreadIQData *inp;
+		DemodulatorThreadIQDataPtr inp;
 		input->pop(inp);
 
 		if (inp) {
@@ -73,7 +73,7 @@ void FFTDataDistributor::process() {
             memcpy(&inputBuffer.data[bufferOffset+bufferedItems],&inp->data[0], nbSamplesToAdd *sizeof(liquid_float_complex));
             bufferedItems += nbSamplesToAdd;
             //
-			inp->decRefCount();
+		
 		} else {
             //empty inp, wait for another.
 			continue;
@@ -105,7 +105,8 @@ void FFTDataDistributor::process() {
 
 					if (lineRateAccum >= 1.0) {
                         //each i represents a FFT computation
-						DemodulatorThreadIQData *outp = outputBuffers.getBuffer();
+                        DemodulatorThreadIQDataPtr outp = outputBuffers.getBuffer();
+
 						outp->frequency = inputBuffer.frequency;
 						outp->sampleRate = inputBuffer.sampleRate;
 						outp->data.assign(inputBuffer.data.begin()+bufferOffset+i,

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <ThreadBlockingQueue.h>
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
+
 FFTDataDistributor::FFTDataDistributor() : outputBuffers("FFTDataDistributorBuffers"), fftSize(DEFAULT_FFT_SIZE), linesPerSecond(DEFAULT_WATERFALL_LPS), lineRateAccum(0.0) {
 
 }
@@ -29,7 +32,10 @@ void FFTDataDistributor::process() {
 			return;
 		}
 		DemodulatorThreadIQDataPtr inp;
-		input->pop(inp);
+
+        if (!input->pop(inp, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+            continue;
+        }
 
 		if (inp) {
             //Settings have changed, set new values and dump all previous samples stored in inputBuffer: 

--- a/src/process/ScopeVisualProcessor.cpp
+++ b/src/process/ScopeVisualProcessor.cpp
@@ -47,7 +47,7 @@ void ScopeVisualProcessor::process() {
     if (!isOutputEmpty()) {
         return;
     }
-    AudioThreadInput *audioInputData;
+    AudioThreadInputPtr audioInputData;
 
     if (input->try_pop(audioInputData)) {
           
@@ -56,11 +56,12 @@ void ScopeVisualProcessor::process() {
         }
         size_t i, iMax = audioInputData->data.size();
         if (!iMax) {
-            delete audioInputData; //->decRefCount();
+            //discard audioInputData.
+            audioInputData = nullptr;
             return;
         }
                 
-        ScopeRenderData *renderData = NULL;
+        ScopeRenderDataPtr renderData = nullptr;
         
         if (scopeEnabled) {
             iMax = audioInputData->data.size();
@@ -150,7 +151,7 @@ void ScopeVisualProcessor::process() {
             renderData->inputRate = audioInputData->inputRate;
             renderData->sampleRate = audioInputData->sampleRate;
             
-            delete audioInputData; //->decRefCount();
+            audioInputData = nullptr; //->decRefCount();
 
             double fft_ceil = 0, fft_floor = 1;
             
@@ -212,8 +213,6 @@ void ScopeVisualProcessor::process() {
             renderData->spectrum = true;
 
             distribute(renderData);
-        } else {
-            delete audioInputData; //->decRefCount();
-        }
+        } 
     } //end if try_pop()
 }

--- a/src/process/ScopeVisualProcessor.h
+++ b/src/process/ScopeVisualProcessor.h
@@ -6,8 +6,9 @@
 #include "VisualProcessor.h"
 #include "AudioThread.h"
 #include "ScopePanel.h"
+#include <memory>
 
-class ScopeRenderData: public ReferenceCounter {
+class ScopeRenderData {
 public:
 	std::vector<float> waveform_points;
     ScopePanel::ScopeMode mode = ScopePanel::SCOPE_MODE_Y;
@@ -17,9 +18,15 @@ public:
     bool spectrum;
     int fft_size;
     double fft_floor, fft_ceil;
+
+    virtual ~ScopeRenderData() {
+
+    }
 };
 
-typedef ThreadBlockingQueue<ScopeRenderData *> ScopeRenderDataQueue;
+typedef std::shared_ptr<ScopeRenderData> ScopeRenderDataPtr;
+
+typedef ThreadBlockingQueue<ScopeRenderDataPtr> ScopeRenderDataQueue;
 
 class ScopeVisualProcessor : public VisualProcessor<AudioThreadInput, ScopeRenderData> {
 public:

--- a/src/process/SpectrumVisualProcessor.cpp
+++ b/src/process/SpectrumVisualProcessor.cpp
@@ -192,7 +192,7 @@ void SpectrumVisualProcessor::process() {
         fftSizeChanged.store(false);
     }
 
-    DemodulatorThreadIQData *iqData;
+    DemodulatorThreadIQDataPtr iqData;
     
     input->pop(iqData);
     
@@ -200,14 +200,8 @@ void SpectrumVisualProcessor::process() {
         return;
     }
 
-   
-    //Start by locking concurrent access to iqData
-    std::lock_guard < std::recursive_mutex > lock(iqData->getMonitor());
-
     //then get the busy_lock
     std::lock_guard < std::mutex > busy_lock(busy_run);    
-
-
    
     bool doPeak = peakHold.load() && (peakReset.load() == 0);
     
@@ -246,7 +240,6 @@ void SpectrumVisualProcessor::process() {
         
         if (is_view.load()) {
             if (!iqData->sampleRate) {
-                iqData->decRefCount();
                
                 return;
             }
@@ -387,7 +380,7 @@ void SpectrumVisualProcessor::process() {
         }
         
         if (execute) {
-            SpectrumVisualData *output = outputBuffers.getBuffer();
+            SpectrumVisualDataPtr output = outputBuffers.getBuffer();
             
             if (output->spectrum_points.size() != fftSize * 2) {
                 output->spectrum_points.resize(fftSize * 2);
@@ -597,10 +590,7 @@ void SpectrumVisualProcessor::process() {
 
             distribute(output);
         }
-    }
- 
-    iqData->decRefCount();
-   
+    }  
     
     lastView = is_view.load();
 }

--- a/src/process/SpectrumVisualProcessor.cpp
+++ b/src/process/SpectrumVisualProcessor.cpp
@@ -4,6 +4,8 @@
 #include "SpectrumVisualProcessor.h"
 #include "CubicSDR.h"
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
 
 SpectrumVisualProcessor::SpectrumVisualProcessor() : outputBuffers("SpectrumVisualProcessorBuffers") {
     lastInputBandwidth = 0;
@@ -194,7 +196,9 @@ void SpectrumVisualProcessor::process() {
 
     DemodulatorThreadIQDataPtr iqData;
     
-    input->pop(iqData);
+    if (!input->pop(iqData, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+        return;
+    }
     
     if (!iqData) {
         return;

--- a/src/process/SpectrumVisualProcessor.h
+++ b/src/process/SpectrumVisualProcessor.h
@@ -6,20 +6,24 @@
 #include "VisualProcessor.h"
 #include "DemodDefs.h"
 #include <cmath>
+#include <memory>
 
 #define SPECTRUM_VZM 2
 #define PEAK_RESET_COUNT 30
 
-class SpectrumVisualData : public ReferenceCounter {
+class SpectrumVisualData {
 public:
     std::vector<float> spectrum_points;
     std::vector<float> spectrum_hold_points;
     double fft_ceiling, fft_floor;
     long long centerFreq;
     int bandwidth;
+
+    virtual ~SpectrumVisualData() {};
 };
 
-typedef ThreadBlockingQueue<SpectrumVisualData *> SpectrumVisualDataQueue;
+typedef std::shared_ptr<SpectrumVisualData> SpectrumVisualDataPtr;
+typedef ThreadBlockingQueue<SpectrumVisualDataPtr> SpectrumVisualDataQueue;
 
 class SpectrumVisualProcessor : public VisualProcessor<DemodulatorThreadIQData, SpectrumVisualData> {
 public:

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -170,7 +170,7 @@ protected:
             if (inp) {
                 OutputDataTypePtr outp = buffers.getBuffer();
 
-                //'deep copy of the contents 
+                //'deep copy' of the contents 
                 (*outp) = (*inp);
   
                 VisualProcessor<OutputDataType, OutputDataType>::distribute(outp);

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -9,11 +9,16 @@
 #include <algorithm>
 #include <vector>
 
-template<typename InputDataType = ReferenceCounter, typename OutputDataType = ReferenceCounter>
+template<typename InputDataType, typename OutputDataType>
 class VisualProcessor {
+    
     //
-    typedef  ThreadBlockingQueue<InputDataType*> VisualInputQueueType;
-    typedef  ThreadBlockingQueue<OutputDataType*> VisualOutputQueueType;
+    typedef std::shared_ptr<InputDataType> InputDataTypePtr;
+    typedef std::shared_ptr<OutputDataType> OutputDataTypePtr;
+
+    typedef  ThreadBlockingQueue<InputDataTypePtr> VisualInputQueueType;
+    typedef  ThreadBlockingQueue<OutputDataTypePtr> VisualOutputQueueType;
+
     typedef typename std::vector< VisualOutputQueueType *>::iterator outputs_i;
 public:
 	virtual ~VisualProcessor() {
@@ -96,22 +101,19 @@ protected:
     //available outputs, previously set by attachOutput().
     //* \param[in] timeout The number of microseconds to wait to push an item in each one of the outputs, 0(default) means indefinite wait.
     //* \param[in] errorMessage an error message written on std::cout in case pf push timeout.
-    void distribute(OutputDataType *item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT, const char* errorMessage = "") {
+    void distribute(OutputDataTypePtr item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT, const char* errorMessage = "") {
       
         std::lock_guard < std::recursive_mutex > busy_lock(busy_update);
         //We will try to distribute 'output' among all 'outputs',
-        //so 'output' will a-priori be shared among all 'outputs' so set its ref count to this 
-        //amount.
-        item->setRefCount((int)outputs.size());
+        //so 'output' will a-priori be shared among all 'outputs'.
+        
         for (outputs_i it = outputs.begin(); it != outputs.end(); it++) {
-            //if 'output' failed to be given to an outputs_i, dec its ref count accordingly.
-            //blocking push, with a timeout
+            //'output' can fail to be given to an outputs_i,
+            //using a blocking push, with a timeout
         	if (!(*it)->push(item, timeout, errorMessage)) {
-                item->decRefCount();
+                //TODO : trace ?
         	} 
         }
-        // Now 'item' refcount matches the times 'item' has been successfully distributed,
-        //i.e shared among the outputs.
     }
 
     //the incoming data queue 
@@ -127,7 +129,7 @@ protected:
 //Specialization much like VisualDataReDistributor, except 
 //the input (pointer) is directly re-dispatched
 //to outputs, so that all output indeed SHARE the same instance. 
-template<typename OutputDataType = ReferenceCounter>
+template<typename OutputDataType>
 class VisualDataDistributor : public VisualProcessor<OutputDataType, OutputDataType> {
 protected:
     virtual void process() {
@@ -136,18 +138,14 @@ protected:
             
             if (!VisualProcessor<OutputDataType, OutputDataType>::isAnyOutputEmpty()) {
                 if (inp) {
-            	    inp->decRefCount();
+            	    //nothing
                 }
                 return;
             }
       
             if (inp) {
-                int previousRefCount = inp->getRefCount();
             	VisualProcessor<OutputDataType, OutputDataType>::distribute(inp);
-                //inp is now shared through the distribute(), which overwrite the previous ref count,
-                //so increment it properly.
-                int distributeRefCount = inp->getRefCount();
-                inp->setRefCount(previousRefCount + distributeRefCount);
+                //inp is now shared through the distribute() call.
             }
         }
     }
@@ -155,7 +153,7 @@ protected:
 
 //specialization class which process() take an input item and re-dispatch
 //A COPY to every outputs, without further processing. This is a 1-to-n dispatcher. 
-template<typename OutputDataType = ReferenceCounter>
+template<typename OutputDataType>
 class VisualDataReDistributor : public VisualProcessor<OutputDataType, OutputDataType> {
 protected:
     virtual void process() {
@@ -164,15 +162,17 @@ protected:
             
             if (!VisualProcessor<OutputDataType, OutputDataType>::isAnyOutputEmpty()) {
                 if (inp) {
-            	    inp->decRefCount();
+            	    //nothing
                 }
                 return;
             }
             
             if (inp) {
-                OutputDataType *outp = buffers.getBuffer();
+                OutputDataTypePtr outp = buffers.getBuffer();
+
+                //'deep copy of the contents 
                 (*outp) = (*inp);
-                inp->decRefCount();
+  
                 VisualProcessor<OutputDataType, OutputDataType>::distribute(outp);
             }
         }

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -101,7 +101,7 @@ protected:
     //available outputs, previously set by attachOutput().
     //* \param[in] timeout The number of microseconds to wait to push an item in each one of the outputs, 0(default) means indefinite wait.
     //* \param[in] errorMessage an error message written on std::cout in case pf push timeout.
-    void distribute(OutputDataTypePtr item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT, const char* errorMessage = "") {
+    void distribute(OutputDataTypePtr item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT, const char* errorMessage = nullptr) {
       
         std::lock_guard < std::recursive_mutex > busy_lock(busy_update);
         //We will try to distribute 'output' among all 'outputs',

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -8,6 +8,9 @@
 #include <vector>
 #include <deque>
 
+//50 ms
+#define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
+
 SDRPostThread::SDRPostThread() : IOThread(), buffers("SDRPostThreadBuffers"), visualDataBuffers("SDRPostThreadVisualDataBuffers"), frequency(0) {
     iqDataInQueue = NULL;
     iqDataOutQueue = NULL;
@@ -185,7 +188,9 @@ void SDRPostThread::run() {
     while (!stopping) {
         SDRThreadIQDataPtr data_in;
         
-        iqDataInQueue->pop(data_in);
+        if (!iqDataInQueue->pop(data_in, HEARTBEAT_CHECK_PERIOD_MICROS)) {
+            continue;
+        }
         //        std::lock_guard < std::mutex > lock(data_in->m_mutex);
 
         std::lock_guard < std::mutex > lock(busy_demod);

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -221,8 +221,8 @@ void SDRPostThread::run() {
         iqVisualQueue->flush();   
     }
 
-   buffers.purge();
-   visualDataBuffers.purge();
+    //    buffers.purge();
+    //    visualDataBuffers.purge();
 
 //    std::cout << "SDR post-processing thread done." << std::endl;
 }

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -183,7 +183,7 @@ void SDRPostThread::run() {
     iqActiveDemodVisualQueue = static_cast<DemodulatorThreadInputQueue*>(getOutputQueue("IQActiveDemodVisualDataOutput"));
     
     while (!stopping) {
-        SDRThreadIQData *data_in;
+        SDRThreadIQDataPtr data_in;
         
         iqDataInQueue->pop(data_in);
         //        std::lock_guard < std::mutex > lock(data_in->m_mutex);
@@ -192,14 +192,14 @@ void SDRPostThread::run() {
 
         if (data_in && data_in->data.size()) {
             if(data_in->numChannels > 1) {
-                runPFBCH(data_in);
+                runPFBCH(data_in.get());
             } else {
-                runSingleCH(data_in);
+                runSingleCH(data_in.get());
             }
         }
 
         if (data_in) {
-            data_in->decRefCount();   
+            //nothing
         }
 
         bool doUpdate = false;
@@ -217,20 +217,19 @@ void SDRPostThread::run() {
     } //end while
     
     //Be safe, remove as many elements as possible
-    DemodulatorThreadIQData *visualDataDummy;
-    while (iqVisualQueue && iqVisualQueue->try_pop(visualDataDummy)) {
-        visualDataDummy->decRefCount();        
+    if (iqVisualQueue) {
+        iqVisualQueue->flush();   
     }
 
-    //    buffers.purge();
-    //    visualDataBuffers.purge();
+   buffers.purge();
+   visualDataBuffers.purge();
 
 //    std::cout << "SDR post-processing thread done." << std::endl;
 }
 
 void SDRPostThread::terminate() {
     IOThread::terminate();
-    SDRThreadIQData *dummy = new SDRThreadIQData;
+    SDRThreadIQDataPtr dummy(new SDRThreadIQData);
     //VSO: blocking push
     iqDataInQueue->push(dummy);
 }
@@ -278,8 +277,8 @@ void SDRPostThread::runSingleCH(SDRThreadIQData *data_in) {
     }
     
     if (refCount) {
-        DemodulatorThreadIQData *demodDataOut = buffers.getBuffer();
-        demodDataOut->setRefCount(refCount);
+        DemodulatorThreadIQDataPtr demodDataOut = buffers.getBuffer();
+
         demodDataOut->frequency = frequency;
         demodDataOut->sampleRate = sampleRate;
         
@@ -333,15 +332,13 @@ void SDRPostThread::runPFBCH(SDRThreadIQData *data_in) {
     }
     
     if (iqDataOutQueue != NULL && !iqDataOutQueue->full()) {
-        DemodulatorThreadIQData *iqDataOut = visualDataBuffers.getBuffer();
+        DemodulatorThreadIQDataPtr iqDataOut = visualDataBuffers.getBuffer();
         
         bool doVis = false;
         
         if (iqVisualQueue != NULL && !iqVisualQueue->full()) {
             doVis = true;
         }
-        
-        iqDataOut->setRefCount(1 + (doVis?1:0));
         
         iqDataOut->frequency = data_in->frequency;
         iqDataOut->sampleRate = data_in->sampleRate;
@@ -407,8 +404,7 @@ void SDRPostThread::runPFBCH(SDRThreadIQData *data_in) {
                 continue;
             }
             
-            DemodulatorThreadIQData *demodDataOut = buffers.getBuffer();
-            demodDataOut->setRefCount(demodChannelActive[i] + doDemodVis);
+            DemodulatorThreadIQDataPtr demodDataOut = buffers.getBuffer();
             demodDataOut->frequency = chanCenters[i];
             demodDataOut->sampleRate = chanBw;
             

--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <atomic>
-
+#include <memory>
 #include "ThreadBlockingQueue.h"
 #include "DemodulatorMgr.h"
 #include "SDRDeviceInfo.h"
@@ -17,7 +17,7 @@
 
 #include <stddef.h>
 
-class SDRThreadIQData: public ReferenceCounter {
+class SDRThreadIQData {
 public:
     long long frequency;
     long long sampleRate;
@@ -35,12 +35,12 @@ public:
 
     }
 
-    ~SDRThreadIQData() {
+    virtual ~SDRThreadIQData() {
 
     }
 };
-
-typedef ThreadBlockingQueue<SDRThreadIQData *> SDRThreadIQDataQueue;
+typedef std::shared_ptr<SDRThreadIQData> SDRThreadIQDataPtr;
+typedef ThreadBlockingQueue<SDRThreadIQDataPtr> SDRThreadIQDataQueue;
 
 class SDRThread : public IOThread {
 private:

--- a/src/util/ThreadBlockingQueue.h
+++ b/src/util/ThreadBlockingQueue.h
@@ -36,7 +36,7 @@ public:
 
     /*! Create safe blocking queue. */
     ThreadBlockingQueue() {
-        //at least 1 (== Exchanger)
+        //at least 1 (== Java SynchronizedQueue)
         m_max_num_items = MIN_ITEM_NB;
     };
     
@@ -258,7 +258,7 @@ public:
     }
 
 private:
-    //TODO: use a circular buffer structure ? (fixed array + modulo)
+
     std::deque<T> m_queue;
 
     mutable std::mutex m_mutex;

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -104,7 +104,7 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     wxPaintDC dc(this);
     const wxSize ClientSize = GetClientSize();
     
-    ScopeRenderData *avData;
+    ScopeRenderDataPtr avData;
     while (inputData.try_pop(avData)) {
        
         
@@ -113,7 +113,7 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
             if (avData->waveform_points.size()) {
                 scopePanel.setPoints(avData->waveform_points);
             }
-            avData->decRefCount();
+
         } else {
             if (avData->waveform_points.size()) {
                 spectrumPanel.setPoints(avData->waveform_points);
@@ -124,8 +124,7 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
                 spectrumPanel.setFFTSize(avData->fft_size);
                 spectrumPanel.setShowDb(showDb);
             }
-            
-            avData->decRefCount();
+         
         }
     }
 

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -54,7 +54,7 @@ void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     wxPaintDC dc(this);
     const wxSize ClientSize = GetClientSize();
     
-    SpectrumVisualData *vData;
+    SpectrumVisualDataPtr vData;
     if (visualDataQueue.try_pop(vData)) {
             
         if (vData) {
@@ -62,7 +62,6 @@ void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
             spectrumPanel.setPeakPoints(vData->spectrum_hold_points);
             spectrumPanel.setFloorValue(vData->fft_floor);
             spectrumPanel.setCeilValue(vData->fft_ceiling);
-            vData->decRefCount();
         }
     }
     

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -97,7 +97,7 @@ void WaterfallCanvas::processInputQueue() {
     if (linesPerSecond) {
         if (lpsIndex >= targetVis) {
             while (lpsIndex >= targetVis) {
-                SpectrumVisualData *vData;
+                SpectrumVisualDataPtr vData;
 
                 if (visualDataQueue.try_pop(vData)) {
                     
@@ -106,7 +106,7 @@ void WaterfallCanvas::processInputQueue() {
                             waterfallPanel.setPoints(vData->spectrum_points);
                         }
                         waterfallPanel.step();
-                        vData->decRefCount();
+                      
                         updated = true;
                     }
                     lpsIndex-=targetVis;
@@ -915,13 +915,7 @@ void WaterfallCanvas::setLinesPerSecond(int lps) {
     linesPerSecond = lps;
 
     //empty all
-    SpectrumVisualData *vData;
-    while (visualDataQueue.try_pop(vData)) {
-        
-        if (vData) {
-            vData->decRefCount();
-        }
-    }
+    visualDataQueue.flush();
 }
 
 void WaterfallCanvas::setMinBandwidth(int min) {


### PR DESCRIPTION
@cjcliffe  Hello !
Time to another major break in the code.
This PR is about using ``std::shared_ptr`` in ReBuffer, completly removing the need of manual ``setRefCount()`` and ``getRefCount()``, which is error prone, and sometimes impossible to set properly according to objects real lifetimes.
So we gain:
-  Simplified ReBuffer usage, 
-  Correct ref-counting in all situations (ex: no longer concurrent set/getRefCount update troubles),
-  Somewhat better memory management and CPU consumption,
- Resurrected the previous ``ThreadBlockingQueue`` using ``std::deque``, needed to play nice with ``std::shared_ptr``. 
Indeed while used as ``ThreadBlockingQueue< std::shared_ptr< T > >``, the container have to be well behaved w.r.t destructors, so I would have to call elements destructors explicitly belonging to the underlying ``m_circular_buffer`` exactly like in a traditional container, and so on...

I observed that using the circular buffer impl of ``ThreadBlockingQueue`` in the [vso_ReBuffer_with_shared_ptr](https://github.com/cjcliffe/CubicSDR/tree/vso_ReBuffer_with_shared_ptr) branch created memory leaks because the m_circular_buffer kept references alive. (exact same problem as in Java !)

At that point I didn't want to complicate further the circular buffer impl, all the more that it didn't bring any visible performance gain compared to the usage of a ``std::deque``. Well, turns out STL is quite good, what a surprise.
 
Also in this PR I think I crushed the application hung problem for good. See commit comments:)
