### PR TITLE
Add  Antenna support (RX only), plus improved Settings menu.

### DIFF
--- a/src/AppConfig.h
+++ b/src/AppConfig.h
@@ -31,6 +31,9 @@ public:
     void setSampleRate(long srate);
     long getSampleRate();
 
+    void setAntennaName(const std::string& name);
+    const std::string& getAntennaName();
+
     void setAGCMode(bool agcMode);
     bool getAGCMode();
     
@@ -64,12 +67,14 @@ public:
 private:
     std::string deviceId;
     std::string deviceName;
+
     std::mutex busy_lock;
 
     std::atomic_int ppm;
     std::atomic_llong offset;
     std::atomic_bool agcMode;
     std::atomic_long sampleRate;
+    std::string antennaName;
     ConfigSettings streamOpts;
     ConfigGains gains;
     std::map<std::string, std::string> settings;

--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -752,11 +752,13 @@ void AppFrame::updateDeviceParams() {
 
     newSettingsMenu->AppendSeparator();
 
-    newSettingsMenu->Append(wxID_SET_DB_OFFSET, "Power Level Offset");
-    newSettingsMenu->Append(wxID_SET_FREQ_OFFSET, "Frequency Offset");
+    settingsMenuItems.clear();
+
+    settingsMenuItems[wxID_SET_DB_OFFSET] = newSettingsMenu->Append(wxID_SET_DB_OFFSET, wxT("Power Level Offset :  ") + std::to_string(wxGetApp().getConfig()->getDBOffset()) + wxT(" dB"));
+    settingsMenuItems[wxID_SET_FREQ_OFFSET] =  newSettingsMenu->Append(wxID_SET_FREQ_OFFSET, wxT("Frequency Offset :  ") + std::to_string(wxGetApp().getOffset()) + wxT(" Hz"));
 
     if (devInfo->hasCORR(SOAPY_SDR_RX, 0)) {
-        newSettingsMenu->Append(wxID_SET_PPM, "Device PPM");
+        settingsMenuItems[wxID_SET_PPM] = newSettingsMenu->Append(wxID_SET_PPM, wxT("Device PPM :  ") + std::to_string(wxGetApp().getPPM()) + wxT(" ppm"));
     }
 
     if (devInfo->getDriver() != "rtlsdr") {
@@ -771,7 +773,43 @@ void AppFrame::updateDeviceParams() {
     } else if (!wxGetApp().getAGCMode()) {
         wxGetApp().setAGCMode(true);
     }
-    
+
+    //Add an Antenna menu if more than one (RX) antenna, to keep the UI free of useless entries
+    antennaNames.clear();
+    antennaMenuItems.clear();
+    std::vector<std::string> availableAntennas = devInfo->getAntennaNames(SOAPY_SDR_RX, 0);
+ 
+    if (availableAntennas.size() > 1) {
+              
+        newSettingsMenu->AppendSeparator();
+
+        antennaNames = availableAntennas;
+
+        wxMenu *subMenu = new wxMenu;
+        
+        int i = 0;
+        std::string antennaChecked;
+        for (std::string currentAntenna : availableAntennas) {
+           
+            antennaMenuItems[wxID_ANTENNAS_BASE + i] = subMenu->AppendRadioItem(wxID_ANTENNAS_BASE + i, currentAntenna);
+
+            if (wxGetApp().getAntennaName() == currentAntenna) {
+                antennaMenuItems[wxID_ANTENNAS_BASE + i]->Check(true);
+                antennaChecked = currentAntenna;
+            }
+
+            i++;
+        }
+        antennaMenuItems[wxID_ANTENNA_CURRENT] = newSettingsMenu->AppendSubMenu(subMenu, "Antenna");
+        
+        //Change the Antenna label to indicate the current antenna.
+        if (!antennaChecked.empty()) {
+            antennaMenuItems[wxID_ANTENNA_CURRENT]->SetItemLabel(wxT("Antenna :  ") + antennaChecked);
+        }
+    }
+   
+    //Runtime settings part
+     
     SoapySDR::ArgInfoList::const_iterator args_i;
     settingArgs = soapyDev->getSettingInfo();
 
@@ -790,15 +828,17 @@ void AppFrame::updateDeviceParams() {
             item->Check(currentVal=="true");
             i++;
         } else if (arg.type == SoapySDR::ArgInfo::INT) {
-            newSettingsMenu->Append(wxID_SETTINGS_BASE+i, arg.name, arg.description);
+            
+            settingsMenuItems[wxID_SETTINGS_BASE + i] = newSettingsMenu->Append(wxID_SETTINGS_BASE + i, wxString(arg.name) + " :  "  + currentVal, arg.description);
             i++;
         } else if (arg.type == SoapySDR::ArgInfo::FLOAT) {
-            newSettingsMenu->Append(wxID_SETTINGS_BASE+i, arg.name, arg.description);
+            settingsMenuItems[wxID_SETTINGS_BASE + i] = newSettingsMenu->Append(wxID_SETTINGS_BASE + i, wxString(arg.name) + " :  " + currentVal, arg.description);
             i++;
         } else if (arg.type == SoapySDR::ArgInfo::STRING) {
             if (arg.options.size()) {
                 wxMenu *subMenu = new wxMenu;
                 int j = 0;
+                std::vector<int> subItemsIds;
 				//for each of this options
                 for (std::string optName : arg.options) {
 					//by default the option name is the same as the displayed name.
@@ -808,15 +848,21 @@ void AppFrame::updateDeviceParams() {
                         displayName = arg.optionNames[j];
                     }
                     wxMenuItem *item = subMenu->AppendRadioItem(wxID_SETTINGS_BASE+i, displayName);
+                    subItemsIds.push_back(wxID_SETTINGS_BASE + i);
+                    
                     if (currentVal == optName) {
                         item->Check(true);
                     }
                     j++;
                     i++;
                 }
-                newSettingsMenu->AppendSubMenu(subMenu, arg.name, arg.description);
+                settingsMenuItems[wxID_SETTINGS_BASE + i] = newSettingsMenu->AppendSubMenu(subMenu, wxString(arg.name) + " :  " + currentVal, arg.description);
+                //map subitems ids to their parent item !
+                for (int currentSubId : subItemsIds) {
+                    settingsMenuItems[currentSubId] = settingsMenuItems[wxID_SETTINGS_BASE + i];
+                }
             } else {
-                newSettingsMenu->Append(wxID_SETTINGS_BASE+i, arg.name, arg.description);
+                settingsMenuItems[wxID_SETTINGS_BASE + i] = newSettingsMenu->Append(wxID_SETTINGS_BASE + i, wxString(arg.name) + " :  " + currentVal, arg.description);
                 i++;
             }
         }
@@ -1104,7 +1150,14 @@ bool AppFrame::actionOnMenuAbout(wxCommandEvent& event) {
 
 bool AppFrame::actionOnMenuSettings(wxCommandEvent& event) {
 
-    if (event.GetId() >= wxID_SETTINGS_BASE && event.GetId() < settingsIdMax) {
+    if (event.GetId() >= wxID_ANTENNAS_BASE && event.GetId() < wxID_ANTENNAS_BASE + antennaNames.size()) {
+
+        wxGetApp().setAntennaName(antennaNames[event.GetId() - wxID_ANTENNAS_BASE]);
+
+        antennaMenuItems[wxID_ANTENNA_CURRENT]->SetItemLabel(wxT("Antenna :  ") + wxGetApp().getAntennaName());
+        return true;
+    } 
+    else if (event.GetId() >= wxID_SETTINGS_BASE && event.GetId() < settingsIdMax) {
 
         int setIdx = event.GetId() - wxID_SETTINGS_BASE;
         int menuIdx = 0;
@@ -1115,6 +1168,9 @@ bool AppFrame::actionOnMenuSettings(wxCommandEvent& event) {
             if (arg.type == SoapySDR::ArgInfo::STRING && arg.options.size() && setIdx >= menuIdx && setIdx < menuIdx + (int)arg.options.size()) {
                 int optIdx = setIdx - menuIdx;
                 wxGetApp().getSDRThread()->writeSetting(arg.key, arg.options[optIdx]);
+                //update parent menu item label to display the current value
+                settingsMenuItems[menuIdx + wxID_SETTINGS_BASE]->SetItemLabel(wxString(arg.name) + " :  " + arg.options[optIdx]);
+              
                 break;
             }
             else if (arg.type == SoapySDR::ArgInfo::STRING && arg.options.size()) {
@@ -1127,6 +1183,9 @@ bool AppFrame::actionOnMenuSettings(wxCommandEvent& event) {
                 }
                 else if (arg.type == SoapySDR::ArgInfo::STRING) {
                     wxString stringVal = wxGetTextFromUser(arg.description, arg.name, wxGetApp().getSDRThread()->readSetting(arg.key));
+
+                    settingsMenuItems[menuIdx + wxID_SETTINGS_BASE]->SetItemLabel(wxString(arg.name) + " :  " + stringVal);
+
                     if (stringVal.ToStdString() != "") {
                         wxGetApp().getSDRThread()->writeSetting(arg.key, stringVal.ToStdString());
                     }
@@ -1141,6 +1200,9 @@ bool AppFrame::actionOnMenuSettings(wxCommandEvent& event) {
                         currentVal = 0;
                     }
                     int intVal = wxGetNumberFromUser(arg.description, arg.units, arg.name, currentVal, arg.range.minimum(), arg.range.maximum(), this);
+
+                    settingsMenuItems[menuIdx + wxID_SETTINGS_BASE]->SetItemLabel(wxString(arg.name) + " :  " + std::to_string(intVal));
+
                     if (intVal != -1) {
                         wxGetApp().getSDRThread()->writeSetting(arg.key, std::to_string(intVal));
                     }
@@ -1154,6 +1216,7 @@ bool AppFrame::actionOnMenuSettings(wxCommandEvent& event) {
                     catch (std::invalid_argument e) {
                         // ...
                     }
+                    settingsMenuItems[menuIdx + wxID_SETTINGS_BASE]->SetItemLabel(wxString(arg.name) + " :  " + floatVal);
                     break;
                 }
                 else {
@@ -1508,6 +1571,8 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
                 "Frequency Offset", wxGetApp().getOffset(), -2000000000, 2000000000, this);
         if (ofs != -1) {
             wxGetApp().setOffset(ofs);
+          
+            settingsMenuItems[wxID_SET_FREQ_OFFSET]->SetItemLabel(wxT("Frequency Offset :  ") + std::to_string(wxGetApp().getOffset()) + wxT(" Hz"));
         }
     } 
     else if (event.GetId() == wxID_SET_DB_OFFSET) {
@@ -1515,6 +1580,7 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
                                        "Power Level Offset", wxGetApp().getConfig()->getDBOffset(), -1000, 1000, this);
         if (ofs != -1) {
             wxGetApp().getConfig()->setDBOffset(ofs);
+            settingsMenuItems[wxID_SET_DB_OFFSET]->SetItemLabel(wxT("Power Level Offset :  ") + std::to_string(wxGetApp().getConfig()->getDBOffset()) + wxT(" dB"));
         }
     } 
     else if (actionOnMenuAGC(event)) {
@@ -1527,6 +1593,8 @@ void AppFrame::OnMenu(wxCommandEvent& event) {
         long ofs = wxGetNumberFromUser("Frequency correction for device in PPM.\ni.e. -51 for -51 PPM\n\nNote: you can adjust PPM interactively\nby holding ALT over the frequency tuning bar.\n", "Parts per million (PPM)",
                 "Frequency Correction", wxGetApp().getPPM(), -1000, 1000, this);
             wxGetApp().setPPM(ofs);
+
+            settingsMenuItems[wxID_SET_PPM]->SetItemLabel(wxT("Device PPM :  ") + std::to_string(wxGetApp().getPPM()) + wxT(" ppm"));
     } 
     else if (actionOnMenuLoadSave(event)) {
         return;
@@ -2019,13 +2087,14 @@ void AppFrame::OnAboutDialogClose(wxCommandEvent& event) {
 }
 
 void AppFrame::saveSession(std::string fileName) {
+
     DataTree s("cubicsdr_session");
     DataNode *header = s.rootNode()->newChild("header");
     //save as wstring to prevent problems 
     header->newChild("version")->element()->set(wxString(CUBICSDR_VERSION).ToStdWstring());
     
     *header->newChild("center_freq") = wxGetApp().getFrequency();
-    *header->newChild("sample_rate") = wxGetApp().getSampleRate();
+    *header->newChild("sample_rate") = wxGetApp().getSampleRate();       
     *header->newChild("solo_mode") = wxGetApp().getSoloMode()?1:0;
     
     if (waterfallCanvas->getViewState()) {
@@ -2061,6 +2130,7 @@ void AppFrame::saveSession(std::string fileName) {
 }
 
 bool AppFrame::loadSession(std::string fileName) {
+
     DataTree l;
     if (!l.LoadFromFileXML(fileName)) {
         return false;

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -64,6 +64,9 @@
 
 #define wxID_SETTINGS_BASE 2300
 
+#define wxID_ANTENNA_CURRENT 2500
+#define wxID_ANTENNAS_BASE 2501
+
 #define wxID_DEVICE_ID 3500
 
 #define wxID_AUDIO_BANDWIDTH_BASE 9000
@@ -192,6 +195,12 @@ private:
     std::map<int,RtAudio::DeviceInfo> outputDevices;
     std::map<int, wxMenuItem *> outputDeviceMenuItems;
     std::map<int, wxMenuItem *> sampleRateMenuItems;
+    std::map<int, wxMenuItem *> antennaMenuItems;
+    
+    //depending on context, maps the item id to wxMenuItem*,
+    //OR the submenu item id to its parent  wxMenuItem*.
+    std::map<int, wxMenuItem *> settingsMenuItems;
+    
     std::map<int, wxMenuItem *> audioSampleRateMenuItems;
     std::map<int, wxMenuItem *> directSamplingMenuItems;
     wxMenuBar *menuBar;
@@ -207,6 +216,8 @@ private:
     int settingsIdMax;
     std::vector<long> sampleRates;
     long manualSampleRate = -1;
+
+    std::vector<std::string> antennaNames;
     
     std::string currentSessionFile;
     

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -166,6 +166,10 @@ private:
     bool actionOnMenuLoadSave(wxCommandEvent& event);
     bool actionOnMenuRig(wxCommandEvent& event);
 
+    wxString getSettingsLabel(const std::string& settingsName, 
+                              const std::string& settingsValue, 
+                              const std::string& settingsSuffix = "");
+
     ScopeCanvas *scopeCanvas;
     SpectrumCanvas *spectrumCanvas;
     WaterfallCanvas *waterfallCanvas;

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -91,6 +91,9 @@ public:
 
     void setOffset(long long ofs);
     long long getOffset();
+
+    void setAntennaName(const std::string& name);
+    const std::string& getAntennaName();
     
     void setDBOffset(int ofs);
     int getDBOffset();
@@ -98,6 +101,7 @@ public:
     void setSampleRate(long long rate_in);
     long long getSampleRate();
 
+   
     std::vector<SDRDeviceInfo *> *getDevices();
     void setDevice(SDRDeviceInfo *dev, int waitMsForTermination);
     void stopDevice(bool store, int waitMsForTermination);
@@ -189,6 +193,7 @@ private:
     std::atomic_llong offset;
     std::atomic_int ppm, snap;
     std::atomic_llong sampleRate;
+    std::string antennaName;
     std::atomic_bool agcMode;
 
     SDRThread *sdrThread = nullptr;

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -132,24 +132,10 @@ void SDRDevicesDialog::refreshDeviceProperties() {
         devSettings["name"] = m_propertyGrid->Append( new wxStringProperty("Name", wxPG_LABEL, devConfig->getDeviceName()) );
         //A-2) Offset
         devSettings["offset"] = m_propertyGrid->Append( new wxIntProperty("Offset (Hz)", wxPG_LABEL, devConfig->getOffset()) );
-        //A-3) ppm
-        devSettings["ppm"] = m_propertyGrid->Append(new wxIntProperty("Frequency Correction (ppm)", wxPG_LABEL, devConfig->getPPM()));
-
-
-        //A-4) AGC control
-        SoapySDR::ArgInfo agcArg;
-
-        agcArg.type = SoapySDR::ArgInfo::BOOL;
-        agcArg.units = "";
-        agcArg.name = "Automatic Gain";
-        agcArg.key = "agc_mode";
-        agcArg.value = devConfig->getAGCMode()?"true":"false"; //must be lowercase for addArgInfoProperty
-
-        devSettings["agc_mode"] = addArgInfoProperty(m_propertyGrid, agcArg);
-       
-        //A-5) Antennas, is there are more than 1 RX antenna, else do not expose the setting.
+        
+        //A-3) Antennas, is there are more than 1 RX antenna, else do not expose the setting.
         //get the saved setting
-        const std::string& currentSetAntenna = wxGetApp().getAntennaName();
+        const std::string& currentSetAntenna = devConfig->getAntennaName();
 
         //compare to the list of existing antennas
         SoapySDR::ArgInfo antennasArg;
@@ -184,7 +170,7 @@ void SDRDevicesDialog::refreshDeviceProperties() {
 
         } //end if more than 1 antenna
 
-        //A-6) Sample_rate:
+        //A-4) Sample_rate:
         long currentSampleRate = wxGetApp().getSampleRate();
         long deviceSampleRate = devConfig->getSampleRate();
         
@@ -524,30 +510,8 @@ void SDRDevicesDialog::OnPropGridChanged( wxPropertyGridEvent& event ) {
             wxGetApp().setOffset(offset);
         }
 
-    } else if (dev && event.GetProperty() == devSettings["ppm"]) {
-        DeviceConfig *devConfig = wxGetApp().getConfig()->getDevice(dev->getDeviceId());
-
-        int ppm = event.GetPropertyValue().GetInteger();
-
-        devConfig->setPPM(ppm);
-
-        if (dev->isActive() || !wxGetApp().getDevice()) {
-
-            wxGetApp().setPPM(ppm);
-        }
-    }
-    else if (dev && event.GetProperty() == devSettings["agc_mode"]) {
-
-        DeviceConfig *devConfig = wxGetApp().getConfig()->getDevice(dev->getDeviceId());
-
-        bool agcMode = event.GetPropertyValue().GetBool();
-
-        devConfig->setAGCMode(agcMode);
-        if (dev->isActive() || !wxGetApp().getDevice()) {
-            wxGetApp().setAGCMode(agcMode);
-        }
- 
-    } else if (dev && event.GetProperty() == devSettings["sample_rate"]) {
+    } 
+    else if (dev && event.GetProperty() == devSettings["sample_rate"]) {
 
         DeviceConfig *devConfig = wxGetApp().getConfig()->getDevice(dev->getDeviceId());
         

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -152,6 +152,10 @@ void SDRDevicesDialog::refreshDeviceProperties() {
             if (found_i != antennaOpts.end()) {
                 antennaToSelect = currentSetAntenna;
             }
+            else {
+                //erroneous antenna name, re-write device config with the first choice of teh list.
+                devConfig->setAntennaName(antennaToSelect);
+            }
 
             //build device settings
             for (std::string antenna : antennaOpts) {
@@ -169,6 +173,9 @@ void SDRDevicesDialog::refreshDeviceProperties() {
             deviceArgs["antenna"] = antennasArg;
 
         } //end if more than 1 antenna
+        else {
+            devConfig->setAntennaName("");
+        }
 
         //A-4) Sample_rate:
         long currentSampleRate = wxGetApp().getSampleRate();

--- a/src/sdr/SDRDeviceInfo.cpp
+++ b/src/sdr/SDRDeviceInfo.cpp
@@ -190,6 +190,13 @@ std::vector<long> SDRDeviceInfo::getSampleRates(int direction, size_t channel) {
     return result;
 }
 
+std::vector<std::string> SDRDeviceInfo::getAntennaNames(int direction, size_t channel) {
+    SoapySDR::Device *dev = getSoapyDevice();
+
+    return  dev->listAntennas(direction, channel);
+   
+}
+
 long SDRDeviceInfo::getSampleRateNear(int direction, size_t channel, long sampleRate_in) {
     std::vector<long> sampleRates = getSampleRates(direction, channel);
     long returnRate = sampleRates[0];

--- a/src/sdr/SDRDeviceInfo.h
+++ b/src/sdr/SDRDeviceInfo.h
@@ -83,6 +83,8 @@ public:
     bool hasCORR(int direction, size_t channel);
     
     std::vector<long> getSampleRates(int direction, size_t channel);
+
+    std::vector<std::string> getAntennaNames(int direction, size_t channel);
     
     long getSampleRateNear(int direction, size_t channel, long sampleRate_in);
 

--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -76,6 +76,9 @@ public:
     
     void setOffset(long long ofs);
     long long getOffset();
+
+    void setAntenna(const std::string& name);
+    std::string getAntenna();
     
     void setSampleRate(long rate);
     long getSampleRate();
@@ -119,7 +122,8 @@ protected:
     std::atomic_llong frequency, offset, lock_freq;
     std::atomic_int ppm, numElems, mtuElems, numChannels;
     std::atomic_bool hasPPM, hasHardwareDC;
-    std::atomic_bool agc_mode, rate_changed, freq_changed, offset_changed,
+    std::string antennaName;
+    std::atomic_bool agc_mode, rate_changed, freq_changed, offset_changed, antenna_changed,
         ppm_changed, device_changed, agc_mode_changed, gain_value_changed, setting_value_changed, frequency_locked, frequency_lock_init, iq_swap;
 
     std::mutex gain_busy;

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -245,6 +245,7 @@ void TuningCanvas::StepTuner(ActiveState state, int exponent, bool up) {
         }
 
         wxGetApp().setPPM(currentPPM);
+        wxGetApp().notifyMainUIOfDeviceChange();
     }
 }
 


### PR DESCRIPTION
Hello @cjcliffe, @romeojulietthotel, @guruofquality, @SDRplay and all.

This PR brings 2 enhancements:

-  Antenna support (RX) through SoapySDR `listAntennas(SOAPY_SDR_RX,...)` and `getAntenna(SOAPY_SDR_RX,...)` calls. 
Now multiple-antenna systems can choose their starting RX Antenna, and later switch their RX antenna dynamically. 

SDRPlay RSP2 have it using the latest module master (tested with) and as far as I can see LimeSDR should have too. (others through SoapyOsmo ?)

In practice, multi-RX systems now see the following change at CubicSDR device selection:
![device_selection](https://user-images.githubusercontent.com/5152742/29699202-22702f3e-895b-11e7-8bf8-6bd1eb7f1037.jpg)
Note the addition of the `Antenna` property.

An 'Antenna' additional menu entry shows up in the `Settings` menu, from which you may switch the antenna dynamically:
![new_settings](https://user-images.githubusercontent.com/5152742/29699327-3ce107f2-895c-11e7-860a-155b17791801.jpg)

On systems with only 1 RX antenna, both `Antenna` additional entries are not present, so Cubic is the same as before to prevent UI clutter. 

In on the above image, you can see the second enhancement:
-  'Single-click' Settings view showing all settings current values on the `Settings` menu itself, so we no longer need to navigate the sub-menus of every setting just to know its current value. 