### PR TITLE
CubicVR2  removal of convert to pointer operators (fixes #550)

### DIFF
--- a/external/cubicvr2/math/mat3.h
+++ b/external/cubicvr2/math/mat3.h
@@ -12,7 +12,7 @@
 #include <iostream>
 #include "vec3.h"
 #include <cstring>
-
+#include <stddef.h>
 namespace CubicVR {
 
     #define mat3SG(c,x,y) \
@@ -20,14 +20,20 @@ namespace CubicVR {
         c & COMBINE(set,x)(mat3 value) { y = value; return *this; }
 
     struct mat3 {
+       
         __float a,b,c,d,e,f,g,h,i;
-
-        //        __float  operator [] (unsigned i) const { return ((__float *)this)[i]; }
-#ifndef _WIN32
-        __float& operator [] (unsigned i)       { return ((__float *)this)[i]; }
-#endif
-        operator __float*() const { return (__float *)this; }
+      
+        //access as-array:
+        inline __float& operator [] (size_t i) {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
         
+        inline const __float& operator [] (size_t i) const { 
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
+    
         mat3(__float ai,__float bi,__float ci,__float di,__float ei,__float fi,__float gi,__float hi,__float ii) {
             a = ai; b = bi; c = ci; d = di; e = ei; f = fi; g = gi; h = hi; i = ii;
         };

--- a/external/cubicvr2/math/mat4.h
+++ b/external/cubicvr2/math/mat4.h
@@ -15,21 +15,44 @@
 #include "vec4.h"
 #include "mat3.h"
 #include <cmath>
+#include <stddef.h>
 
 namespace CubicVR {
     using namespace std;
     #define mat4SG(c,x,y) \
         mat4 COMBINE(get,x)() { return y; } \
         c & COMBINE(set,x)(mat4 value) { y = value; return *this; }
+
     struct mat4 {
-        __float a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p;
+      
+         //16 elements
+         __float a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p;
+      
+        //access as-array:
+        inline __float& operator [] (size_t i) {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
 
-        //        __float  operator [] (unsigned i) const { return ((__float *)this)[i]; }
-#ifndef _WIN32
-        __float& operator [] (unsigned i)       { return ((__float *)this)[i]; }
-#endif
+        inline const __float& operator [] (size_t i) const {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
 
-        operator __float*() const { return (__float *)this; }
+        //compare to ZERO-filled matrix
+        inline operator bool() const {
+            
+            return (a != 0.0f || b != 0.0f || c != 0.0f || d != 0.0f ||
+                e != 0.0f || f != 0.0f || g != 0.0f || h != 0.0f ||
+                i != 0.0f || j != 0.0f || k != 0.0f || l != 0.0f ||
+                m != 0.0f || n != 0.0f || o != 0.0f || p != 0.0f);
+        }
+
+        //To be accessed by GL API directly, accessed by pointer.
+        //operator* overloading is way too dangerous, especially in ptr != NULL
+        //tests.
+       inline  float* to_ptr() const { return (__float *)this; }
+
         mat4(__float ai,__float bi,__float ci,__float di,__float ei,__float fi,__float gi,__float hi,__float ii,__float ji,__float ki,__float li,__float mi,__float ni,__float oi,__float pi) {
             a = ai; b = bi; c = ci; d = di; e = ei; f = fi; g = gi; h = hi; i = ii; j = ji; k = ki; l = li; m = mi; n = ni; o = oi; p = pi;
         }
@@ -263,15 +286,15 @@ namespace CubicVR {
         static mat4 transform(vec3 position, vec3 rotation, vec3 scale) {
             mat4 m = mat4::identity();
             
-            if (position!=NULL) {
+            if (!position) {
                 m *= mat4::translate(position[0],position[1],position[2]);
             }
-            if (rotation!=NULL) {
+            if (!rotation) {
                 if (!(rotation[0] == 0 && rotation[1] == 0 && rotation[2] == 0)) {
                     m *= mat4::rotate(rotation[0],rotation[1],rotation[2]);
                 }
             }
-            if (scale!=NULL) {
+            if (!scale) {
                 if (!(scale[0] == 1 && scale[1] == 1 && scale[2] == 1)) {
                     m *= mat4::scale(scale[0],scale[1],scale[2]);
                 }

--- a/external/cubicvr2/math/mat4.h
+++ b/external/cubicvr2/math/mat4.h
@@ -39,15 +39,6 @@ namespace CubicVR {
             return (as_array[i]);
         }
 
-        //compare to ZERO-filled matrix
-        inline operator bool() const {
-            
-            return (a != 0.0f || b != 0.0f || c != 0.0f || d != 0.0f ||
-                e != 0.0f || f != 0.0f || g != 0.0f || h != 0.0f ||
-                i != 0.0f || j != 0.0f || k != 0.0f || l != 0.0f ||
-                m != 0.0f || n != 0.0f || o != 0.0f || p != 0.0f);
-        }
-
         //To be accessed by GL API directly, accessed by pointer.
         //operator* overloading is way too dangerous, especially in ptr != NULL
         //tests.
@@ -286,22 +277,19 @@ namespace CubicVR {
         static mat4 transform(vec3 position, vec3 rotation, vec3 scale) {
             mat4 m = mat4::identity();
             
-            if (!position) {
-                m *= mat4::translate(position[0],position[1],position[2]);
+            m *= mat4::translate(position[0],position[1],position[2]);
+          
+            if (!(rotation[0] == 0 && rotation[1] == 0 && rotation[2] == 0)) {
+                m *= mat4::rotate(rotation[0], rotation[1], rotation[2]);    
             }
-            if (!rotation) {
-                if (!(rotation[0] == 0 && rotation[1] == 0 && rotation[2] == 0)) {
-                    m *= mat4::rotate(rotation[0],rotation[1],rotation[2]);
-                }
-            }
-            if (!scale) {
-                if (!(scale[0] == 1 && scale[1] == 1 && scale[2] == 1)) {
-                    m *= mat4::scale(scale[0],scale[1],scale[2]);
-                }
+             
+            if (!(scale[0] == 1 && scale[1] == 1 && scale[2] == 1)) {
+                m *= mat4::scale(scale[0],scale[1],scale[2]);
             }
             
             return m;
         };
+
         static vec4 vec4_multiply(vec4 m1, mat4 m2) {
             vec4 mOut;
 

--- a/external/cubicvr2/math/transform.h
+++ b/external/cubicvr2/math/transform.h
@@ -73,7 +73,7 @@ namespace CubicVR {
         
         void pushMatrix(mat4 m) {
             c_stack++;
-            m_stack[c_stack] = (m ? m : getIdentity());
+            m_stack[c_stack] = m;
         }
         
         void popMatrix() {
@@ -91,11 +91,7 @@ namespace CubicVR {
 
             result = mat4::identity();
             
-            if (!init_mat) {
-                m_stack[0] = init_mat;
-            } else {
-                setIdentity();
-            }
+            m_stack[0] = init_mat; 
         }
         
         void translate(__float x, __float y, __float z) {

--- a/external/cubicvr2/math/transform.h
+++ b/external/cubicvr2/math/transform.h
@@ -88,10 +88,10 @@ namespace CubicVR {
             m_cache.clear();
             c_stack = 0;
             valid = 0;
-            delete result;
+
             result = mat4::identity();
             
-            if (init_mat != NULL) {
+            if (!init_mat) {
                 m_stack[0] = init_mat;
             } else {
                 setIdentity();

--- a/external/cubicvr2/math/vec2.h
+++ b/external/cubicvr2/math/vec2.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <cmath>
 #include "cubic_types.h"
+#include <stddef.h>
 
 namespace CubicVR {
     #define vec2SG(c,x,y) \
@@ -20,20 +21,27 @@ namespace CubicVR {
 
     struct vec2 {
         __float x, y;
+
     public:
         __float& u() { return x; }
         __float& v() { return y; }
         
-//        __float  operator [] (unsigned i) const { return ((__float *)this)[i]; }
-#ifndef _WIN32
-		__float& operator [] (unsigned i)       { return ((__float *)this)[i]; }
-#endif        
+        //access as-array:
+        inline __float& operator [] (size_t i) {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
+
+        inline const __float& operator [] (size_t i) const {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
+
         vec2 (__float xi,__float yi) { x = xi; y = yi;  }
         vec2 () { x = y = 0.0f; }
-        
-        operator __float*() const { return (__float *)this; }
-        
+         
         vec2 operator*(__float v) { return vec2( x*v, y*v ); }
+
         //    vec2 operator*(vec2 v) { return vec2::cross(*this,v); }
         vec2 operator+(vec2 v) { return vec2::add(*this,v); }
         vec2 operator-(vec2 v) { return vec2::subtract(*this,v); }

--- a/external/cubicvr2/math/vec3.h
+++ b/external/cubicvr2/math/vec3.h
@@ -39,12 +39,6 @@ namespace CubicVR {
             return (as_array[i]);
         }
 
-        //compare to ZERO-filled vector
-        inline operator bool() const {
-
-            return (x != 0.0f || y != 0.0f || z != 0.0f);
-        }
-
         vec3 (__float xi,__float yi,__float zi) { x = xi; y = yi; z = zi; }
         vec3 () { x = y = z = 0.0f; }
         

--- a/external/cubicvr2/math/vec3.h
+++ b/external/cubicvr2/math/vec3.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include "cubic_types.h"
 #include <cmath>
+#include <stddef.h>
 
 namespace CubicVR {
     
@@ -23,18 +24,29 @@ namespace CubicVR {
     struct vec3 {
         __float x,y,z;
 
-        operator __float*() const { return (__float *)this; }
-
         __float& r() { return x; }
         __float& g() { return y; }
         __float& b() { return z; }
         
-#ifndef _WIN32
-        __float& operator [] (unsigned i)       { return ((__float *)this)[i]; }
-#endif
+        //access as-array:
+        inline __float& operator [] (size_t i) {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
+
+        inline const __float& operator [] (size_t i) const {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
+
+        //compare to ZERO-filled vector
+        inline operator bool() const {
+
+            return (x != 0.0f || y != 0.0f || z != 0.0f);
+        }
+
         vec3 (__float xi,__float yi,__float zi) { x = xi; y = yi; z = zi; }
         vec3 () { x = y = z = 0.0f; }
-        
         
         vec3 operator*(__float v) { return vec3(x*v, y*v, z*v); }
         vec3 operator*(vec3 v) { return vec3::cross(*this,v); }

--- a/external/cubicvr2/math/vec4.h
+++ b/external/cubicvr2/math/vec4.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include "cubic_types.h"
 #include <cmath>
+#include <stddef.h>
 
 namespace CubicVR {
 
@@ -20,22 +21,28 @@ namespace CubicVR {
     c & COMBINE(set,x)(vec3 value) { y = value; return *this; }
 
     struct vec4 {
-        __float x,y,z,w;
+
+        __float x, y, z, w;
+
     public:
         __float& r() { return x; }
         __float& g() { return y; }
         __float& b() { return z; }
         __float& a() { return w; }
         
-//        __float  operator [] (unsigned i) const { return ((__float *)this)[i]; }
-#ifndef _WIN32
-        __float& operator [] (unsigned i)       { return ((__float *)this)[i]; }
-#endif
+        //access as-array:
+        inline __float& operator [] (size_t i) {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
+
+        inline const __float& operator [] (size_t i) const {
+            __float* as_array = (__float*)this;
+            return (as_array[i]);
+        }
 
         vec4 (__float xi,__float yi,__float zi,__float wi) { x = xi; y = yi; z = zi; w = wi; }
         vec4 () { x = y = z = w =  0.0f; }
-        
-        operator __float*() const { return (__float *)this; }
         
         vec4 operator*(__float v) { return vec4(x*v, y*v, z*v, w*v); }
 //        vec4 operator*(vec4 v) { return vec4::cross(*this,v); }

--- a/src/panel/ScopePanel.cpp
+++ b/src/panel/ScopePanel.cpp
@@ -35,7 +35,7 @@ void ScopePanel::drawPanelContents() {
         bgPanel.draw();
         glLineWidth(1.0);
         glEnable(GL_LINE_SMOOTH);
-        glLoadMatrixf(transform);
+        glLoadMatrixf(transform.to_ptr());
         glColor3f(ThemeMgr::mgr.currentTheme->scopeLine.r * 0.35, ThemeMgr::mgr.currentTheme->scopeLine.g * 0.35,
                   ThemeMgr::mgr.currentTheme->scopeLine.b * 0.35);
         glBegin (GL_LINES);
@@ -52,7 +52,7 @@ void ScopePanel::drawPanelContents() {
         bgPanelStereo[1].draw();
 
         glLineWidth(1.0);
-        glLoadMatrixf(transform);
+        glLoadMatrixf(transform.to_ptr());
         glColor3f(ThemeMgr::mgr.currentTheme->scopeLine.r, ThemeMgr::mgr.currentTheme->scopeLine.g, ThemeMgr::mgr.currentTheme->scopeLine.b);
         glEnable(GL_LINE_SMOOTH);
         glBegin (GL_LINES);
@@ -76,7 +76,7 @@ void ScopePanel::drawPanelContents() {
         glLineWidth(1.0);
         glEnable(GL_POINT_SMOOTH);
         glPointSize(1.0);
-        glLoadMatrixf(transform);
+        glLoadMatrixf(transform.to_ptr());
         glColor3f(ThemeMgr::mgr.currentTheme->scopeLine.r * 0.15, ThemeMgr::mgr.currentTheme->scopeLine.g * 0.15,
                   ThemeMgr::mgr.currentTheme->scopeLine.b * 0.15);
     }
@@ -95,16 +95,16 @@ void ScopePanel::drawPanelContents() {
         glVertexPointer(2, GL_FLOAT, 0, &points[0]);
         glLineWidth(1.5);
         if (scopeMode == SCOPE_MODE_Y) {
-            glLoadMatrixf(bgPanel.transform);
+            glLoadMatrixf(bgPanel.transform.to_ptr());
             glDrawArrays(GL_LINE_STRIP, 0, points.size() / 2);
         } else if (scopeMode == SCOPE_MODE_2Y)  {
-            glLoadMatrixf(bgPanelStereo[0].transform);
+            glLoadMatrixf(bgPanelStereo[0].transform.to_ptr());
             glDrawArrays(GL_LINE_STRIP, 0, points.size() / 4);
 
-            glLoadMatrixf(bgPanelStereo[1].transform);
+            glLoadMatrixf(bgPanelStereo[1].transform.to_ptr());
             glDrawArrays(GL_LINE_STRIP, points.size() / 4, points.size() / 4);
         } else if (scopeMode == SCOPE_MODE_XY) {
-            glLoadMatrixf(bgPanel.transform);
+            glLoadMatrixf(bgPanel.transform.to_ptr());
             glDrawArrays(GL_POINTS, 0, points.size() / 2);
         }
         glLineWidth(1.0);

--- a/src/panel/SpectrumPanel.cpp
+++ b/src/panel/SpectrumPanel.cpp
@@ -113,7 +113,7 @@ void SpectrumPanel::drawPanelContents() {
     glEnable(GL_LINE_SMOOTH);
     glHint( GL_LINE_SMOOTH_HINT, GL_NICEST );
 
-    glLoadMatrixf(transform * (CubicVR::mat4::translate(-1.0f, -0.75f, 0.0f) * CubicVR::mat4::scale(2.0f, 1.5f, 1.0f)));
+    glLoadMatrixf((transform * (CubicVR::mat4::translate(-1.0f, -0.75f, 0.0f) * CubicVR::mat4::scale(2.0f, 1.5f, 1.0f))).to_ptr());
 
     if (points.size()) {
         glBlendFunc(GL_SRC_ALPHA, GL_ONE);
@@ -166,7 +166,7 @@ void SpectrumPanel::drawPanelContents() {
     
     float viewHeight = (float) vp[3];
     float viewWidth = (float) vp[2];
-    glLoadMatrixf(transform);
+    glLoadMatrixf(transform.to_ptr());
 
     
     long long leftFreq = (double) freq - ((double) bandwidth / 2.0);

--- a/src/panel/WaterfallPanel.cpp
+++ b/src/panel/WaterfallPanel.cpp
@@ -165,7 +165,7 @@ void WaterfallPanel::drawPanelContents() {
 
     int half_fft_size = fft_size / 2;
     
-    glLoadMatrixf(transform);
+    glLoadMatrixf(transform.to_ptr());
     
     glEnable (GL_TEXTURE_2D);
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_DECAL);

--- a/src/ui/GLPanel.cpp
+++ b/src/ui/GLPanel.cpp
@@ -308,7 +308,7 @@ void GLPanel::calcTransform(mat4 transform_in) {
 void GLPanel::draw() {
     float min = -1.0, max = 1.0;
 
-    glLoadMatrixf(transform);
+    glLoadMatrixf(transform.to_ptr());
     
     if (fillType != GLPANEL_FILL_NONE && visible) {
         glEnable(GL_BLEND);
@@ -378,7 +378,7 @@ void GLPanel::draw() {
         }
         //        if (coord == GLPANEL_Y_UP) {
         //        }
-        glLoadMatrixf(transform * mCoord);
+        glLoadMatrixf((transform * mCoord).to_ptr());
         drawPanelContents();
     }
 }

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -148,7 +148,7 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    glLoadMatrixf(CubicVR::mat4::perspective(45.0, 1.0, 1.0, 1000.0));
+    glLoadMatrixf(CubicVR::mat4::perspective(45.0, 1.0, 1.0, 1000.0).to_ptr());
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     
@@ -210,7 +210,7 @@ void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
         spectrumPanel.drawChildren();
     }
     
-    glLoadMatrixf(scopePanel.transform);
+    glLoadMatrixf(scopePanel.transform.to_ptr());
     if (!deviceName.empty()) {
         glContext->DrawDeviceName(deviceName);
     }


### PR DESCRIPTION
@cjcliffe This fixes #550 where @braselectron couldn't compile on Ubuntu 14.04.5 LTS 32bit.
The reason is that the ``operator __float*() const`` confuses the Gcc 4.8 compiler.

So this PR removes all convert-to-pointer of ``CubicVR2`` structures, which turns were not really needed, and authorized incredibly dangerous conversions and tests against NULL, and so on.
Modifications:
-  Removed all ``operator __float*() const``, 
-  Changed  ``CubicVR2`` to remove the few NULL-checks based on this operator,
-  Added a ``__float mat4::to_ptr()`` explicit method for direct access by GL APIs in CubicSDR code,
-  Changed in CubicSDR the few  access-through-pointer calls by ``to_ptr()``
 