### PR TITLE
Change boolean to bool

### DIFF
--- a/src/demod/DemodulatorMgr.cpp
+++ b/src/demod/DemodulatorMgr.cpp
@@ -278,7 +278,7 @@ DemodulatorInstance *DemodulatorMgr::getLastDemodulatorWith(const std::string& t
 	return nullptr;
 }
 
-void DemodulatorMgr::garbageCollect(boolean forcedGC) {
+void DemodulatorMgr::garbageCollect(bool forcedGC) {
     
     std::lock_guard < std::mutex > lock(deleted_demods_busy);
 

--- a/src/demod/DemodulatorMgr.h
+++ b/src/demod/DemodulatorMgr.h
@@ -73,7 +73,7 @@ public:
     //all deleted demodulators are effectively GCed.
     //else: (default) the method test for effective termination
     //and GC one demod per call. 
-    void garbageCollect(boolean forcedGC = false);
+    void garbageCollect(bool forcedGC = false);
     
 private:
 


### PR DESCRIPTION
boolean needs changed to bool for garbageCollect in both DemodulatorMgr.cpp and DemodulatorMgr.h. It causes a compile error since boolean in not a recognized keyword for C++. Compiles fine after changing both files.

Sorry for the 2 pull requests, I caught the dumb.