### PR TITLE
Avoid build failure when liquid-dsp is not in a default libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,7 +672,7 @@ IF (NOT BUNDLE_APP)
         configure_files(${CUBICSDR_HEADER_IMAGE_DIR} ${CMAKE_BINARY_DIR}/${EX_PLATFORM_NAME} ${CUBICSDR_HEADER_IMAGE_FILE})
     ENDIF()
     add_executable(CubicSDR ${cubicsdr_sources} ${cubicsdr_headers} ${RES_FILES})
-    target_link_libraries(CubicSDR ${LIQUID_LIB} ${wxWidgets_LIBRARIES} ${OPENGL_LIBRARIES} ${OTHER_LIBRARIES})
+    target_link_libraries(CubicSDR ${wxWidgets_LIBRARIES} ${OPENGL_LIBRARIES} ${OTHER_LIBRARIES})
 ENDIF (NOT BUNDLE_APP)
 
 IF (MSVC)


### PR DESCRIPTION
Hello

on my system libliquiddsp is installed in my home directory.

The presence of -lliquid in the linker command line breaks the build if -lliquid cannot be found in any default directory, moreover this switch is set before any lib directory is set.

In fact, this switch is unnecessary since liquiddsp is explicitly linked via its correct full path later in the command line (below for reference). I suspect this is a leftover from previous development stages, since the problematic cmake variable is not used elsewhere.

Removing this variable allowed CubicSDR be to build on my system.

Congrats, that softare is beautiful.

Annex: failing link command line (before fix) via make VERBOSE=1
```
[100%] Linking CXX executable x64/CubicSDR
/usr/bin/cmake -E cmake_link_script CMakeFiles/CubicSDR.dir/link.txt --verbose=1
/usr/bin/c++
		-pthread 
		-fvisibility-inlines-hidden 
		-O3 
		-DNDEBUG   
(all compiled objects)
		-o x64/CubicSDR 
		-rdynamic 
		-lliquid 
		-L/usr/lib/x86_64-linux-gnu 
		-pthread 
		-lwx_gtk2u_gl-3.0 
		-lwx_gtk2u_core-3.0 
		-lwx_gtk2u_propgrid-3.0 
		-lwx_gtk2u_adv-3.0 
		-lwx_baseu-3.0 
		-lGLU 
		-lGL 
		/home/joe/sys/lib/libSoapySDR.so 
		/home/joe/sys/lib/libliquid.so -ldl -lpulse-simple -lpulse -Wl,-rpath,/home/joe/sys/lib:
/usr/bin/ld: cannot find -lliquid
```

BTW, it works perfectly with the wxgtk 3.0.2 from my mint18 system, no need to build wxwidgets 3.1
