### PR TITLE
Automatic DemodulatorInstance memory management through shared_ptr and misc.

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -2273,7 +2273,7 @@ bool AppFrame::loadSession(std::string fileName) {
         }
         
         if (demodsLoaded.size()) {
-            wxGetApp().bindDemodulators(demodsLoaded);
+            wxGetApp().notifyDemodulatorsChanged();
         }
             
         } // if l.rootNode()->hasAnother("demodulators")

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -26,7 +26,8 @@
 #include "FrequencyDialog.h"
 #include "BookmarkView.h"
 #include "AboutDialog.h"
-
+#include "DemodulatorInstance.h"
+#include "DemodulatorThread.h"
 #include <map>
 
 #define wxID_RT_AUDIO_DEVICE 1000
@@ -107,8 +108,8 @@ public:
     void setMainWaterfallFFTSize(int fftSize);
     void setScopeDeviceName(std::string deviceName);
 
-    void gkNudgeLeft(DemodulatorInstance *demod, int snap);
-    void gkNudgeRight(DemodulatorInstance *demod, int snap);
+    void gkNudgeLeft(DemodulatorInstancePtr demod, int snap);
+    void gkNudgeRight(DemodulatorInstancePtr demod, int snap);
 
     int OnGlobalKeyDown(wxKeyEvent &event);
     int OnGlobalKeyUp(wxKeyEvent &event);
@@ -193,7 +194,7 @@ private:
     wxBoxSizer *demodTray;
     BookmarkView *bookmarkView;
     
-    DemodulatorInstance *activeDemodulator;
+    DemodulatorInstancePtr activeDemodulator;
 
     std::vector<RtAudio::DeviceInfo> devices;
     std::map<int,RtAudio::DeviceInfo> inputDevices;

--- a/src/BookmarkMgr.cpp
+++ b/src/BookmarkMgr.cpp
@@ -205,7 +205,7 @@ bool BookmarkMgr::hasBackup(std::string bookmarkFn) {
     return backupFile.FileExists() && backupFile.IsFileReadable();
 }
 
-void BookmarkMgr::addBookmark(std::string group, DemodulatorInstance *demod) {
+void BookmarkMgr::addBookmark(std::string group, DemodulatorInstancePtr demod) {
     std::lock_guard < std::recursive_mutex > lock(busy_lock);
     
 	//Create a BookmarkEntry from demod data, saving its
@@ -392,7 +392,7 @@ void BookmarkMgr::updateBookmarks(std::string group) {
 }
 
 
-void BookmarkMgr::addRecent(DemodulatorInstance *demod) {
+void BookmarkMgr::addRecent(DemodulatorInstancePtr demod) {
     std::lock_guard < std::recursive_mutex > lock(busy_lock);
 
     recents.push_back(demodToBookmarkEntry(demod));
@@ -482,7 +482,7 @@ void BookmarkMgr::clearRanges() {
 }
 
 
-BookmarkEntryPtr BookmarkMgr::demodToBookmarkEntry(DemodulatorInstance *demod) {
+BookmarkEntryPtr BookmarkMgr::demodToBookmarkEntry(DemodulatorInstancePtr demod) {
     
     BookmarkEntryPtr be(new BookmarkEntry);
     
@@ -536,7 +536,7 @@ std::wstring BookmarkMgr::getBookmarkEntryDisplayName(BookmarkEntryPtr bmEnt) {
     return dispName;
 }
 
-std::wstring BookmarkMgr::getActiveDisplayName(DemodulatorInstance *demod) {
+std::wstring BookmarkMgr::getActiveDisplayName(DemodulatorInstancePtr demod) {
     std::wstring activeName = demod->getDemodulatorUserLabel();
     
     if (activeName == "") {
@@ -547,7 +547,7 @@ std::wstring BookmarkMgr::getActiveDisplayName(DemodulatorInstance *demod) {
     return activeName;
 }
 
-void BookmarkMgr::removeActive(DemodulatorInstance *demod) {
+void BookmarkMgr::removeActive(DemodulatorInstancePtr demod) {
 	
 	std::lock_guard < std::recursive_mutex > lock(busy_lock);
 

--- a/src/BookmarkMgr.h
+++ b/src/BookmarkMgr.h
@@ -85,7 +85,7 @@ public:
     bool hasLastLoad(std::string bookmarkFn);
     bool hasBackup(std::string bookmarkFn);
 
-    void addBookmark(std::string group, DemodulatorInstance *demod);
+    void addBookmark(std::string group, DemodulatorInstancePtr demod);
     void addBookmark(std::string group, BookmarkEntryPtr be);
     void removeBookmark(std::string group, BookmarkEntryPtr be);
     void removeBookmark(BookmarkEntryPtr be);
@@ -105,13 +105,13 @@ public:
     void updateBookmarks();
     void updateBookmarks(std::string group);
 
-    void addRecent(DemodulatorInstance *demod);
+    void addRecent(DemodulatorInstancePtr demod);
     void addRecent(BookmarkEntryPtr be);
     void removeRecent(BookmarkEntryPtr be);
     const BookmarkList& getRecents();
     void clearRecents();
 
-	void removeActive(DemodulatorInstance *demod);
+	void removeActive(DemodulatorInstancePtr demod);
 
     void addRange(BookmarkRangeEntryPtr re);
     void removeRange(BookmarkRangeEntryPtr re);
@@ -119,13 +119,13 @@ public:
     void clearRanges();
 	
     static std::wstring getBookmarkEntryDisplayName(BookmarkEntryPtr bmEnt);
-    static std::wstring getActiveDisplayName(DemodulatorInstance *demod);
+    static std::wstring getActiveDisplayName(DemodulatorInstancePtr demod);
 
 protected:
 
     void trimRecents();
     
-    BookmarkEntryPtr demodToBookmarkEntry(DemodulatorInstance *demod);
+    BookmarkEntryPtr demodToBookmarkEntry(DemodulatorInstancePtr demod);
     BookmarkEntryPtr nodeToBookmark(DataNode *node);
     
     BookmarkMap bmData;

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -421,9 +421,6 @@ int CubicSDR::OnExit() {
     std::cout << "Terminating All Demodulators.." << std::endl << std::flush;
     demodMgr.terminateAll();
 
-    //wait for effective death of all demodulators before continuing.
-    terminationSequenceOK = terminationSequenceOK && demodMgr.garbageCollect(true, 3000);
-   
     std::cout << "Terminating Visual Processor threads.." << std::endl << std::flush;
     spectrumVisualThread->terminate();
     if (demodVisualThread) {
@@ -831,17 +828,15 @@ SDRThread *CubicSDR::getSDRThread() {
 }
 
 
-void CubicSDR::bindDemodulator(DemodulatorInstance *demod) {
+void CubicSDR::bindDemodulator(DemodulatorInstancePtr demod) {
     if (!demod) {
         return;
     }
     sdrPostThread->bindDemodulator(demod);
 }
 
-void CubicSDR::bindDemodulators(std::vector<DemodulatorInstance *> *demods) {
-    if (!demods) {
-        return;
-    }
+void CubicSDR::bindDemodulators(const std::vector<DemodulatorInstancePtr>& demods) {
+    
     sdrPostThread->bindDemodulators(demods);
 }
 
@@ -849,7 +844,7 @@ long long CubicSDR::getSampleRate() {
     return sampleRate;
 }
 
-void CubicSDR::removeDemodulator(DemodulatorInstance *demod) {
+void CubicSDR::removeDemodulator(DemodulatorInstancePtr demod) {
     if (!demod) {
         return;
     }
@@ -926,7 +921,7 @@ void CubicSDR::showFrequencyInput(FrequencyDialog::FrequencyDialogTarget targetM
 
 void CubicSDR::showLabelInput() {
 
-    DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getActiveDemodulator();
+    DemodulatorInstancePtr activeDemod = wxGetApp().getDemodMgr().getActiveDemodulator();
 
     if (activeDemod != nullptr) {
 

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -828,16 +828,9 @@ SDRThread *CubicSDR::getSDRThread() {
 }
 
 
-void CubicSDR::bindDemodulator(DemodulatorInstancePtr demod) {
-    if (!demod) {
-        return;
-    }
-    sdrPostThread->bindDemodulator(demod);
-}
-
-void CubicSDR::bindDemodulators(const std::vector<DemodulatorInstancePtr>& demods) {
+void CubicSDR::notifyDemodulatorsChanged() {
     
-    sdrPostThread->bindDemodulators(demods);
+    sdrPostThread->notifyDemodulatorsChanged();
 }
 
 long long CubicSDR::getSampleRate() {
@@ -849,7 +842,7 @@ void CubicSDR::removeDemodulator(DemodulatorInstancePtr demod) {
         return;
     }
     demod->setActive(false);
-    sdrPostThread->removeDemodulator(demod);
+    sdrPostThread->notifyDemodulatorsChanged();
     wxGetApp().getAppFrame()->notifyUpdateModemProperties();
 }
 

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -121,8 +121,8 @@ public:
     SDRPostThread *getSDRPostThread();
     SDRThread *getSDRThread();
 
-    void bindDemodulator(DemodulatorInstancePtr demod);
-    void bindDemodulators(const std::vector<DemodulatorInstancePtr>& demods);
+    void notifyDemodulatorsChanged();
+   
     void removeDemodulator(DemodulatorInstancePtr demod);
 
     void setFrequencySnap(int snap);

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -121,9 +121,9 @@ public:
     SDRPostThread *getSDRPostThread();
     SDRThread *getSDRThread();
 
-    void bindDemodulator(DemodulatorInstance *demod);
-    void bindDemodulators(std::vector<DemodulatorInstance *> *demods);
-    void removeDemodulator(DemodulatorInstance *demod);
+    void bindDemodulator(DemodulatorInstancePtr demod);
+    void bindDemodulators(const std::vector<DemodulatorInstancePtr>& demods);
+    void removeDemodulator(DemodulatorInstancePtr demod);
 
     void setFrequencySnap(int snap);
     int getFrequencySnap();

--- a/src/DemodLabelDialog.cpp
+++ b/src/DemodLabelDialog.cpp
@@ -13,7 +13,7 @@ EVT_SHOW(DemodLabelDialog::OnShow)
 wxEND_EVENT_TABLE()
 
 DemodLabelDialog::DemodLabelDialog(wxWindow * parent, wxWindowID id, const wxString & title, 
-        DemodulatorInstance *demod, const wxPoint & position,
+        DemodulatorInstancePtr demod, const wxPoint & position,
         const wxSize & size, long style) :
         wxDialog(parent, id, title, position, size, style) {
 

--- a/src/DemodLabelDialog.h
+++ b/src/DemodLabelDialog.h
@@ -16,7 +16,7 @@ class DemodLabelDialog : public wxDialog
 public:
   
     DemodLabelDialog( wxWindow * parent, wxWindowID id, const wxString & title,
-                  DemodulatorInstance *demod = NULL,
+                  DemodulatorInstancePtr demod = nullptr,
                   const wxPoint & pos = wxDefaultPosition,
                   const wxSize & size = wxDefaultSize,
                   long style = wxDEFAULT_DIALOG_STYLE);
@@ -24,7 +24,7 @@ public:
     wxTextCtrl * dialogText;
 
 private:
-    DemodulatorInstance *activeDemod = nullptr;
+    DemodulatorInstancePtr activeDemod = nullptr;
     void OnEnter ( wxCommandEvent &event );
     void OnChar ( wxKeyEvent &event );
 	void OnShow(wxShowEvent &event);

--- a/src/FrequencyDialog.cpp
+++ b/src/FrequencyDialog.cpp
@@ -12,11 +12,13 @@ EVT_CHAR_HOOK(FrequencyDialog::OnChar)
 EVT_SHOW(FrequencyDialog::OnShow)
 wxEND_EVENT_TABLE()
 
-FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxString & title, DemodulatorInstance *demod, const wxPoint & position,
+FrequencyDialog::FrequencyDialog(wxWindow * parent, wxWindowID id, const wxString & title, DemodulatorInstancePtr demod, const wxPoint & position,
         const wxSize & size, long style, FrequencyDialogTarget targetMode, wxString initString) :
         wxDialog(parent, id, title, position, size, style) {
     wxString freqStr;
+    
     activeDemod = demod;
+    
     this->targetMode = targetMode;
 	this->initialString = initString;
 

--- a/src/FrequencyDialog.h
+++ b/src/FrequencyDialog.h
@@ -24,7 +24,7 @@ public:
         FDIALOG_TARGET_GAIN
     } FrequencyDialogTarget;
     FrequencyDialog ( wxWindow * parent, wxWindowID id, const wxString & title,
-                  DemodulatorInstance *demod = NULL,
+                  DemodulatorInstancePtr demod = nullptr,
                   const wxPoint & pos = wxDefaultPosition,
                   const wxSize & size = wxDefaultSize,
                   long style = wxDEFAULT_DIALOG_STYLE,
@@ -34,7 +34,7 @@ public:
     wxTextCtrl * dialogText;
 
 private:
-    DemodulatorInstance *activeDemod;
+    DemodulatorInstancePtr activeDemod;
     void OnEnter ( wxCommandEvent &event );
     void OnChar ( wxKeyEvent &event );
 	void OnShow(wxShowEvent &event);

--- a/src/ModemProperties.cpp
+++ b/src/ModemProperties.cpp
@@ -101,7 +101,7 @@ void ModemProperties::initDefaultProperties() {
     defaultProps["._audio_output"] = addArgInfoProperty(m_propertyGrid, outputArg);
 }
 
-void ModemProperties::initProperties(ModemArgInfoList newArgs, DemodulatorInstance *demodInstance) {
+void ModemProperties::initProperties(ModemArgInfoList newArgs, DemodulatorInstancePtr demodInstance) {
     args = newArgs;
     demodContext = demodInstance;
     

--- a/src/ModemProperties.h
+++ b/src/ModemProperties.h
@@ -24,7 +24,7 @@ public:
     ~ModemProperties();
     
     void initDefaultProperties();
-    void initProperties(ModemArgInfoList newArgs, DemodulatorInstance *demodInstance);
+    void initProperties(ModemArgInfoList newArgs, DemodulatorInstancePtr demodInstance);
     bool isMouseInView();
     void setCollapsed(bool state);
     bool isCollapsed();
@@ -46,7 +46,8 @@ private:
     wxBoxSizer* bSizer;
     wxPropertyGrid* m_propertyGrid;
     ModemArgInfoList args;
-    DemodulatorInstance *demodContext;
+    DemodulatorInstancePtr demodContext;
+
     std::map<std::string, wxPGProperty *> props;
     bool mouseInView, collapsed;
     

--- a/src/audio/AudioThread.cpp
+++ b/src/audio/AudioThread.cpp
@@ -304,14 +304,12 @@ void AudioThread::setSampleRate(int sampleRate) {
             srcmix->setSampleRate(sampleRate);
         }
 
-        std::vector<DemodulatorInstance *>::iterator demod_i;
-        std::vector<DemodulatorInstance *> *demodulators;
+        //make a local copy, snapshot of the list of demodulators
+        std::vector<DemodulatorInstancePtr> demodulators = wxGetApp().getDemodMgr().getDemodulators();
 
-        demodulators = &wxGetApp().getDemodMgr().getDemodulators();
-
-        for (demod_i = demodulators->begin(); demod_i != demodulators->end(); demod_i++) {
-            if ((*demod_i)->getOutputDevice() == outputDevice.load()) {
-                (*demod_i)->setAudioSampleRate(sampleRate);
+        for (auto demod : demodulators) {
+            if (demod->getOutputDevice() == outputDevice.load()) {
+                demod->setAudioSampleRate(sampleRate);
             }
         }
 

--- a/src/audio/AudioThread.h
+++ b/src/audio/AudioThread.h
@@ -35,6 +35,10 @@ public:
 
 typedef std::shared_ptr<AudioThreadInput> AudioThreadInputPtr;
 
+typedef ThreadBlockingQueue<AudioThreadInputPtr> DemodulatorThreadOutputQueue;
+
+typedef std::shared_ptr<DemodulatorThreadOutputQueue> DemodulatorThreadOutputQueuePtr;
+
 class AudioThreadCommand {
 public:
     enum AudioThreadCommandEnum {

--- a/src/demod/DemodDefs.h
+++ b/src/demod/DemodDefs.h
@@ -15,7 +15,6 @@
 
 class DemodulatorThread;
 
-
 class DemodulatorThreadControlCommand {
 public:
     enum DemodulatorThreadControlCommandEnum {

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -83,6 +83,8 @@ DemodulatorInstance::DemodulatorInstance() {
 }
 
 DemodulatorInstance::~DemodulatorInstance() {
+    
+    std::lock_guard < std::recursive_mutex > lockData(m_thread_control_mutex);
 
     //now that DemodulatorInstance are managed through shared_ptr, we 
     //should enter here ONLY when it is no longer used by any piece of code, anywhere.
@@ -119,6 +121,8 @@ void DemodulatorInstance::setVisualOutputQueue(DemodulatorThreadOutputQueuePtr t
 }
 
 void DemodulatorInstance::run() {
+
+    std::lock_guard < std::recursive_mutex > lockData(m_thread_control_mutex);
 
     if (active) {
         return;
@@ -186,6 +190,8 @@ void DemodulatorInstance::setLabel(std::string labelStr) {
 }
 
 bool DemodulatorInstance::isTerminated() {
+
+    std::lock_guard < std::recursive_mutex > lockData(m_thread_control_mutex);
 
     bool audioTerminated = audioThread->isTerminated();
     bool demodTerminated = demodulatorThread->isTerminated();

--- a/src/demod/DemodulatorInstance.cpp
+++ b/src/demod/DemodulatorInstance.cpp
@@ -85,10 +85,10 @@ DemodulatorInstance::DemodulatorInstance() {
 DemodulatorInstance::~DemodulatorInstance() {
 
     //now that DemodulatorInstance are managed through shared_ptr, we 
-    //should enter here ONLY when it is no longer used by any piece of code, anywahere.
+    //should enter here ONLY when it is no longer used by any piece of code, anywhere.
     //so active wait on IsTerminated(), then die.
 #define TERMINATION_SPIN_WAIT_MS (20)
-#define MAX_WAIT_FOR_TERMINATION_MS (1000.0)
+#define MAX_WAIT_FOR_TERMINATION_MS (3000.0)
     //this is a stupid busy plus sleep loop
     int  nbCyclesToWait = (MAX_WAIT_FOR_TERMINATION_MS / TERMINATION_SPIN_WAIT_MS) + 1;
     int currentCycle = 0;

--- a/src/demod/DemodulatorInstance.h
+++ b/src/demod/DemodulatorInstance.h
@@ -139,6 +139,9 @@ private:
     DemodulatorThread *demodulatorThread;
     DemodulatorThreadControlCommandQueuePtr threadQueueControl;
 
+    //protects child thread creation and termination 
+    std::recursive_mutex m_thread_control_mutex;
+
     std::atomic<std::string *> label; //
     // User editable buffer, 16 bit string.
     std::atomic<std::wstring *> user_label; 

--- a/src/demod/DemodulatorInstance.h
+++ b/src/demod/DemodulatorInstance.h
@@ -6,12 +6,11 @@
 #include <vector>
 #include <map>
 #include <thread>
-
-#include "DemodulatorThread.h"
-#include "DemodulatorPreThread.h"
-
+#include <memory>
+#include "DemodDefs.h"
 #include "ModemDigital.h"
 #include "ModemAnalog.h"
+#include "AudioThread.h"
 
 #if ENABLE_DIGITAL_LAB
 #include "DigitalConsole.h"
@@ -30,6 +29,8 @@ private:
     std::atomic_int squelchBreak;
 };
 
+class DemodulatorThread;
+class DemodulatorPreThread;
 
 class DemodulatorInstance {
 public:
@@ -138,9 +139,6 @@ private:
     DemodulatorThread *demodulatorThread;
     DemodulatorThreadControlCommandQueuePtr threadQueueControl;
 
-    //protects child thread creation and termination 
-    std::mutex m_thread_control_mutex;
-
     std::atomic<std::string *> label; //
     // User editable buffer, 16 bit string.
     std::atomic<std::wstring *> user_label; 
@@ -161,3 +159,5 @@ private:
     ModemDigitalOutput *activeOutput;
 #endif
 };
+
+typedef std::shared_ptr<DemodulatorInstance> DemodulatorInstancePtr;

--- a/src/demod/DemodulatorMgr.h
+++ b/src/demod/DemodulatorMgr.h
@@ -16,23 +16,32 @@ public:
     DemodulatorMgr();
     ~DemodulatorMgr();
 
-    DemodulatorInstance *newThread();
-    std::vector<DemodulatorInstance *> &getDemodulators();
-    std::vector<DemodulatorInstance *> getOrderedDemodulators(bool actives = true);
-    std::vector<DemodulatorInstance *> getDemodulatorsAt(long long freq, int bandwidth);
-    DemodulatorInstance *getPreviousDemodulator(DemodulatorInstance *demod, bool actives = true);
-    DemodulatorInstance *getNextDemodulator(DemodulatorInstance *demod, bool actives = true);
-    DemodulatorInstance *getLastDemodulator();
-    DemodulatorInstance *getFirstDemodulator();
+    DemodulatorInstancePtr newThread();
+   
+    //return snapshot-copy of the list purposefully
+    std::vector<DemodulatorInstancePtr> getDemodulators();
+
+    std::vector<DemodulatorInstancePtr> getOrderedDemodulators(bool actives = true);
+    std::vector<DemodulatorInstancePtr> getDemodulatorsAt(long long freq, int bandwidth);
+    
+    DemodulatorInstancePtr getPreviousDemodulator(DemodulatorInstancePtr demod, bool actives = true);
+    DemodulatorInstancePtr getNextDemodulator(DemodulatorInstancePtr demod, bool actives = true);
+    DemodulatorInstancePtr getLastDemodulator();
+    DemodulatorInstancePtr getFirstDemodulator();
     bool anyDemodulatorsAt(long long freq, int bandwidth);
-    void deleteThread(DemodulatorInstance *);
+    void deleteThread(DemodulatorInstancePtr);
 
     void terminateAll();
 
-    void setActiveDemodulator(DemodulatorInstance *demod, bool temporary = true);
-    DemodulatorInstance *getActiveDemodulator();
-    DemodulatorInstance *getLastActiveDemodulator();
-	DemodulatorInstance *getLastDemodulatorWith(const std::string& type,
+    void setActiveDemodulator(DemodulatorInstancePtr demod, bool temporary = true);
+
+    //Dangerous: this is only intended by some internal classes,
+    // and only set a pre-existing demod
+    void setActiveDemodulatorByRawPointer(DemodulatorInstance* demod, bool temporary = true);
+
+    DemodulatorInstancePtr getActiveDemodulator();
+    DemodulatorInstancePtr getLastActiveDemodulator();
+    DemodulatorInstancePtr getLastDemodulatorWith(const std::string& type,
 												const std::wstring& userLabel,
 												long long frequency,
 												int bandwidth);
@@ -64,28 +73,17 @@ public:
     void updateLastState();
     
     void setOutputDevices(std::map<int,RtAudio::DeviceInfo> devs);
-    void saveInstance(DataNode *node, DemodulatorInstance *inst);
+    void saveInstance(DataNode *node, DemodulatorInstancePtr inst);
 	
-    DemodulatorInstance *loadInstance(DataNode *node);
+    DemodulatorInstancePtr loadInstance(DataNode *node);
 
-    //to be called periodically to cleanup removed demodulators.
-    //if forcedGC = true, the methods waits until 
-    //all deleted demodulators are effectively GCed.
-    //else: (default) the method test for effective termination
-    //and GC one demod per call. 
-    // if forcedGC = true and maxWaitForTerminationMs > 0, do not
-    //block the method more than maxWaitForTerminationMs millisecs before returning.
-    //Returns: true if forcedGC = false, else true only if all deleted demodulators were GCs before maxWaitForTerminationMs.
-    bool garbageCollect(bool forcedGC = false, int maxWaitForTerminationMs = 0);
-    
 private:
 
-    std::vector<DemodulatorInstance *> demods;
-    std::vector<DemodulatorInstance *> demods_deleted;
+    std::vector<DemodulatorInstancePtr> demods;
     
-    std::atomic<DemodulatorInstance *> activeDemodulator;
-    std::atomic<DemodulatorInstance *> lastActiveDemodulator;
-    std::atomic<DemodulatorInstance *> activeVisualDemodulator;
+    DemodulatorInstancePtr activeDemodulator;
+    DemodulatorInstancePtr lastActiveDemodulator;
+    DemodulatorInstancePtr activeVisualDemodulator;
 
     int lastBandwidth;
     std::string lastDemodType;
@@ -99,9 +97,7 @@ private:
     //protects access to demods lists and such, need to be recursive
     //because of the usage of public re-entrant methods 
     std::recursive_mutex demods_busy;
-
-    std::mutex deleted_demods_busy;
-    
+   
     std::map<std::string, ModemSettings> lastModemSettings;
     std::map<int,RtAudio::DeviceInfo> outputDevices;
 };

--- a/src/demod/DemodulatorPreThread.cpp
+++ b/src/demod/DemodulatorPreThread.cpp
@@ -15,7 +15,7 @@
 //50 ms
 #define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
 
-DemodulatorPreThread::DemodulatorPreThread(DemodulatorInstance *parent) : IOThread(), iqResampler(NULL), iqResampleRatio(1), cModem(nullptr), cModemKit(nullptr), iqInputQueue(NULL), iqOutputQueue(NULL)
+DemodulatorPreThread::DemodulatorPreThread(DemodulatorInstance* parent) : IOThread(), iqResampler(NULL), iqResampleRatio(1), cModem(nullptr), cModemKit(nullptr), iqInputQueue(NULL), iqOutputQueue(NULL)
  {
 	initialized.store(false);
     this->parent = parent;

--- a/src/demod/DemodulatorPreThread.h
+++ b/src/demod/DemodulatorPreThread.h
@@ -17,7 +17,7 @@ class DemodulatorInstance;
 class DemodulatorPreThread : public IOThread {
 public:
 
-    DemodulatorPreThread(DemodulatorInstance *parent);
+    DemodulatorPreThread(DemodulatorInstance* parent);
     virtual ~DemodulatorPreThread();
 
     virtual void run();
@@ -50,7 +50,9 @@ public:
     void writeModemSettings(ModemSettings settings);
 
 protected:
-    DemodulatorInstance *parent;
+  
+    DemodulatorInstance* parent;
+
     msresamp_crcf iqResampler;
     double iqResampleRatio;
     std::vector<liquid_float_complex> resampledData;

--- a/src/demod/DemodulatorThread.h
+++ b/src/demod/DemodulatorThread.h
@@ -11,10 +11,6 @@
 #include "AudioThread.h"
 #include "Modem.h"
 
-typedef ThreadBlockingQueue<AudioThreadInputPtr> DemodulatorThreadOutputQueue;
-
-typedef std::shared_ptr<DemodulatorThreadOutputQueue> DemodulatorThreadOutputQueuePtr;
-
 #define DEMOD_VIS_SIZE 2048
 #define DEMOD_SIGNAL_MIN -30
 #define DEMOD_SIGNAL_MAX 30
@@ -24,7 +20,7 @@ class DemodulatorInstance;
 class DemodulatorThread : public IOThread {
 public:
 
-    DemodulatorThread(DemodulatorInstance *parent);
+    DemodulatorThread(DemodulatorInstance* parent);
     virtual ~DemodulatorThread();
 
     void onBindOutput(std::string name, ThreadQueueBasePtr threadQueue);
@@ -43,13 +39,14 @@ public:
    
     bool getSquelchBreak();
 
-    static void releaseSquelchLock(DemodulatorInstance *inst);
+
+    static void releaseSquelchLock(DemodulatorInstance* inst);
 protected:
     
     double abMagnitude(float inphase, float quadrature);
     double linearToDb(double linear);
 
-    DemodulatorInstance *demodInstance = nullptr;
+    DemodulatorInstance* demodInstance;
     ReBuffer<AudioThreadInput> outputBuffers;
 
     std::atomic_bool muted;
@@ -58,7 +55,7 @@ protected:
     std::atomic<float> signalLevel, signalFloor, signalCeil;
     bool squelchEnabled, squelchBreak;
     
-    static std::atomic<DemodulatorInstance *> squelchLock;
+    static DemodulatorInstance* squelchLock;
     static std::mutex squelchLockMutex;
     
     

--- a/src/demod/DemodulatorWorkerThread.cpp
+++ b/src/demod/DemodulatorWorkerThread.cpp
@@ -9,9 +9,6 @@
 //50 ms
 #define HEARTBEAT_CHECK_PERIOD_MICROS (50 * 1000) 
 
-//1s
-#define MAX_BLOCKING_DURATION_MICROS (1000 * 1000)
-
 DemodulatorWorkerThread::DemodulatorWorkerThread() : IOThread(),
         commandQueue(nullptr), resultQueue(nullptr), cModem(nullptr), cModemKit(nullptr) {
 }
@@ -111,7 +108,7 @@ void DemodulatorWorkerThread::run() {
             result.modemName = cModemName;
             
             //VSO: blocking push
-            resultQueue->push(result, MAX_BLOCKING_DURATION_MICROS, "resultQueue");
+            resultQueue->push(result);
         }
     }
 //    std::cout << "Demodulator worker thread done." << std::endl;

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -348,10 +348,9 @@ wxTreeItemId BookmarkView::refreshBookmarks() {
 
 
 void BookmarkView::doUpdateActiveList() {
-    std::vector<DemodulatorInstance *> &demods = wxGetApp().getDemodMgr().getDemodulators();
-    
-//    DemodulatorInstance *activeDemodulator = wxGetApp().getDemodMgr().getActiveDemodulator();
-    DemodulatorInstance *lastActiveDemodulator = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+
+    auto demods = wxGetApp().getDemodMgr().getDemodulators();
+    auto lastActiveDemodulator = wxGetApp().getDemodMgr().getLastActiveDemodulator();
 
     //capture the previously selected item info BY COPY (because the original will be destroyed together with the destroyed tree items) to restore it again after 
     //having rebuilding the whole tree.
@@ -693,7 +692,8 @@ wxButton *BookmarkView::addButton(wxWindow *parent, std::string labelVal, wxObje
 }
 
 
-void BookmarkView::doBookmarkActive(std::string group, DemodulatorInstance *demod) {
+void BookmarkView::doBookmarkActive(std::string group, DemodulatorInstancePtr demod) {
+
     wxGetApp().getBookmarkMgr().addBookmark(group, demod);
     wxGetApp().getBookmarkMgr().updateBookmarks();
 }
@@ -717,7 +717,7 @@ void BookmarkView::doMoveBookmark(BookmarkEntryPtr be, std::string group) {
 }
 
 
-void BookmarkView::doRemoveActive(DemodulatorInstance *demod) {
+void BookmarkView::doRemoveActive(DemodulatorInstancePtr demod) {
 
 	wxGetApp().getBookmarkMgr().removeActive(demod);
 	wxGetApp().getBookmarkMgr().updateActiveList();
@@ -792,7 +792,7 @@ void BookmarkView::onBookmarkChoice( wxCommandEvent & /* event */ ) {
 }
 
 
-void BookmarkView::activeSelection(DemodulatorInstance *dsel) {
+void BookmarkView::activeSelection(DemodulatorInstancePtr dsel) {
     
     m_frequencyVal->SetLabelText(frequencyToStr(dsel->getFrequency()));
     m_bandwidthVal->SetLabelText(frequencyToStr(dsel->getBandwidth()));
@@ -835,7 +835,7 @@ void BookmarkView::activateBookmark(BookmarkEntryPtr bmEnt) {
 	//the already existing one:
 	// we search among the list of existing demodulators the one matching 
 	//bmEnt and activate it. The search is made backwards, to select the most recently created one.
-	DemodulatorInstance *matchingDemod = wxGetApp().getDemodMgr().getLastDemodulatorWith(
+	DemodulatorInstancePtr matchingDemod = wxGetApp().getDemodMgr().getLastDemodulatorWith(
 																		bmEnt->type,
 																		bmEnt->label, 
 																		bmEnt->frequency, 

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -845,7 +845,7 @@ void BookmarkView::activateBookmark(BookmarkEntryPtr bmEnt) {
 
 		matchingDemod = wxGetApp().getDemodMgr().loadInstance(bmEnt->node);
 		matchingDemod->run();
-		wxGetApp().bindDemodulator(matchingDemod);
+		wxGetApp().notifyDemodulatorsChanged();
 	}
 
 	matchingDemod->setActive(true);

--- a/src/forms/Bookmark/BookmarkView.h
+++ b/src/forms/Bookmark/BookmarkView.h
@@ -43,7 +43,7 @@ public:
     BookmarkEntryPtr bookmarkEnt; 
     BookmarkRangeEntryPtr rangeEnt;
     
-    DemodulatorInstance* demod;
+    DemodulatorInstancePtr demod;
     std::string groupName;
 };
 
@@ -84,7 +84,7 @@ public:
     static BookmarkRangeEntryPtr makeActiveRangeEntry();
 
 protected:
-    void activeSelection(DemodulatorInstance *dsel);
+    void activeSelection(DemodulatorInstancePtr dsel);
     void bookmarkSelection(BookmarkEntryPtr bmSel);
     void rangeSelection(BookmarkRangeEntryPtr re);
     
@@ -133,10 +133,10 @@ protected:
     wxButton *makeButton(wxWindow *parent, std::string labelVal, wxObjectEventFunction handler);
     wxButton *addButton(wxWindow *parent, std::string labelVal, wxObjectEventFunction handler);
 
-    void doBookmarkActive(std::string group, DemodulatorInstance *demod);
+    void doBookmarkActive(std::string group, DemodulatorInstancePtr demod);
     void doBookmarkRecent(std::string group, BookmarkEntryPtr be);
     void doMoveBookmark(BookmarkEntryPtr be, std::string group);
-    void doRemoveActive(DemodulatorInstance *demod);
+    void doRemoveActive(DemodulatorInstancePtr demod);
     void doRemoveRecent(BookmarkEntryPtr be);
     void doClearRecents();
     
@@ -191,7 +191,7 @@ protected:
     // Focus
     BookmarkEntryPtr nextEnt;
     BookmarkRangeEntryPtr nextRange;
-    DemodulatorInstance *nextDemod;
+    DemodulatorInstancePtr nextDemod;
     std::string nextGroup;
     
     // Search

--- a/src/rig/RigThread.cpp
+++ b/src/rig/RigThread.cpp
@@ -73,8 +73,8 @@ void RigThread::run() {
     while (!stopping) {
         std::this_thread::sleep_for(std::chrono::milliseconds(150));
         
-        DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getActiveDemodulator();
-        DemodulatorInstance *lastDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+        auto activeDemod = wxGetApp().getDemodMgr().getActiveDemodulator();
+        auto lastDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
 
         if (freqChanged.load() && (controlMode.load() || setOneShot.load())) {
             status = rig_get_freq(rig, RIG_VFO_CURR, &freq);

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -16,12 +16,12 @@
 #define MAX_BLOCKING_DURATION_MICROS (1000 * 1000)
 
 SDRPostThread::SDRPostThread() : IOThread(), buffers("SDRPostThreadBuffers"), visualDataBuffers("SDRPostThreadVisualDataBuffers"), frequency(0) {
-    iqDataInQueue = NULL;
-    iqDataOutQueue = NULL;
-    iqVisualQueue = NULL;
+    iqDataInQueue = nullptr;
+    iqDataOutQueue = nullptr;
+    iqVisualQueue = nullptr;
 
     numChannels = 0;
-    channelizer = NULL;
+    channelizer = nullptr;
     
     sampleRate = 0;
     nRunDemods = 0;
@@ -92,7 +92,7 @@ void SDRPostThread::updateActiveDemodulators() {
             }
         } else if (!demod->isActive()) { // in range, activate if not activated
             demod->setActive(true);
-            if (wxGetApp().getDemodMgr().getLastActiveDemodulator() == NULL) {
+            if (wxGetApp().getDemodMgr().getLastActiveDemodulator() == nullptr) {
 
                 wxGetApp().getDemodMgr().setActiveDemodulator(demod);
             }
@@ -232,7 +232,7 @@ void SDRPostThread::runSingleCH(SDRThreadIQData *data_in) {
     
     size_t refCount = nRunDemods;
     bool doIQDataOut = (iqDataOutQueue != nullptr && !iqDataOutQueue->full());
-    bool doDemodVisOut = (nRunDemods && iqActiveDemodVisualQueue != NULL && !iqActiveDemodVisualQueue->full());
+    bool doDemodVisOut = (nRunDemods && iqActiveDemodVisualQueue != nullptr && !iqActiveDemodVisualQueue->full());
     bool doVisOut = (iqVisualQueue != nullptr && !iqVisualQueue->full());
     
     if (doIQDataOut) {
@@ -309,7 +309,7 @@ void SDRPostThread::runPFBCH(SDRThreadIQData *data_in) {
         
         bool doVis = false;
         
-        if (iqVisualQueue != NULL && !iqVisualQueue->full()) {
+        if (iqVisualQueue != nullptr && !iqVisualQueue->full()) {
             doVis = true;
         }
         
@@ -371,7 +371,7 @@ void SDRPostThread::runPFBCH(SDRThreadIQData *data_in) {
         
         // Run channels
         for (int i = 0; i < numChannels+1; i++) {
-            int doDemodVis = ((activeDemodChannel == i) && (iqActiveDemodVisualQueue != NULL) && !iqActiveDemodVisualQueue->full())?1:0;
+            int doDemodVis = ((activeDemodChannel == i) && (iqActiveDemodVisualQueue != nullptr) && !iqActiveDemodVisualQueue->full())?1:0;
             
             if (!doDemodVis && demodChannelActive[i] == 0) {
                 continue;

--- a/src/sdr/SDRPostThread.h
+++ b/src/sdr/SDRPostThread.h
@@ -11,9 +11,9 @@ public:
     SDRPostThread();
     ~SDRPostThread();
 
-    void bindDemodulator(DemodulatorInstance *demod);
-    void bindDemodulators(std::vector<DemodulatorInstance *> *demods);
-    void removeDemodulator(DemodulatorInstance *demod);
+    void bindDemodulator(DemodulatorInstancePtr demod);
+    void bindDemodulators(const std::vector<DemodulatorInstancePtr>& demods);
+    void removeDemodulator(DemodulatorInstancePtr demod);
     
     virtual void run();
     virtual void terminate();
@@ -30,7 +30,7 @@ protected:
     
     //protects access to demodulators lists and such
     std::mutex busy_demod;
-    std::vector<DemodulatorInstance *> demodulators;
+    std::vector<DemodulatorInstancePtr> demodulators;
 
     
 
@@ -48,7 +48,7 @@ private:
     long long chanBw = 0;
     
     size_t nRunDemods;
-    std::vector<DemodulatorInstance *> runDemods;
+    std::vector<DemodulatorInstancePtr> runDemods;
     std::vector<int> demodChannel;
     std::vector<int> demodChannelActive;
 

--- a/src/sdr/SDRPostThread.h
+++ b/src/sdr/SDRPostThread.h
@@ -11,10 +11,8 @@ public:
     SDRPostThread();
     ~SDRPostThread();
 
-    void bindDemodulator(DemodulatorInstancePtr demod);
-    void bindDemodulators(const std::vector<DemodulatorInstancePtr>& demods);
-    void removeDemodulator(DemodulatorInstancePtr demod);
-    
+    void notifyDemodulatorsChanged();
+   
     virtual void run();
     virtual void terminate();
 
@@ -27,12 +25,6 @@ protected:
     DemodulatorThreadInputQueuePtr iqDataOutQueue;
     DemodulatorThreadInputQueuePtr iqVisualQueue;
     DemodulatorThreadInputQueuePtr iqActiveDemodVisualQueue;
-    
-    //protects access to demodulators lists and such
-    std::mutex busy_demod;
-    std::vector<DemodulatorInstancePtr> demodulators;
-
-    
 
 private:
 

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -13,10 +13,10 @@
 #define TARGET_DISPLAY_FPS 60
 
 SDRThread::SDRThread() : IOThread(), buffers("SDRThreadBuffers") {
-    device = NULL;
+    device = nullptr;
 
-    deviceConfig.store(NULL);
-    deviceInfo.store(NULL);
+    deviceConfig.store(nullptr);
+    deviceInfo.store(nullptr);
 
     sampleRate.store(DEFAULT_SAMPLE_RATE);
     frequency.store(0);

--- a/src/visual/PrimaryGLContext.cpp
+++ b/src/visual/PrimaryGLContext.cpp
@@ -62,7 +62,7 @@ PrimaryGLContext::PrimaryGLContext(wxGLCanvas *canvas, wxGLContext *sharedContex
 //#endif
 }
 
-void PrimaryGLContext::DrawDemodInfo(DemodulatorInstance *demod, RGBA4f color, long long center_freq, long long srate, bool centerline) {
+void PrimaryGLContext::DrawDemodInfo(DemodulatorInstancePtr demod, RGBA4f color, long long center_freq, long long srate, bool centerline) {
     if (!demod) {
         return;
     }
@@ -287,7 +287,7 @@ void PrimaryGLContext::DrawFreqBwInfo(long long freq, int bw, RGBA4f color, long
     glDisable(GL_BLEND);
 }
 
-void PrimaryGLContext::DrawDemod(DemodulatorInstance *demod, RGBA4f color, long long center_freq, long long srate) {
+void PrimaryGLContext::DrawDemod(DemodulatorInstancePtr demod, RGBA4f color, long long center_freq, long long srate) {
     if (!demod) {
         return;
     }
@@ -409,7 +409,8 @@ void PrimaryGLContext::drawSingleDemodLabel(const std::wstring& demodStr, float 
 }
 
 void PrimaryGLContext::DrawFreqSelector(float uxPos, RGBA4f color, float w, long long /* center_freq */, long long srate) {
-    DemodulatorInstance *demod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+    
+    DemodulatorInstancePtr demod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
 
     long long bw = 0;
 

--- a/src/visual/PrimaryGLContext.h
+++ b/src/visual/PrimaryGLContext.h
@@ -26,9 +26,9 @@ public:
 
     void DrawFreqSelector(float uxPos, RGBA4f color, float w = 0, long long center_freq = -1, long long srate = 0);
     void DrawRangeSelector(float uxPos1, float uxPos2, RGBA4f color);
-    void DrawDemod(DemodulatorInstance *demod, RGBA4f color, long long center_freq = -1, long long srate = 0);
+    void DrawDemod(DemodulatorInstancePtr demod, RGBA4f color, long long center_freq = -1, long long srate = 0);
     
-    void DrawDemodInfo(DemodulatorInstance *demod, RGBA4f color, long long center_freq = -1, long long srate = 0, bool centerline = false);
+    void DrawDemodInfo(DemodulatorInstancePtr demod, RGBA4f color, long long center_freq = -1, long long srate = 0, bool centerline = false);
     void DrawFreqBwInfo(long long freq, int bw, RGBA4f color, long long center_freq = - 1, long long srate = 0, bool stack = false, bool centerline = false);
 
     void setHoverAlpha(float hoverAlpha);

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -90,9 +90,8 @@ void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     
     glLoadIdentity();
     
-    std::vector<DemodulatorInstance *> &demods = wxGetApp().getDemodMgr().getDemodulators();
-
-    DemodulatorInstance *activeDemodulator = wxGetApp().getDemodMgr().getActiveDemodulator();
+    auto demods = wxGetApp().getDemodMgr().getDemodulators();
+    auto activeDemodulator = wxGetApp().getDemodMgr().getActiveDemodulator();
 
     for (int i = 0, iMax = demods.size(); i < iMax; i++) {
         if (!demods[i]->isActive()) {
@@ -112,7 +111,7 @@ void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
                 freq = roundf((float)freq/(float)snap)*snap;
             }
 
-            DemodulatorInstance *lastActiveDemodulator = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+            auto lastActiveDemodulator = wxGetApp().getDemodMgr().getLastActiveDemodulator();
 
             bool isNew = (((waterfallCanvas->isShiftDown() || (lastActiveDemodulator && !lastActiveDemodulator->isActive())) && lastActiveDemodulator) || (!lastActiveDemodulator));
             

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -61,7 +61,8 @@ TuningCanvas::~TuningCanvas() {
 }
 
 bool TuningCanvas::changed() {
-    DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+
+    auto activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
     
     long long current_freq = 0;
     if (activeDemod != NULL) {
@@ -92,7 +93,7 @@ void TuningCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
 
     glContext->DrawBegin();
 
-    DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+    auto activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
     
     freq = 0;
     if (activeDemod != NULL) {
@@ -170,7 +171,7 @@ void TuningCanvas::StepTuner(ActiveState state, int exponent, bool up) {
         amount *= 2;
     }
     
-    DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+    auto activeDemod = wxGetApp().getDemodMgr().getLastActiveDemodulator();
     if (state == TUNING_HOVER_FREQ && activeDemod) {
         long long freq = activeDemod->getFrequency();
         long long diff = abs(wxGetApp().getFrequency() - freq);

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -331,7 +331,7 @@ void TuningCanvas::OnMouseMoved(wxMouseEvent& event) {
     if (hoverState == TUNING_HOVER_BW || hoverState == TUNING_HOVER_FREQ) {
          wxGetApp().getDemodMgr().setActiveDemodulator(wxGetApp().getDemodMgr().getLastActiveDemodulator());
      } else {
-         wxGetApp().getDemodMgr().setActiveDemodulator(NULL);
+         wxGetApp().getDemodMgr().setActiveDemodulator(nullptr);
      }
 }
 
@@ -401,7 +401,7 @@ void TuningCanvas::OnMouseLeftWindow(wxMouseEvent& event) {
     SetCursor(wxCURSOR_CROSS);
     hoverIndex = 0;
     hoverState = TUNING_HOVER_NONE;
-    wxGetApp().getDemodMgr().setActiveDemodulator(NULL);
+    wxGetApp().getDemodMgr().setActiveDemodulator(nullptr);
 
     if (currentPPM != lastPPM) {
         wxGetApp().saveConfig();

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -309,9 +309,9 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
             }
         } else {
             if (lastActiveDemodulator) {
-                glContext->DrawDemod(lastActiveDemodulator, ((isNew && activeDemodulator == NULL) || (activeDemodulator != NULL))?currentTheme->waterfallHighlight:currentTheme->waterfallDestroy, currentCenterFreq, currentBandwidth);
+                glContext->DrawDemod(lastActiveDemodulator, ((isNew && activeDemodulator == nullptr) || (activeDemodulator != nullptr))?currentTheme->waterfallHighlight:currentTheme->waterfallDestroy, currentCenterFreq, currentBandwidth);
             }
-            if (activeDemodulator == NULL) {
+            if (activeDemodulator == nullptr) {
                 glContext->DrawFreqSelector(mouseTracker.getMouseX(), ((isNew && lastActiveDemodulator) || (!lastActiveDemodulator) )?currentTheme->waterfallNew:currentTheme->waterfallHover, 0, currentCenterFreq, currentBandwidth);
             } else {
                 glContext->DrawDemod(activeDemodulator, currentTheme->waterfallHover, currentCenterFreq, currentBandwidth);
@@ -539,7 +539,7 @@ void WaterfallCanvas::updateHoverState() {
             }
         }
         
-        if (activeDemodulator == NULL) {
+        if (activeDemodulator == nullptr) {
             nextDragState = WF_DRAG_NONE;
             SetCursor(wxCURSOR_CROSS);
             return;
@@ -593,7 +593,7 @@ void WaterfallCanvas::OnMouseMoved(wxMouseEvent& event) {
     auto demod = wxGetApp().getDemodMgr().getActiveDemodulator();
 
     if (mouseTracker.mouseDown()) {
-        if (demod == NULL) {
+        if (demod == nullptr) {
             return;
         }
         if (dragState == WF_DRAG_BANDWIDTH_LEFT || dragState == WF_DRAG_BANDWIDTH_RIGHT) {
@@ -672,7 +672,7 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
     InteractiveCanvas::OnMouseReleased(event);
     wxGetApp().getDemodMgr().updateLastState();
 
-    bool isNew = shiftDown || (wxGetApp().getDemodMgr().getLastActiveDemodulator() == NULL)
+    bool isNew = shiftDown || (wxGetApp().getDemodMgr().getLastActiveDemodulator() == nullptr)
             || (wxGetApp().getDemodMgr().getLastActiveDemodulator() && !wxGetApp().getDemodMgr().getLastActiveDemodulator()->isActive());
 
     mouseTracker.setVertDragLock(false);
@@ -832,7 +832,7 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
             wxGetApp().notifyDemodulatorsChanged();
         }
 
-        if (demod == NULL) {
+        if (demod == nullptr) {
             dragState = WF_DRAG_NONE;
             return;
         }
@@ -852,7 +852,7 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
 void WaterfallCanvas::OnMouseLeftWindow(wxMouseEvent& event) {
     InteractiveCanvas::OnMouseLeftWindow(event);
     SetCursor(wxCURSOR_CROSS);
-    wxGetApp().getDemodMgr().setActiveDemodulator(NULL);
+    wxGetApp().getDemodMgr().setActiveDemodulator(nullptr);
     mouseZoom = 1.0;
 }
 

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -729,7 +729,7 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
                 demod->writeModemSettings(mgr->getLastModemSettings(mgr->getLastDemodulatorType()));
                 demod->run();
 
-                wxGetApp().bindDemodulator(demod);
+                wxGetApp().notifyDemodulatorsChanged();
                 DemodulatorThread::releaseSquelchLock(nullptr);
             }
 
@@ -829,7 +829,7 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
 
             demod->run();
 
-            wxGetApp().bindDemodulator(demod);
+            wxGetApp().notifyDemodulatorsChanged();
         }
 
         if (demod == NULL) {

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -24,6 +24,8 @@
 
 #include <wx/numformatter.h>
 
+#include "DemodulatorThread.h"
+
 wxBEGIN_EVENT_TABLE(WaterfallCanvas, wxGLCanvas)
 EVT_PAINT(WaterfallCanvas::OnPaint)
 EVT_IDLE(WaterfallCanvas::OnIdle)
@@ -263,10 +265,10 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     waterfallPanel.calcTransform(CubicVR::mat4::identity());
     waterfallPanel.draw();
 
-    std::vector<DemodulatorInstance *> &demods = wxGetApp().getDemodMgr().getDemodulators();
+    auto demods = wxGetApp().getDemodMgr().getDemodulators();
 
-    DemodulatorInstance *activeDemodulator = wxGetApp().getDemodMgr().getActiveDemodulator();
-    DemodulatorInstance *lastActiveDemodulator = wxGetApp().getDemodMgr().getLastActiveDemodulator();
+    auto activeDemodulator = wxGetApp().getDemodMgr().getActiveDemodulator();
+    auto lastActiveDemodulator = wxGetApp().getDemodMgr().getLastActiveDemodulator();
 
     bool isNew = shiftDown
             || (wxGetApp().getDemodMgr().getLastActiveDemodulator() && !wxGetApp().getDemodMgr().getLastActiveDemodulator()->isActive());
@@ -390,7 +392,7 @@ void WaterfallCanvas::OnKeyUp(wxKeyEvent& event) {
 void WaterfallCanvas::OnKeyDown(wxKeyEvent& event) {
     InteractiveCanvas::OnKeyDown(event);
 
-    DemodulatorInstance *activeDemod = wxGetApp().getDemodMgr().getActiveDemodulator();
+    auto activeDemod = wxGetApp().getDemodMgr().getActiveDemodulator();
 
     long long originalFreq = getCenterFrequency();
     long long freq = originalFreq;
@@ -490,9 +492,9 @@ void WaterfallCanvas::OnIdle(wxIdleEvent &event) {
 void WaterfallCanvas::updateHoverState() {
     long long freqPos = getFrequencyAt(mouseTracker.getMouseX());
     
-    std::vector<DemodulatorInstance *> demodsHover = wxGetApp().getDemodMgr().getDemodulatorsAt(freqPos, 15000);
+    auto demodsHover = wxGetApp().getDemodMgr().getDemodulatorsAt(freqPos, 15000);
     
-    wxGetApp().getDemodMgr().setActiveDemodulator(NULL);
+    wxGetApp().getDemodMgr().setActiveDemodulator(nullptr);
     
     if (altDown) {
         nextDragState = WF_DRAG_RANGE;
@@ -506,10 +508,10 @@ void WaterfallCanvas::updateHoverState() {
     } else if (demodsHover.size() && !shiftDown) {
         long near_dist = getBandwidth();
         
-        DemodulatorInstance *activeDemodulator = NULL;
+        DemodulatorInstancePtr activeDemodulator = nullptr;
         
         for (int i = 0, iMax = demodsHover.size(); i < iMax; i++) {
-            DemodulatorInstance *demod = demodsHover[i];
+            auto demod = demodsHover[i];
             long long freqDiff = demod->getFrequency() - freqPos;
             long halfBw = (demod->getBandwidth() / 2);
             long long currentBw = getBandwidth();
@@ -588,7 +590,7 @@ void WaterfallCanvas::updateHoverState() {
 
 void WaterfallCanvas::OnMouseMoved(wxMouseEvent& event) {
     InteractiveCanvas::OnMouseMoved(event);
-    DemodulatorInstance *demod = wxGetApp().getDemodMgr().getActiveDemodulator();
+    auto demod = wxGetApp().getDemodMgr().getActiveDemodulator();
 
     if (mouseTracker.mouseDown()) {
         if (demod == NULL) {
@@ -650,7 +652,7 @@ void WaterfallCanvas::OnMouseDown(wxMouseEvent& event) {
     wxGetApp().getDemodMgr().updateLastState();
 
     if (dragState && dragState != WF_DRAG_RANGE) {
-        DemodulatorInstance *demod = wxGetApp().getDemodMgr().getActiveDemodulator();
+        auto demod = wxGetApp().getDemodMgr().getActiveDemodulator();
         if (demod) {
             dragOfs = (long long) (mouseTracker.getMouseX() * (float) getBandwidth()) + getCenterFrequency() - (getBandwidth() / 2) - demod->getFrequency();
             dragBW = demod->getBandwidth();
@@ -676,8 +678,8 @@ void WaterfallCanvas::OnMouseReleased(wxMouseEvent& event) {
     mouseTracker.setVertDragLock(false);
     mouseTracker.setHorizDragLock(false);
 
-    DemodulatorInstance *demod = isNew?NULL:wxGetApp().getDemodMgr().getLastActiveDemodulator();
-    DemodulatorInstance *activeDemod = isNew?NULL:wxGetApp().getDemodMgr().getActiveDemodulator();
+    DemodulatorInstancePtr demod = isNew?nullptr:wxGetApp().getDemodMgr().getLastActiveDemodulator();
+    DemodulatorInstancePtr activeDemod = isNew?nullptr:wxGetApp().getDemodMgr().getActiveDemodulator();
 
     DemodulatorMgr *mgr = &wxGetApp().getDemodMgr();
 


### PR DESCRIPTION
@cjcliffe  Hello! This PR brings DemodulatorInstance automatic memory management using ``std::shared_ptr<DemodulatorInstance>` encapsulation by CubicSDR code.
This PR brings the following benefits:
-  No longer need to `garbageCollect` manuallly or anything,
-  Always correct deallocation, authorized only when no code is using the instance,
-  SDRPostThread simplification: no need to maintain a private copy of demodulators that can turn de-synchronized in case of problems,
-  Thanks to `std::shared_ptr`, in the worst case `DemodulatorMgr::getDemodulators()` returns a not-up-to-date list of demodulators, but all of them are actually (valid/still allocated) demodulators for the client code,
-  Misc: liberal use of `auto` in the modified code. 

A very important exception to the use of `std_shared_ptr` is in `DemodulatorPreThread` and `DemodulatorThread` where DemodulatorInstance parent must stay a raw pointer, because of the circular dependency. This is perfectly fine, because those thread lifetimes are completely managed by the  DemodulatorInstance itself.