### PR TITLE
Halloween compiler Warnings cleanup

### DIFF
--- a/external/cubicvr2/math/mat4.h
+++ b/external/cubicvr2/math/mat4.h
@@ -324,7 +324,7 @@ namespace CubicVR {
         };
         
         static vec3 unProject(mat4 pMatrix, mat4 mvMatrix, float width, float height, float winx, float winy, float /* winz */) {
-            vec4 p(((winx / width) * 2.0f) - 1.0, -(((winy / height) * 2.0f) - 1.0), 1.0, 1.0);
+            vec4 p(((winx / width) * 2.0f) - 1.0f, -(((winy / height) * 2.0f) - 1.0f), 1.0f, 1.0f);
             
             vec4 invp = mat4::vec4_multiply(mat4::vec4_multiply(p, mat4::inverse(pMatrix)), mat4::inverse(mvMatrix));
             

--- a/src/forms/Bookmark/BookmarkPanel.cpp
+++ b/src/forms/Bookmark/BookmarkPanel.cpp
@@ -1,136 +1,136 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Jun 17 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "BookmarkPanel.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-BookmarkPanel::BookmarkPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style ) : wxPanel( parent, id, pos, size, style )
+BookmarkPanel::BookmarkPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style) : wxPanel(parent, id, pos, size, style)
 {
 	wxBoxSizer* bSizer1;
-	bSizer1 = new wxBoxSizer( wxVERTICAL );
-	
-	m_searchText = new wxTextCtrl( this, wxID_ANY, wxT("Search.."), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
-	bSizer1->Add( m_searchText, 0, wxALL|wxEXPAND, 5 );
-	
-	m_clearSearchButton = new wxButton( this, wxID_ANY, wxT("Clear Search"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer1->Add( m_clearSearchButton, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
-	m_treeView = new wxTreeCtrl( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE|wxTR_HAS_VARIABLE_ROW_HEIGHT|wxTR_HIDE_ROOT|wxTR_SINGLE );
-	bSizer1->Add( m_treeView, 1, wxEXPAND, 5 );
-	
-	m_propPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	bSizer1 = new wxBoxSizer(wxVERTICAL);
+
+	m_searchText = new wxTextCtrl(this, wxID_ANY, wxT("Search.."), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	bSizer1->Add(m_searchText, 0, wxALL | wxEXPAND, 5);
+
+	m_clearSearchButton = new wxButton(this, wxID_ANY, wxT("Clear Search"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer1->Add(m_clearSearchButton, 0, wxBOTTOM | wxEXPAND | wxLEFT | wxRIGHT, 5);
+
+	m_treeView = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE | wxTR_HAS_VARIABLE_ROW_HEIGHT | wxTR_HIDE_ROOT | wxTR_SINGLE);
+	bSizer1->Add(m_treeView, 1, wxEXPAND, 5);
+
+	m_propPanel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxFlexGridSizer* fgPropSizer;
-	fgPropSizer = new wxFlexGridSizer( 0, 2, 0, 0 );
-	fgPropSizer->AddGrowableCol( 1 );
-	fgPropSizer->SetFlexibleDirection( wxBOTH );
-	fgPropSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_labelLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("Label"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_labelLabel->Wrap( -1 );
-	fgPropSizer->Add( m_labelLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
-	m_labelText = new wxTextCtrl( m_propPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
-	fgPropSizer->Add( m_labelText, 0, wxALL|wxEXPAND, 5 );
-	
-	m_frequencyLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("Freq"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_frequencyLabel->Wrap( -1 );
-	fgPropSizer->Add( m_frequencyLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
-	m_frequencyVal = new wxStaticText( m_propPanel, wxID_ANY, wxT("FrequencyVal"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_frequencyVal->Wrap( -1 );
-	fgPropSizer->Add( m_frequencyVal, 0, wxALL, 5 );
-	
-	m_bandwidthLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("BW"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_bandwidthLabel->Wrap( -1 );
-	fgPropSizer->Add( m_bandwidthLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
-	m_bandwidthVal = new wxStaticText( m_propPanel, wxID_ANY, wxT("BandwidthVal"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_bandwidthVal->Wrap( -1 );
-	fgPropSizer->Add( m_bandwidthVal, 0, wxALL, 5 );
-	
-	m_modulationLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("Type"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_modulationLabel->Wrap( -1 );
-	fgPropSizer->Add( m_modulationLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
-	m_modulationVal = new wxStaticText( m_propPanel, wxID_ANY, wxT("TypeVal"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_modulationVal->Wrap( -1 );
-	fgPropSizer->Add( m_modulationVal, 0, wxALL, 5 );
-	
-	
-	m_propPanel->SetSizer( fgPropSizer );
+	fgPropSizer = new wxFlexGridSizer(0, 2, 0, 0);
+	fgPropSizer->AddGrowableCol(1);
+	fgPropSizer->SetFlexibleDirection(wxBOTH);
+	fgPropSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+	m_labelLabel = new wxStaticText(m_propPanel, wxID_ANY, wxT("Label"), wxDefaultPosition, wxDefaultSize, 0);
+	m_labelLabel->Wrap(-1);
+	fgPropSizer->Add(m_labelLabel, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 5);
+
+	m_labelText = new wxTextCtrl(m_propPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	fgPropSizer->Add(m_labelText, 0, wxALL | wxEXPAND, 5);
+
+	m_frequencyLabel = new wxStaticText(m_propPanel, wxID_ANY, wxT("Freq"), wxDefaultPosition, wxDefaultSize, 0);
+	m_frequencyLabel->Wrap(-1);
+	fgPropSizer->Add(m_frequencyLabel, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 5);
+
+	m_frequencyVal = new wxStaticText(m_propPanel, wxID_ANY, wxT("FrequencyVal"), wxDefaultPosition, wxDefaultSize, 0);
+	m_frequencyVal->Wrap(-1);
+	fgPropSizer->Add(m_frequencyVal, 0, wxALL, 5);
+
+	m_bandwidthLabel = new wxStaticText(m_propPanel, wxID_ANY, wxT("BW"), wxDefaultPosition, wxDefaultSize, 0);
+	m_bandwidthLabel->Wrap(-1);
+	fgPropSizer->Add(m_bandwidthLabel, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 5);
+
+	m_bandwidthVal = new wxStaticText(m_propPanel, wxID_ANY, wxT("BandwidthVal"), wxDefaultPosition, wxDefaultSize, 0);
+	m_bandwidthVal->Wrap(-1);
+	fgPropSizer->Add(m_bandwidthVal, 0, wxALL, 5);
+
+	m_modulationLabel = new wxStaticText(m_propPanel, wxID_ANY, wxT("Type"), wxDefaultPosition, wxDefaultSize, 0);
+	m_modulationLabel->Wrap(-1);
+	fgPropSizer->Add(m_modulationLabel, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT, 5);
+
+	m_modulationVal = new wxStaticText(m_propPanel, wxID_ANY, wxT("TypeVal"), wxDefaultPosition, wxDefaultSize, 0);
+	m_modulationVal->Wrap(-1);
+	fgPropSizer->Add(m_modulationVal, 0, wxALL, 5);
+
+
+	m_propPanel->SetSizer(fgPropSizer);
 	m_propPanel->Layout();
-	fgPropSizer->Fit( m_propPanel );
-	bSizer1->Add( m_propPanel, 0, wxALL|wxBOTTOM|wxEXPAND|wxTOP, 5 );
-	
-	m_buttonPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	fgPropSizer->Fit(m_propPanel);
+	bSizer1->Add(m_propPanel, 0, wxALL | wxBOTTOM | wxEXPAND | wxTOP, 5);
+
+	m_buttonPanel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* m_buttonPanelSizer;
-	m_buttonPanelSizer = new wxBoxSizer( wxVERTICAL );
-	
-	
-	m_buttonPanel->SetSizer( m_buttonPanelSizer );
+	m_buttonPanelSizer = new wxBoxSizer(wxVERTICAL);
+
+
+	m_buttonPanel->SetSizer(m_buttonPanelSizer);
 	m_buttonPanel->Layout();
-	m_buttonPanelSizer->Fit( m_buttonPanel );
-	bSizer1->Add( m_buttonPanel, 0, wxALL|wxEXPAND, 5 );
-	
-	
-	this->SetSizer( bSizer1 );
+	m_buttonPanelSizer->Fit(m_buttonPanel);
+	bSizer1->Add(m_buttonPanel, 0, wxALL | wxEXPAND, 5);
+
+
+	this->SetSizer(bSizer1);
 	this->Layout();
-	m_updateTimer.SetOwner( this, wxID_ANY );
-	
+	m_updateTimer.SetOwner(this, wxID_ANY);
+
 	// Connect Events
-	this->Connect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( BookmarkPanel::onEnterWindow ) );
-	this->Connect( wxEVT_LEAVE_WINDOW, wxMouseEventHandler( BookmarkPanel::onLeaveWindow ) );
-	this->Connect( wxEVT_MOTION, wxMouseEventHandler( BookmarkPanel::onMotion ) );
-	m_searchText->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler( BookmarkPanel::onSearchTextFocus ), NULL, this );
-	m_searchText->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( BookmarkPanel::onSearchText ), NULL, this );
-	m_clearSearchButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( BookmarkPanel::onClearSearch ), NULL, this );
-	m_treeView->Connect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( BookmarkPanel::onEnterWindow ), NULL, this );
-	m_treeView->Connect( wxEVT_LEAVE_WINDOW, wxMouseEventHandler( BookmarkPanel::onLeaveWindow ), NULL, this );
-	m_treeView->Connect( wxEVT_MOTION, wxMouseEventHandler( BookmarkPanel::onMotion ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_BEGIN_DRAG, wxTreeEventHandler( BookmarkPanel::onTreeBeginDrag ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_END_DRAG, wxTreeEventHandler( BookmarkPanel::onTreeEndDrag ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_ITEM_ACTIVATED, wxTreeEventHandler( BookmarkPanel::onTreeActivate ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_ITEM_COLLAPSED, wxTreeEventHandler( BookmarkPanel::onTreeCollapse ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_ITEM_EXPANDED, wxTreeEventHandler( BookmarkPanel::onTreeExpanded ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP, wxTreeEventHandler( BookmarkPanel::onTreeItemGetTooltip ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_ITEM_MENU, wxTreeEventHandler( BookmarkPanel::onTreeItemMenu ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler( BookmarkPanel::onTreeSelect ), NULL, this );
-	m_treeView->Connect( wxEVT_COMMAND_TREE_SEL_CHANGING, wxTreeEventHandler( BookmarkPanel::onTreeSelectChanging ), NULL, this );
-	m_labelText->Connect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( BookmarkPanel::onLabelText ), NULL, this );
-	m_frequencyVal->Connect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( BookmarkPanel::onDoubleClickFreq ), NULL, this );
-	m_bandwidthVal->Connect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( BookmarkPanel::onDoubleClickBandwidth ), NULL, this );
-	this->Connect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( BookmarkPanel::onUpdateTimer ) );
+	this->Connect(wxEVT_ENTER_WINDOW, wxMouseEventHandler(BookmarkPanel::onEnterWindow));
+	this->Connect(wxEVT_LEAVE_WINDOW, wxMouseEventHandler(BookmarkPanel::onLeaveWindow));
+	this->Connect(wxEVT_MOTION, wxMouseEventHandler(BookmarkPanel::onMotion));
+	m_searchText->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(BookmarkPanel::onSearchTextFocus), NULL, this);
+	m_searchText->Connect(wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler(BookmarkPanel::onSearchText), NULL, this);
+	m_clearSearchButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(BookmarkPanel::onClearSearch), NULL, this);
+	m_treeView->Connect(wxEVT_ENTER_WINDOW, wxMouseEventHandler(BookmarkPanel::onEnterWindow), NULL, this);
+	m_treeView->Connect(wxEVT_LEAVE_WINDOW, wxMouseEventHandler(BookmarkPanel::onLeaveWindow), NULL, this);
+	m_treeView->Connect(wxEVT_MOTION, wxMouseEventHandler(BookmarkPanel::onMotion), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_BEGIN_DRAG, wxTreeEventHandler(BookmarkPanel::onTreeBeginDrag), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_END_DRAG, wxTreeEventHandler(BookmarkPanel::onTreeEndDrag), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_ITEM_ACTIVATED, wxTreeEventHandler(BookmarkPanel::onTreeActivate), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_ITEM_COLLAPSED, wxTreeEventHandler(BookmarkPanel::onTreeCollapse), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_ITEM_EXPANDED, wxTreeEventHandler(BookmarkPanel::onTreeExpanded), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP, wxTreeEventHandler(BookmarkPanel::onTreeItemGetTooltip), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_ITEM_MENU, wxTreeEventHandler(BookmarkPanel::onTreeItemMenu), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler(BookmarkPanel::onTreeSelect), NULL, this);
+	m_treeView->Connect(wxEVT_COMMAND_TREE_SEL_CHANGING, wxTreeEventHandler(BookmarkPanel::onTreeSelectChanging), NULL, this);
+	m_labelText->Connect(wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler(BookmarkPanel::onLabelText), NULL, this);
+	m_frequencyVal->Connect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(BookmarkPanel::onDoubleClickFreq), NULL, this);
+	m_bandwidthVal->Connect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(BookmarkPanel::onDoubleClickBandwidth), NULL, this);
+	this->Connect(wxID_ANY, wxEVT_TIMER, wxTimerEventHandler(BookmarkPanel::onUpdateTimer));
 }
 
 BookmarkPanel::~BookmarkPanel()
 {
 	// Disconnect Events
-	this->Disconnect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( BookmarkPanel::onEnterWindow ) );
-	this->Disconnect( wxEVT_LEAVE_WINDOW, wxMouseEventHandler( BookmarkPanel::onLeaveWindow ) );
-	this->Disconnect( wxEVT_MOTION, wxMouseEventHandler( BookmarkPanel::onMotion ) );
-	m_searchText->Disconnect( wxEVT_LEFT_DOWN, wxMouseEventHandler( BookmarkPanel::onSearchTextFocus ), NULL, this );
-	m_searchText->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( BookmarkPanel::onSearchText ), NULL, this );
-	m_clearSearchButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( BookmarkPanel::onClearSearch ), NULL, this );
-	m_treeView->Disconnect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( BookmarkPanel::onEnterWindow ), NULL, this );
-	m_treeView->Disconnect( wxEVT_LEAVE_WINDOW, wxMouseEventHandler( BookmarkPanel::onLeaveWindow ), NULL, this );
-	m_treeView->Disconnect( wxEVT_MOTION, wxMouseEventHandler( BookmarkPanel::onMotion ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_BEGIN_DRAG, wxTreeEventHandler( BookmarkPanel::onTreeBeginDrag ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_END_DRAG, wxTreeEventHandler( BookmarkPanel::onTreeEndDrag ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_ITEM_ACTIVATED, wxTreeEventHandler( BookmarkPanel::onTreeActivate ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_ITEM_COLLAPSED, wxTreeEventHandler( BookmarkPanel::onTreeCollapse ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_ITEM_EXPANDED, wxTreeEventHandler( BookmarkPanel::onTreeExpanded ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP, wxTreeEventHandler( BookmarkPanel::onTreeItemGetTooltip ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_ITEM_MENU, wxTreeEventHandler( BookmarkPanel::onTreeItemMenu ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler( BookmarkPanel::onTreeSelect ), NULL, this );
-	m_treeView->Disconnect( wxEVT_COMMAND_TREE_SEL_CHANGING, wxTreeEventHandler( BookmarkPanel::onTreeSelectChanging ), NULL, this );
-	m_labelText->Disconnect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( BookmarkPanel::onLabelText ), NULL, this );
-	m_frequencyVal->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( BookmarkPanel::onDoubleClickFreq ), NULL, this );
-	m_bandwidthVal->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( BookmarkPanel::onDoubleClickBandwidth ), NULL, this );
-	this->Disconnect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( BookmarkPanel::onUpdateTimer ) );
-	
+	this->Disconnect(wxEVT_ENTER_WINDOW, wxMouseEventHandler(BookmarkPanel::onEnterWindow));
+	this->Disconnect(wxEVT_LEAVE_WINDOW, wxMouseEventHandler(BookmarkPanel::onLeaveWindow));
+	this->Disconnect(wxEVT_MOTION, wxMouseEventHandler(BookmarkPanel::onMotion));
+	m_searchText->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(BookmarkPanel::onSearchTextFocus), NULL, this);
+	m_searchText->Disconnect(wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler(BookmarkPanel::onSearchText), NULL, this);
+	m_clearSearchButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(BookmarkPanel::onClearSearch), NULL, this);
+	m_treeView->Disconnect(wxEVT_ENTER_WINDOW, wxMouseEventHandler(BookmarkPanel::onEnterWindow), NULL, this);
+	m_treeView->Disconnect(wxEVT_LEAVE_WINDOW, wxMouseEventHandler(BookmarkPanel::onLeaveWindow), NULL, this);
+	m_treeView->Disconnect(wxEVT_MOTION, wxMouseEventHandler(BookmarkPanel::onMotion), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_BEGIN_DRAG, wxTreeEventHandler(BookmarkPanel::onTreeBeginDrag), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_END_DRAG, wxTreeEventHandler(BookmarkPanel::onTreeEndDrag), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_ITEM_ACTIVATED, wxTreeEventHandler(BookmarkPanel::onTreeActivate), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_ITEM_COLLAPSED, wxTreeEventHandler(BookmarkPanel::onTreeCollapse), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_ITEM_EXPANDED, wxTreeEventHandler(BookmarkPanel::onTreeExpanded), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP, wxTreeEventHandler(BookmarkPanel::onTreeItemGetTooltip), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_ITEM_MENU, wxTreeEventHandler(BookmarkPanel::onTreeItemMenu), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler(BookmarkPanel::onTreeSelect), NULL, this);
+	m_treeView->Disconnect(wxEVT_COMMAND_TREE_SEL_CHANGING, wxTreeEventHandler(BookmarkPanel::onTreeSelectChanging), NULL, this);
+	m_labelText->Disconnect(wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler(BookmarkPanel::onLabelText), NULL, this);
+	m_frequencyVal->Disconnect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(BookmarkPanel::onDoubleClickFreq), NULL, this);
+	m_bandwidthVal->Disconnect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(BookmarkPanel::onDoubleClickBandwidth), NULL, this);
+	this->Disconnect(wxID_ANY, wxEVT_TIMER, wxTimerEventHandler(BookmarkPanel::onUpdateTimer));
+
 }

--- a/src/forms/Bookmark/BookmarkPanel.h
+++ b/src/forms/Bookmark/BookmarkPanel.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Jun 17 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __BOOKMARKPANEL_H__
@@ -29,53 +29,53 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class BookmarkPanel
 ///////////////////////////////////////////////////////////////////////////////
-class BookmarkPanel : public wxPanel 
+class BookmarkPanel : public wxPanel
 {
-	private:
-	
-	protected:
-		wxTextCtrl* m_searchText;
-		wxButton* m_clearSearchButton;
-		wxTreeCtrl* m_treeView;
-		wxPanel* m_propPanel;
-		wxStaticText* m_labelLabel;
-		wxTextCtrl* m_labelText;
-		wxStaticText* m_frequencyLabel;
-		wxStaticText* m_frequencyVal;
-		wxStaticText* m_bandwidthLabel;
-		wxStaticText* m_bandwidthVal;
-		wxStaticText* m_modulationLabel;
-		wxStaticText* m_modulationVal;
-		wxPanel* m_buttonPanel;
-		wxTimer m_updateTimer;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void onEnterWindow( wxMouseEvent& event ) { event.Skip(); }
-		virtual void onLeaveWindow( wxMouseEvent& event ) { event.Skip(); }
-		virtual void onMotion( wxMouseEvent& event ) { event.Skip(); }
-		virtual void onSearchTextFocus( wxMouseEvent& event ) { event.Skip(); }
-		virtual void onSearchText( wxCommandEvent& event ) { event.Skip(); }
-		virtual void onClearSearch( wxCommandEvent& event ) { event.Skip(); }
-		virtual void onTreeBeginDrag( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeEndDrag( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeActivate( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeCollapse( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeExpanded( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeItemGetTooltip( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeItemMenu( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeSelect( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onTreeSelectChanging( wxTreeEvent& event ) { event.Skip(); }
-		virtual void onLabelText( wxCommandEvent& event ) { event.Skip(); }
-		virtual void onDoubleClickFreq( wxMouseEvent& event ) { event.Skip(); }
-		virtual void onDoubleClickBandwidth( wxMouseEvent& event ) { event.Skip(); }
-		virtual void onUpdateTimer( wxTimerEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		BookmarkPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 169,471 ), long style = wxTAB_TRAVERSAL ); 
-		~BookmarkPanel();
-	
+private:
+
+protected:
+	wxTextCtrl* m_searchText;
+	wxButton* m_clearSearchButton;
+	wxTreeCtrl* m_treeView;
+	wxPanel* m_propPanel;
+	wxStaticText* m_labelLabel;
+	wxTextCtrl* m_labelText;
+	wxStaticText* m_frequencyLabel;
+	wxStaticText* m_frequencyVal;
+	wxStaticText* m_bandwidthLabel;
+	wxStaticText* m_bandwidthVal;
+	wxStaticText* m_modulationLabel;
+	wxStaticText* m_modulationVal;
+	wxPanel* m_buttonPanel;
+	wxTimer m_updateTimer;
+
+	// Virtual event handlers, overide them in your derived class
+	virtual void onEnterWindow(wxMouseEvent& event) { event.Skip(); }
+	virtual void onLeaveWindow(wxMouseEvent& event) { event.Skip(); }
+	virtual void onMotion(wxMouseEvent& event) { event.Skip(); }
+	virtual void onSearchTextFocus(wxMouseEvent& event) { event.Skip(); }
+	virtual void onSearchText(wxCommandEvent& event) { event.Skip(); }
+	virtual void onClearSearch(wxCommandEvent& event) { event.Skip(); }
+	virtual void onTreeBeginDrag(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeEndDrag(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeActivate(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeCollapse(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeExpanded(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeItemGetTooltip(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeItemMenu(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeSelect(wxTreeEvent& event) { event.Skip(); }
+	virtual void onTreeSelectChanging(wxTreeEvent& event) { event.Skip(); }
+	virtual void onLabelText(wxCommandEvent& event) { event.Skip(); }
+	virtual void onDoubleClickFreq(wxMouseEvent& event) { event.Skip(); }
+	virtual void onDoubleClickBandwidth(wxMouseEvent& event) { event.Skip(); }
+	virtual void onUpdateTimer(wxTimerEvent& event) { event.Skip(); }
+
+
+public:
+
+	BookmarkPanel(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(169, 471), long style = wxTAB_TRAVERSAL);
+	~BookmarkPanel();
+
 };
 
 #endif //__BOOKMARKPANEL_H__

--- a/src/forms/Dialog/AboutDialogBase.cpp
+++ b/src/forms/Dialog/AboutDialogBase.cpp
@@ -1,483 +1,483 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "AboutDialogBase.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-AboutDialogBase::AboutDialogBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
+AboutDialogBase::AboutDialogBase(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
+	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+
 	wxBoxSizer* dlgSizer;
-	dlgSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_hPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	dlgSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_hPanel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* m_hSizer;
-	m_hSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_appName = new wxStaticText( m_hPanel, wxID_ANY, wxT("CubicSDR"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_appName->Wrap( -1 );
-	m_appName->SetFont( wxFont( 20, 70, 90, 90, false, wxEmptyString ) );
-	
-	m_hSizer->Add( m_appName, 0, wxALL, 6 );
-	
-	
-	m_hPanel->SetSizer( m_hSizer );
+	m_hSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	m_appName = new wxStaticText(m_hPanel, wxID_ANY, wxT("CubicSDR"), wxDefaultPosition, wxDefaultSize, 0);
+	m_appName->Wrap(-1);
+	m_appName->SetFont(wxFont(20, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_hSizer->Add(m_appName, 0, wxALL, 6);
+
+
+	m_hPanel->SetSizer(m_hSizer);
 	m_hPanel->Layout();
-	m_hSizer->Fit( m_hPanel );
-	dlgSizer->Add( m_hPanel, 0, wxALL|wxEXPAND, 5 );
-	
-	m_aboutNotebook = new wxNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbScroll = new wxScrolledWindow( m_aboutNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL|wxVSCROLL );
-	m_dbScroll->SetScrollRate( 5, 5 );
+	m_hSizer->Fit(m_hPanel);
+	dlgSizer->Add(m_hPanel, 0, wxALL | wxEXPAND, 5);
+
+	m_aboutNotebook = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
+	m_dbScroll = new wxScrolledWindow(m_aboutNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxVSCROLL);
+	m_dbScroll->SetScrollRate(5, 5);
 	wxBoxSizer* m_dbPane;
-	m_dbPane = new wxBoxSizer( wxVERTICAL );
-	
+	m_dbPane = new wxBoxSizer(wxVERTICAL);
+
 	wxFlexGridSizer* m_dbSizer;
-	m_dbSizer = new wxFlexGridSizer( 0, 3, 2, 20 );
-	m_dbSizer->SetFlexibleDirection( wxBOTH );
-	m_dbSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_ALL );
-	
-	m_dbHeader = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Developed By"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_dbHeader->Wrap( -1 );
-	m_dbHeader->SetFont( wxFont( 15, 70, 90, 90, false, wxEmptyString ) );
-	
-	m_dbSizer->Add( m_dbHeader, 0, wxALL, 5 );
-	
-	m_dbGHHeader = new wxStaticText( m_dbScroll, wxID_ANY, wxT("GitHub"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbGHHeader->Wrap( -1 );
-	m_dbGHHeader->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
-	
-	m_dbSizer->Add( m_dbGHHeader, 0, wxALL, 5 );
-	
-	m_dbTwitter = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Twitter"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbTwitter->Wrap( -1 );
-	m_dbTwitter->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
-	
-	m_dbSizer->Add( m_dbTwitter, 0, wxALL, 5 );
-	
-	m_dbCharlesCliffe = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Charles J. Cliffe"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbCharlesCliffe->Wrap( -1 );
-	m_dbSizer->Add( m_dbCharlesCliffe, 0, wxALL, 5 );
-	
-	m_dbghCC = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@cjcliffe"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbghCC->Wrap( -1 );
-	m_dbSizer->Add( m_dbghCC, 0, wxALL, 5 );
-	
-	m_dbtCC = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@ccliffe"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbtCC->Wrap( -1 );
-	m_dbSizer->Add( m_dbtCC, 0, wxALL, 5 );
-	
-	m_dbVincentSonnier = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Vincent Sonnier"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbVincentSonnier->Wrap( -1 );
-	m_dbSizer->Add( m_dbVincentSonnier, 0, wxALL, 5 );
-	
-	m_dbghVS = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@vsonnier"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbghVS->Wrap( -1 );
-	m_dbSizer->Add( m_dbghVS, 0, wxALL, 5 );
-	
-	m_dbtVS = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@VincentSonnier"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dbtVS->Wrap( -1 );
-	m_dbSizer->Add( m_dbtVS, 0, wxALL, 5 );
-	
-	
-	m_dbPane->Add( m_dbSizer, 0, wxALL|wxEXPAND, 5 );
-	
-	m_dbDivider1 = new wxStaticLine( m_dbScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-	m_dbPane->Add( m_dbDivider1, 0, wxALL|wxEXPAND, 10 );
-	
+	m_dbSizer = new wxFlexGridSizer(0, 3, 2, 20);
+	m_dbSizer->SetFlexibleDirection(wxBOTH);
+	m_dbSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_ALL);
+
+	m_dbHeader = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Developed By"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_dbHeader->Wrap(-1);
+	m_dbHeader->SetFont(wxFont(15, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_dbSizer->Add(m_dbHeader, 0, wxALL, 5);
+
+	m_dbGHHeader = new wxStaticText(m_dbScroll, wxID_ANY, wxT("GitHub"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbGHHeader->Wrap(-1);
+	m_dbGHHeader->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_dbSizer->Add(m_dbGHHeader, 0, wxALL, 5);
+
+	m_dbTwitter = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Twitter"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbTwitter->Wrap(-1);
+	m_dbTwitter->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_dbSizer->Add(m_dbTwitter, 0, wxALL, 5);
+
+	m_dbCharlesCliffe = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Charles J. Cliffe"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbCharlesCliffe->Wrap(-1);
+	m_dbSizer->Add(m_dbCharlesCliffe, 0, wxALL, 5);
+
+	m_dbghCC = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@cjcliffe"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbghCC->Wrap(-1);
+	m_dbSizer->Add(m_dbghCC, 0, wxALL, 5);
+
+	m_dbtCC = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@ccliffe"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbtCC->Wrap(-1);
+	m_dbSizer->Add(m_dbtCC, 0, wxALL, 5);
+
+	m_dbVincentSonnier = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Vincent Sonnier"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbVincentSonnier->Wrap(-1);
+	m_dbSizer->Add(m_dbVincentSonnier, 0, wxALL, 5);
+
+	m_dbghVS = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@vsonnier"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbghVS->Wrap(-1);
+	m_dbSizer->Add(m_dbghVS, 0, wxALL, 5);
+
+	m_dbtVS = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@VincentSonnier"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dbtVS->Wrap(-1);
+	m_dbSizer->Add(m_dbtVS, 0, wxALL, 5);
+
+
+	m_dbPane->Add(m_dbSizer, 0, wxALL | wxEXPAND, 5);
+
+	m_dbDivider1 = new wxStaticLine(m_dbScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL);
+	m_dbPane->Add(m_dbDivider1, 0, wxALL | wxEXPAND, 10);
+
 	wxFlexGridSizer* m_cSizer;
-	m_cSizer = new wxFlexGridSizer( 0, 2, 2, 20 );
-	m_cSizer->SetFlexibleDirection( wxBOTH );
-	m_cSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_ALL );
-	
-	m_cContributorsHeader = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Contributors"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_cContributorsHeader->Wrap( -1 );
-	m_cContributorsHeader->SetFont( wxFont( 15, 70, 90, 90, false, wxEmptyString ) );
-	
-	m_cSizer->Add( m_cContributorsHeader, 0, wxALL, 5 );
-	
-	m_cGitHub = new wxStaticText( m_dbScroll, wxID_ANY, wxT("GitHub"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cGitHub->Wrap( -1 );
-	m_cGitHub->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
-	
-	m_cSizer->Add( m_cGitHub, 0, wxALL, 5 );
-	
-	m_cCorneLukken = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Corne Lukken"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cCorneLukken->Wrap( -1 );
-	m_cSizer->Add( m_cCorneLukken, 0, wxALL, 5 );
-	
-	m_cghCL = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@Dantali0n"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghCL->Wrap( -1 );
-	m_cSizer->Add( m_cghCL, 0, wxALL, 5 );
-	
-	m_cStainislawPitucha = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Stanisław Pitucha"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cStainislawPitucha->Wrap( -1 );
-	m_cSizer->Add( m_cStainislawPitucha, 0, wxALL, 5 );
-	
-	m_cghSP = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@viraptor"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghSP->Wrap( -1 );
-	m_cSizer->Add( m_cghSP, 0, wxALL, 5 );
-	
-	m_cghStefanTalpalaru = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Ștefan Talpalaru"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghStefanTalpalaru->Wrap( -1 );
-	m_cSizer->Add( m_cghStefanTalpalaru, 0, wxALL, 5 );
-	
-	m_cghST = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@stefantalpalaru"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghST->Wrap( -1 );
-	m_cSizer->Add( m_cghST, 0, wxALL, 5 );
-	
-	m_cCrisMotch = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Chris Motch"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cCrisMotch->Wrap( -1 );
-	m_cSizer->Add( m_cCrisMotch, 0, wxALL, 5 );
-	
-	m_cghCM = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@bodrick"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghCM->Wrap( -1 );
-	m_cSizer->Add( m_cghCM, 0, wxALL, 5 );
-	
-	m_cMariuszRyndzionek = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Mariusz Ryndzionek"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cMariuszRyndzionek->Wrap( -1 );
-	m_cSizer->Add( m_cMariuszRyndzionek, 0, wxALL, 5 );
-	
-	m_cghMR = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@mryndzionek"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghMR->Wrap( -1 );
-	m_cSizer->Add( m_cghMR, 0, wxALL, 5 );
-	
-	m_cJiangWei = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Jiang Wei"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cJiangWei->Wrap( -1 );
-	m_cSizer->Add( m_cJiangWei, 0, wxALL, 5 );
-	
-	m_cghJW = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@jocover"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghJW->Wrap( -1 );
-	m_cSizer->Add( m_cghJW, 0, wxALL, 5 );
-	
-	m_cTomSwartz = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Tom Swartz"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cTomSwartz->Wrap( -1 );
-	m_cSizer->Add( m_cTomSwartz, 0, wxALL, 5 );
-	
-	m_cghTS = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@tomswartz07"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghTS->Wrap( -1 );
-	m_cSizer->Add( m_cghTS, 0, wxALL, 5 );
-	
-	m_cInfinityCyberworks = new wxStaticText( m_dbScroll, wxID_ANY, wxT("Infinity Cyberworks"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cInfinityCyberworks->Wrap( -1 );
-	m_cSizer->Add( m_cInfinityCyberworks, 0, wxALL, 5 );
-	
-	m_cghIC = new wxStaticText( m_dbScroll, wxID_ANY, wxT("@infinitycyberworks"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cghIC->Wrap( -1 );
-	m_cSizer->Add( m_cghIC, 0, wxALL, 5 );
-	
-	
-	m_dbPane->Add( m_cSizer, 0, wxALL|wxEXPAND, 5 );
-	
-	
-	m_dbScroll->SetSizer( m_dbPane );
+	m_cSizer = new wxFlexGridSizer(0, 2, 2, 20);
+	m_cSizer->SetFlexibleDirection(wxBOTH);
+	m_cSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_ALL);
+
+	m_cContributorsHeader = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Contributors"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_cContributorsHeader->Wrap(-1);
+	m_cContributorsHeader->SetFont(wxFont(15, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_cSizer->Add(m_cContributorsHeader, 0, wxALL, 5);
+
+	m_cGitHub = new wxStaticText(m_dbScroll, wxID_ANY, wxT("GitHub"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cGitHub->Wrap(-1);
+	m_cGitHub->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_cSizer->Add(m_cGitHub, 0, wxALL, 5);
+
+	m_cCorneLukken = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Corne Lukken"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cCorneLukken->Wrap(-1);
+	m_cSizer->Add(m_cCorneLukken, 0, wxALL, 5);
+
+	m_cghCL = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@Dantali0n"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghCL->Wrap(-1);
+	m_cSizer->Add(m_cghCL, 0, wxALL, 5);
+
+	m_cStainislawPitucha = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Stanisław Pitucha"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cStainislawPitucha->Wrap(-1);
+	m_cSizer->Add(m_cStainislawPitucha, 0, wxALL, 5);
+
+	m_cghSP = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@viraptor"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghSP->Wrap(-1);
+	m_cSizer->Add(m_cghSP, 0, wxALL, 5);
+
+	m_cghStefanTalpalaru = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Ștefan Talpalaru"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghStefanTalpalaru->Wrap(-1);
+	m_cSizer->Add(m_cghStefanTalpalaru, 0, wxALL, 5);
+
+	m_cghST = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@stefantalpalaru"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghST->Wrap(-1);
+	m_cSizer->Add(m_cghST, 0, wxALL, 5);
+
+	m_cCrisMotch = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Chris Motch"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cCrisMotch->Wrap(-1);
+	m_cSizer->Add(m_cCrisMotch, 0, wxALL, 5);
+
+	m_cghCM = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@bodrick"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghCM->Wrap(-1);
+	m_cSizer->Add(m_cghCM, 0, wxALL, 5);
+
+	m_cMariuszRyndzionek = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Mariusz Ryndzionek"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cMariuszRyndzionek->Wrap(-1);
+	m_cSizer->Add(m_cMariuszRyndzionek, 0, wxALL, 5);
+
+	m_cghMR = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@mryndzionek"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghMR->Wrap(-1);
+	m_cSizer->Add(m_cghMR, 0, wxALL, 5);
+
+	m_cJiangWei = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Jiang Wei"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cJiangWei->Wrap(-1);
+	m_cSizer->Add(m_cJiangWei, 0, wxALL, 5);
+
+	m_cghJW = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@jocover"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghJW->Wrap(-1);
+	m_cSizer->Add(m_cghJW, 0, wxALL, 5);
+
+	m_cTomSwartz = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Tom Swartz"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cTomSwartz->Wrap(-1);
+	m_cSizer->Add(m_cTomSwartz, 0, wxALL, 5);
+
+	m_cghTS = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@tomswartz07"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghTS->Wrap(-1);
+	m_cSizer->Add(m_cghTS, 0, wxALL, 5);
+
+	m_cInfinityCyberworks = new wxStaticText(m_dbScroll, wxID_ANY, wxT("Infinity Cyberworks"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cInfinityCyberworks->Wrap(-1);
+	m_cSizer->Add(m_cInfinityCyberworks, 0, wxALL, 5);
+
+	m_cghIC = new wxStaticText(m_dbScroll, wxID_ANY, wxT("@infinitycyberworks"), wxDefaultPosition, wxDefaultSize, 0);
+	m_cghIC->Wrap(-1);
+	m_cSizer->Add(m_cghIC, 0, wxALL, 5);
+
+
+	m_dbPane->Add(m_cSizer, 0, wxALL | wxEXPAND, 5);
+
+
+	m_dbScroll->SetSizer(m_dbPane);
 	m_dbScroll->Layout();
-	m_dbPane->Fit( m_dbScroll );
-	m_aboutNotebook->AddPage( m_dbScroll, wxT("Developers"), false );
-	m_dScroll = new wxScrolledWindow( m_aboutNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL|wxVSCROLL );
-	m_dScroll->SetScrollRate( 5, 5 );
+	m_dbPane->Fit(m_dbScroll);
+	m_aboutNotebook->AddPage(m_dbScroll, wxT("Developers"), false);
+	m_dScroll = new wxScrolledWindow(m_aboutNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxVSCROLL);
+	m_dScroll->SetScrollRate(5, 5);
 	wxBoxSizer* m_dBSizer;
-	m_dBSizer = new wxBoxSizer( wxVERTICAL );
-	
+	m_dBSizer = new wxBoxSizer(wxVERTICAL);
+
 	wxBoxSizer* m_dSizer;
-	m_dSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_dHeader = new wxStaticText( m_dScroll, wxID_ANY, wxT("Thanks to everyone who donated at cubicsdr.com!"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_dHeader->Wrap( -1 );
-	m_dHeader->SetFont( wxFont( 15, 70, 90, 90, false, wxEmptyString ) );
-	
-	m_dSizer->Add( m_dHeader, 0, wxALL, 5 );
-	
-	m_dDivider1 = new wxStaticLine( m_dScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-	m_dSizer->Add( m_dDivider1, 0, wxEXPAND | wxALL, 5 );
-	
-	m_dSDRplay = new wxStaticText( m_dScroll, wxID_ANY, wxT("SDRplay / sdrplay.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dSDRplay->Wrap( -1 );
-	m_dSizer->Add( m_dSDRplay, 0, wxALL, 5 );
-	
-	m_dMichaelLadd = new wxStaticText( m_dScroll, wxID_ANY, wxT("Michael Ladd"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dMichaelLadd->Wrap( -1 );
-	m_dSizer->Add( m_dMichaelLadd, 0, wxALL, 5 );
-	
-	m_dAutoMotiveTemplates = new wxStaticText( m_dScroll, wxID_ANY, wxT("Automotive Templates"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dAutoMotiveTemplates->Wrap( -1 );
-	m_dSizer->Add( m_dAutoMotiveTemplates, 0, wxALL, 5 );
-	
-	m_dJorgeMorales = new wxStaticText( m_dScroll, wxID_ANY, wxT("Jorge Morales"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dJorgeMorales->Wrap( -1 );
-	m_dSizer->Add( m_dJorgeMorales, 0, wxALL, 5 );
-	
-	m_dMichaelRooke = new wxStaticText( m_dScroll, wxID_ANY, wxT("Michael Rooke"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dMichaelRooke->Wrap( -1 );
-	m_dSizer->Add( m_dMichaelRooke, 0, wxALL, 5 );
-	
-	m_dTNCOM = new wxStaticText( m_dScroll, wxID_ANY, wxT("TNCOM"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dTNCOM->Wrap( -1 );
-	m_dSizer->Add( m_dTNCOM, 0, wxALL, 5 );
-	
-	m_dErikWied = new wxStaticText( m_dScroll, wxID_ANY, wxT("Erik Mikkel Wied"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dErikWied->Wrap( -1 );
-	m_dSizer->Add( m_dErikWied, 0, wxALL, 5 );
-	
-	m_dRobertDuering = new wxStaticText( m_dScroll, wxID_ANY, wxT("Robert Duering"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dRobertDuering->Wrap( -1 );
-	m_dSizer->Add( m_dRobertDuering, 0, wxALL, 5 );
-	
-	m_dJimDeitch = new wxStaticText( m_dScroll, wxID_ANY, wxT("Jim Deitch"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dJimDeitch->Wrap( -1 );
-	m_dSizer->Add( m_dJimDeitch, 0, wxALL, 5 );
-	
-	m_dNooElec = new wxStaticText( m_dScroll, wxID_ANY, wxT("NooElec Inc. / nooelec.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dNooElec->Wrap( -1 );
-	m_dSizer->Add( m_dNooElec, 0, wxALL, 5 );
-	
-	m_dDavidAhlgren = new wxStaticText( m_dScroll, wxID_ANY, wxT("David Ahlgren"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dDavidAhlgren->Wrap( -1 );
-	m_dSizer->Add( m_dDavidAhlgren, 0, wxALL, 5 );
-	
-	m_dRonaldCook = new wxStaticText( m_dScroll, wxID_ANY, wxT("Ronald Cook"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dRonaldCook->Wrap( -1 );
-	m_dSizer->Add( m_dRonaldCook, 0, wxALL, 5 );
-	
-	m_dEricPeterson = new wxStaticText( m_dScroll, wxID_ANY, wxT("Eric Peterson"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dEricPeterson->Wrap( -1 );
-	m_dSizer->Add( m_dEricPeterson, 0, wxALL, 5 );
-	
-	m_dGeoDistributing = new wxStaticText( m_dScroll, wxID_ANY, wxT("Geo Distributing"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dGeoDistributing->Wrap( -1 );
-	m_dSizer->Add( m_dGeoDistributing, 0, wxALL, 5 );
-	
-	m_dJamesCarson = new wxStaticText( m_dScroll, wxID_ANY, wxT("James Carson"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dJamesCarson->Wrap( -1 );
-	m_dSizer->Add( m_dJamesCarson, 0, wxALL, 5 );
-	
-	m_dCraigWilliams = new wxStaticText( m_dScroll, wxID_ANY, wxT("Craig Williams"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dCraigWilliams->Wrap( -1 );
-	m_dSizer->Add( m_dCraigWilliams, 0, wxALL, 5 );
-	
-	m_dRudolfShaffer = new wxStaticText( m_dScroll, wxID_ANY, wxT("Rudolf Schaffer"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dRudolfShaffer->Wrap( -1 );
-	m_dSizer->Add( m_dRudolfShaffer, 0, wxALL, 5 );
-	
-	m_dJohnKaton = new wxStaticText( m_dScroll, wxID_ANY, wxT("John Katon"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dJohnKaton->Wrap( -1 );
-	m_dSizer->Add( m_dJohnKaton, 0, wxALL, 5 );
-	
-	m_dVincentSonnier = new wxStaticText( m_dScroll, wxID_ANY, wxT("Vincent Sonnier"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dVincentSonnier->Wrap( -1 );
-	m_dSizer->Add( m_dVincentSonnier, 0, wxALL, 5 );
-	
-	m_dCorq = new wxStaticText( m_dScroll, wxID_ANY, wxT("corq's auctions/L. Easterly LTD (x 4)"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dCorq->Wrap( -1 );
-	m_dSizer->Add( m_dCorq, 0, wxALL, 5 );
-	
-	m_dIvanAlekseev = new wxStaticText( m_dScroll, wxID_ANY, wxT("Ivan Alekseev"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dIvanAlekseev->Wrap( -1 );
-	m_dSizer->Add( m_dIvanAlekseev, 0, wxALL, 5 );
-	
-	m_dOleJorgenKolsrud = new wxStaticText( m_dScroll, wxID_ANY, wxT("Ole-Jørgen Næss Kolsrud"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dOleJorgenKolsrud->Wrap( -1 );
-	m_dSizer->Add( m_dOleJorgenKolsrud, 0, wxALL, 5 );
-	
-	m_dHenrikJagemyr = new wxStaticText( m_dScroll, wxID_ANY, wxT("Henrik Jagemyr"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dHenrikJagemyr->Wrap( -1 );
-	m_dSizer->Add( m_dHenrikJagemyr, 0, wxALL, 5 );
-	
-	m_dPeterHaines = new wxStaticText( m_dScroll, wxID_ANY, wxT("Peter Haines"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dPeterHaines->Wrap( -1 );
-	m_dSizer->Add( m_dPeterHaines, 0, wxALL, 5 );
-	
-	m_dLeonAbrassart = new wxStaticText( m_dScroll, wxID_ANY, wxT("Leon Abrassart"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dLeonAbrassart->Wrap( -1 );
-	m_dSizer->Add( m_dLeonAbrassart, 0, wxALL, 5 );
-	
-	m_dGeorgeTalbot = new wxStaticText( m_dScroll, wxID_ANY, wxT("George Alan Talbot"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dGeorgeTalbot->Wrap( -1 );
-	m_dSizer->Add( m_dGeorgeTalbot, 0, wxALL, 5 );
-	
-	m_dFranciscoPuerta = new wxStaticText( m_dScroll, wxID_ANY, wxT("Francisco Borja Marcos de la Puerta"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dFranciscoPuerta->Wrap( -1 );
-	m_dSizer->Add( m_dFranciscoPuerta, 0, wxALL, 5 );
-	
-	m_dRonaldLundeen = new wxStaticText( m_dScroll, wxID_ANY, wxT("Ronald A. Lundeen"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dRonaldLundeen->Wrap( -1 );
-	m_dSizer->Add( m_dRonaldLundeen, 0, wxALL, 5 );
-	
-	m_dWalterHorbert = new wxStaticText( m_dScroll, wxID_ANY, wxT("Walter Horbert"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dWalterHorbert->Wrap( -1 );
-	m_dSizer->Add( m_dWalterHorbert, 0, wxALL, 5 );
-	
-	m_dWilliamLD = new wxStaticText( m_dScroll, wxID_ANY, wxT("William Lloyd-Davies"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dWilliamLD->Wrap( -1 );
-	m_dSizer->Add( m_dWilliamLD, 0, wxALL, 5 );
-	
-	m_dBratislavArandjelovic = new wxStaticText( m_dScroll, wxID_ANY, wxT("Bratislav Arandjelovic"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dBratislavArandjelovic->Wrap( -1 );
-	m_dSizer->Add( m_dBratislavArandjelovic, 0, wxALL, 5 );
-	
-	m_dGaryMartin = new wxStaticText( m_dScroll, wxID_ANY, wxT("Gary Martin"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dGaryMartin->Wrap( -1 );
-	m_dSizer->Add( m_dGaryMartin, 0, wxALL, 5 );
-	
-	m_dEinarsRepse = new wxStaticText( m_dScroll, wxID_ANY, wxT("Einars Repse"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dEinarsRepse->Wrap( -1 );
-	m_dSizer->Add( m_dEinarsRepse, 0, wxALL, 5 );
-	
-	m_dTimothyGatton = new wxStaticText( m_dScroll, wxID_ANY, wxT("Timothy Gatton"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dTimothyGatton->Wrap( -1 );
-	m_dSizer->Add( m_dTimothyGatton, 0, wxALL, 5 );
-	
-	m_dStephenCuccio = new wxStaticText( m_dScroll, wxID_ANY, wxT("Stephen Cuccio"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dStephenCuccio->Wrap( -1 );
-	m_dSizer->Add( m_dStephenCuccio, 0, wxALL, 5 );
-	
-	m_dKeshavlalPatel = new wxStaticText( m_dScroll, wxID_ANY, wxT("Keshavlal Patel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dKeshavlalPatel->Wrap( -1 );
-	m_dSizer->Add( m_dKeshavlalPatel, 0, wxALL, 5 );
-	
-	m_dBobSchatzman = new wxStaticText( m_dScroll, wxID_ANY, wxT("Bob Schatzman"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dBobSchatzman->Wrap( -1 );
-	m_dSizer->Add( m_dBobSchatzman, 0, wxALL, 5 );
-	
-	m_dRobertRoss = new wxStaticText( m_dScroll, wxID_ANY, wxT("Robert Ross"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dRobertRoss->Wrap( -1 );
-	m_dSizer->Add( m_dRobertRoss, 0, wxALL, 5 );
-	
-	m_dRobertoBellotti = new wxStaticText( m_dScroll, wxID_ANY, wxT("Roberto Bellotti"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dRobertoBellotti->Wrap( -1 );
-	m_dSizer->Add( m_dRobertoBellotti, 0, wxALL, 5 );
-	
-	m_dSergeVanderTorre = new wxStaticText( m_dScroll, wxID_ANY, wxT("Serge Van der Torre"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dSergeVanderTorre->Wrap( -1 );
-	m_dSizer->Add( m_dSergeVanderTorre, 0, wxALL, 5 );
-	
-	m_dDieterSchneider = new wxStaticText( m_dScroll, wxID_ANY, wxT("Dieter Schneider"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dDieterSchneider->Wrap( -1 );
-	m_dSizer->Add( m_dDieterSchneider, 0, wxALL, 5 );
-	
-	m_dPetrikaJaneku = new wxStaticText( m_dScroll, wxID_ANY, wxT("Petrika Janeku"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_dPetrikaJaneku->Wrap( -1 );
-	m_dSizer->Add( m_dPetrikaJaneku, 0, wxALL, 5 );
-	
-	
-	m_dBSizer->Add( m_dSizer, 1, wxALL|wxEXPAND, 5 );
-	
-	
-	m_dScroll->SetSizer( m_dBSizer );
+	m_dSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_dHeader = new wxStaticText(m_dScroll, wxID_ANY, wxT("Thanks to everyone who donated at cubicsdr.com!"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_dHeader->Wrap(-1);
+	m_dHeader->SetFont(wxFont(15, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_dSizer->Add(m_dHeader, 0, wxALL, 5);
+
+	m_dDivider1 = new wxStaticLine(m_dScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL);
+	m_dSizer->Add(m_dDivider1, 0, wxEXPAND | wxALL, 5);
+
+	m_dSDRplay = new wxStaticText(m_dScroll, wxID_ANY, wxT("SDRplay / sdrplay.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dSDRplay->Wrap(-1);
+	m_dSizer->Add(m_dSDRplay, 0, wxALL, 5);
+
+	m_dMichaelLadd = new wxStaticText(m_dScroll, wxID_ANY, wxT("Michael Ladd"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dMichaelLadd->Wrap(-1);
+	m_dSizer->Add(m_dMichaelLadd, 0, wxALL, 5);
+
+	m_dAutoMotiveTemplates = new wxStaticText(m_dScroll, wxID_ANY, wxT("Automotive Templates"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dAutoMotiveTemplates->Wrap(-1);
+	m_dSizer->Add(m_dAutoMotiveTemplates, 0, wxALL, 5);
+
+	m_dJorgeMorales = new wxStaticText(m_dScroll, wxID_ANY, wxT("Jorge Morales"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dJorgeMorales->Wrap(-1);
+	m_dSizer->Add(m_dJorgeMorales, 0, wxALL, 5);
+
+	m_dMichaelRooke = new wxStaticText(m_dScroll, wxID_ANY, wxT("Michael Rooke"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dMichaelRooke->Wrap(-1);
+	m_dSizer->Add(m_dMichaelRooke, 0, wxALL, 5);
+
+	m_dTNCOM = new wxStaticText(m_dScroll, wxID_ANY, wxT("TNCOM"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dTNCOM->Wrap(-1);
+	m_dSizer->Add(m_dTNCOM, 0, wxALL, 5);
+
+	m_dErikWied = new wxStaticText(m_dScroll, wxID_ANY, wxT("Erik Mikkel Wied"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dErikWied->Wrap(-1);
+	m_dSizer->Add(m_dErikWied, 0, wxALL, 5);
+
+	m_dRobertDuering = new wxStaticText(m_dScroll, wxID_ANY, wxT("Robert Duering"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dRobertDuering->Wrap(-1);
+	m_dSizer->Add(m_dRobertDuering, 0, wxALL, 5);
+
+	m_dJimDeitch = new wxStaticText(m_dScroll, wxID_ANY, wxT("Jim Deitch"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dJimDeitch->Wrap(-1);
+	m_dSizer->Add(m_dJimDeitch, 0, wxALL, 5);
+
+	m_dNooElec = new wxStaticText(m_dScroll, wxID_ANY, wxT("NooElec Inc. / nooelec.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dNooElec->Wrap(-1);
+	m_dSizer->Add(m_dNooElec, 0, wxALL, 5);
+
+	m_dDavidAhlgren = new wxStaticText(m_dScroll, wxID_ANY, wxT("David Ahlgren"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dDavidAhlgren->Wrap(-1);
+	m_dSizer->Add(m_dDavidAhlgren, 0, wxALL, 5);
+
+	m_dRonaldCook = new wxStaticText(m_dScroll, wxID_ANY, wxT("Ronald Cook"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dRonaldCook->Wrap(-1);
+	m_dSizer->Add(m_dRonaldCook, 0, wxALL, 5);
+
+	m_dEricPeterson = new wxStaticText(m_dScroll, wxID_ANY, wxT("Eric Peterson"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dEricPeterson->Wrap(-1);
+	m_dSizer->Add(m_dEricPeterson, 0, wxALL, 5);
+
+	m_dGeoDistributing = new wxStaticText(m_dScroll, wxID_ANY, wxT("Geo Distributing"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dGeoDistributing->Wrap(-1);
+	m_dSizer->Add(m_dGeoDistributing, 0, wxALL, 5);
+
+	m_dJamesCarson = new wxStaticText(m_dScroll, wxID_ANY, wxT("James Carson"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dJamesCarson->Wrap(-1);
+	m_dSizer->Add(m_dJamesCarson, 0, wxALL, 5);
+
+	m_dCraigWilliams = new wxStaticText(m_dScroll, wxID_ANY, wxT("Craig Williams"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dCraigWilliams->Wrap(-1);
+	m_dSizer->Add(m_dCraigWilliams, 0, wxALL, 5);
+
+	m_dRudolfShaffer = new wxStaticText(m_dScroll, wxID_ANY, wxT("Rudolf Schaffer"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dRudolfShaffer->Wrap(-1);
+	m_dSizer->Add(m_dRudolfShaffer, 0, wxALL, 5);
+
+	m_dJohnKaton = new wxStaticText(m_dScroll, wxID_ANY, wxT("John Katon"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dJohnKaton->Wrap(-1);
+	m_dSizer->Add(m_dJohnKaton, 0, wxALL, 5);
+
+	m_dVincentSonnier = new wxStaticText(m_dScroll, wxID_ANY, wxT("Vincent Sonnier"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dVincentSonnier->Wrap(-1);
+	m_dSizer->Add(m_dVincentSonnier, 0, wxALL, 5);
+
+	m_dCorq = new wxStaticText(m_dScroll, wxID_ANY, wxT("corq's auctions/L. Easterly LTD (x 4)"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dCorq->Wrap(-1);
+	m_dSizer->Add(m_dCorq, 0, wxALL, 5);
+
+	m_dIvanAlekseev = new wxStaticText(m_dScroll, wxID_ANY, wxT("Ivan Alekseev"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dIvanAlekseev->Wrap(-1);
+	m_dSizer->Add(m_dIvanAlekseev, 0, wxALL, 5);
+
+	m_dOleJorgenKolsrud = new wxStaticText(m_dScroll, wxID_ANY, wxT("Ole-Jørgen Næss Kolsrud"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dOleJorgenKolsrud->Wrap(-1);
+	m_dSizer->Add(m_dOleJorgenKolsrud, 0, wxALL, 5);
+
+	m_dHenrikJagemyr = new wxStaticText(m_dScroll, wxID_ANY, wxT("Henrik Jagemyr"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dHenrikJagemyr->Wrap(-1);
+	m_dSizer->Add(m_dHenrikJagemyr, 0, wxALL, 5);
+
+	m_dPeterHaines = new wxStaticText(m_dScroll, wxID_ANY, wxT("Peter Haines"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dPeterHaines->Wrap(-1);
+	m_dSizer->Add(m_dPeterHaines, 0, wxALL, 5);
+
+	m_dLeonAbrassart = new wxStaticText(m_dScroll, wxID_ANY, wxT("Leon Abrassart"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dLeonAbrassart->Wrap(-1);
+	m_dSizer->Add(m_dLeonAbrassart, 0, wxALL, 5);
+
+	m_dGeorgeTalbot = new wxStaticText(m_dScroll, wxID_ANY, wxT("George Alan Talbot"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dGeorgeTalbot->Wrap(-1);
+	m_dSizer->Add(m_dGeorgeTalbot, 0, wxALL, 5);
+
+	m_dFranciscoPuerta = new wxStaticText(m_dScroll, wxID_ANY, wxT("Francisco Borja Marcos de la Puerta"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dFranciscoPuerta->Wrap(-1);
+	m_dSizer->Add(m_dFranciscoPuerta, 0, wxALL, 5);
+
+	m_dRonaldLundeen = new wxStaticText(m_dScroll, wxID_ANY, wxT("Ronald A. Lundeen"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dRonaldLundeen->Wrap(-1);
+	m_dSizer->Add(m_dRonaldLundeen, 0, wxALL, 5);
+
+	m_dWalterHorbert = new wxStaticText(m_dScroll, wxID_ANY, wxT("Walter Horbert"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dWalterHorbert->Wrap(-1);
+	m_dSizer->Add(m_dWalterHorbert, 0, wxALL, 5);
+
+	m_dWilliamLD = new wxStaticText(m_dScroll, wxID_ANY, wxT("William Lloyd-Davies"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dWilliamLD->Wrap(-1);
+	m_dSizer->Add(m_dWilliamLD, 0, wxALL, 5);
+
+	m_dBratislavArandjelovic = new wxStaticText(m_dScroll, wxID_ANY, wxT("Bratislav Arandjelovic"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dBratislavArandjelovic->Wrap(-1);
+	m_dSizer->Add(m_dBratislavArandjelovic, 0, wxALL, 5);
+
+	m_dGaryMartin = new wxStaticText(m_dScroll, wxID_ANY, wxT("Gary Martin"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dGaryMartin->Wrap(-1);
+	m_dSizer->Add(m_dGaryMartin, 0, wxALL, 5);
+
+	m_dEinarsRepse = new wxStaticText(m_dScroll, wxID_ANY, wxT("Einars Repse"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dEinarsRepse->Wrap(-1);
+	m_dSizer->Add(m_dEinarsRepse, 0, wxALL, 5);
+
+	m_dTimothyGatton = new wxStaticText(m_dScroll, wxID_ANY, wxT("Timothy Gatton"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dTimothyGatton->Wrap(-1);
+	m_dSizer->Add(m_dTimothyGatton, 0, wxALL, 5);
+
+	m_dStephenCuccio = new wxStaticText(m_dScroll, wxID_ANY, wxT("Stephen Cuccio"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dStephenCuccio->Wrap(-1);
+	m_dSizer->Add(m_dStephenCuccio, 0, wxALL, 5);
+
+	m_dKeshavlalPatel = new wxStaticText(m_dScroll, wxID_ANY, wxT("Keshavlal Patel"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dKeshavlalPatel->Wrap(-1);
+	m_dSizer->Add(m_dKeshavlalPatel, 0, wxALL, 5);
+
+	m_dBobSchatzman = new wxStaticText(m_dScroll, wxID_ANY, wxT("Bob Schatzman"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dBobSchatzman->Wrap(-1);
+	m_dSizer->Add(m_dBobSchatzman, 0, wxALL, 5);
+
+	m_dRobertRoss = new wxStaticText(m_dScroll, wxID_ANY, wxT("Robert Ross"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dRobertRoss->Wrap(-1);
+	m_dSizer->Add(m_dRobertRoss, 0, wxALL, 5);
+
+	m_dRobertoBellotti = new wxStaticText(m_dScroll, wxID_ANY, wxT("Roberto Bellotti"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dRobertoBellotti->Wrap(-1);
+	m_dSizer->Add(m_dRobertoBellotti, 0, wxALL, 5);
+
+	m_dSergeVanderTorre = new wxStaticText(m_dScroll, wxID_ANY, wxT("Serge Van der Torre"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dSergeVanderTorre->Wrap(-1);
+	m_dSizer->Add(m_dSergeVanderTorre, 0, wxALL, 5);
+
+	m_dDieterSchneider = new wxStaticText(m_dScroll, wxID_ANY, wxT("Dieter Schneider"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dDieterSchneider->Wrap(-1);
+	m_dSizer->Add(m_dDieterSchneider, 0, wxALL, 5);
+
+	m_dPetrikaJaneku = new wxStaticText(m_dScroll, wxID_ANY, wxT("Petrika Janeku"), wxDefaultPosition, wxDefaultSize, 0);
+	m_dPetrikaJaneku->Wrap(-1);
+	m_dSizer->Add(m_dPetrikaJaneku, 0, wxALL, 5);
+
+
+	m_dBSizer->Add(m_dSizer, 1, wxALL | wxEXPAND, 5);
+
+
+	m_dScroll->SetSizer(m_dBSizer);
 	m_dScroll->Layout();
-	m_dBSizer->Fit( m_dScroll );
-	m_aboutNotebook->AddPage( m_dScroll, wxT("Donations"), false );
-	m_stScroll = new wxScrolledWindow( m_aboutNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL|wxVSCROLL );
-	m_stScroll->SetScrollRate( 5, 5 );
+	m_dBSizer->Fit(m_dScroll);
+	m_aboutNotebook->AddPage(m_dScroll, wxT("Donations"), false);
+	m_stScroll = new wxScrolledWindow(m_aboutNotebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxVSCROLL);
+	m_stScroll->SetScrollRate(5, 5);
 	wxBoxSizer* m_stBSizer;
-	m_stBSizer = new wxBoxSizer( wxVERTICAL );
-	
+	m_stBSizer = new wxBoxSizer(wxVERTICAL);
+
 	wxBoxSizer* m_stSizer;
-	m_stSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_stHeader = new wxStaticText( m_stScroll, wxID_ANY, wxT("Special Thanks To"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_stHeader->Wrap( -1 );
-	m_stHeader->SetFont( wxFont( 15, 70, 90, 90, false, wxEmptyString ) );
-	
-	m_stSizer->Add( m_stHeader, 0, wxALL, 5 );
-	
-	m_stDivider1 = new wxStaticLine( m_stScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-	m_stSizer->Add( m_stDivider1, 0, wxEXPAND | wxALL, 5 );
-	
-	m_stSoapyDevAssistHeader = new wxStaticText( m_stScroll, wxID_ANY, wxT("SoapySDR Development and Assistance:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_stSoapyDevAssistHeader->Wrap( -1 );
-	m_stSoapyDevAssistHeader->SetFont( wxFont( 10, 70, 90, 92, false, wxEmptyString ) );
-	
-	m_stSizer->Add( m_stSoapyDevAssistHeader, 0, wxALL, 5 );
-	
-	m_stJoshBlum = new wxStaticText( m_stScroll, wxID_ANY, wxT("Josh Blum / @guruofquality / pothosware.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stJoshBlum->Wrap( -1 );
-	m_stSizer->Add( m_stJoshBlum, 0, wxALL, 5 );
-	
-	m_stDivider2 = new wxStaticLine( m_stScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-	m_stSizer->Add( m_stDivider2, 0, wxEXPAND | wxALL, 5 );
-	
-	m_stLiquidDSPHeader = new wxStaticText( m_stScroll, wxID_ANY, wxT("Liquid-DSP Development and Assistance:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_stLiquidDSPHeader->Wrap( -1 );
-	m_stLiquidDSPHeader->SetFont( wxFont( 10, 70, 90, 92, false, wxEmptyString ) );
-	
-	m_stSizer->Add( m_stLiquidDSPHeader, 0, wxALL, 5 );
-	
-	m_stJosephGaeddert = new wxStaticText( m_stScroll, wxID_ANY, wxT("Joseph D. Gaeddert / @jgaeddert / liquidsdr.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stJosephGaeddert->Wrap( -1 );
-	m_stSizer->Add( m_stJosephGaeddert, 0, wxALL, 5 );
-	
-	m_stDivider3 = new wxStaticLine( m_stScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-	m_stSizer->Add( m_stDivider3, 0, wxEXPAND | wxALL, 5 );
-	
-	m_stIdeasDirectionsHeader = new wxStaticText( m_stScroll, wxID_ANY, wxT("Ideas, Direction && Encouragement:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
-	m_stIdeasDirectionsHeader->Wrap( -1 );
-	m_stIdeasDirectionsHeader->SetFont( wxFont( 10, 70, 90, 92, false, wxEmptyString ) );
-	
-	m_stSizer->Add( m_stIdeasDirectionsHeader, 0, wxALL, 5 );
-	
-	m_stTonMachielsen = new wxStaticText( m_stScroll, wxID_ANY, wxT("Ton Machielsen / @Toontje / @EA3HOE "), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stTonMachielsen->Wrap( -1 );
-	m_stSizer->Add( m_stTonMachielsen, 0, wxALL, 5 );
-	
-	m_stMikeLadd = new wxStaticText( m_stScroll, wxID_ANY, wxT("Mike Ladd / KD2KOG.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stMikeLadd->Wrap( -1 );
-	m_stSizer->Add( m_stMikeLadd, 0, wxALL, 5 );
-	
-	m_stSDRplay = new wxStaticText( m_stScroll, wxID_ANY, wxT("SDRplay team / @SDRplay / SDRplay.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stSDRplay->Wrap( -1 );
-	m_stSizer->Add( m_stSDRplay, 0, wxALL, 5 );
-	
-	m_stSDRplayFB = new wxStaticText( m_stScroll, wxID_ANY, wxT("SDRplay Facebook group"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stSDRplayFB->Wrap( -1 );
-	m_stSizer->Add( m_stSDRplayFB, 0, wxALL, 5 );
-	
-	m_stPaulWarren = new wxStaticText( m_stScroll, wxID_ANY, wxT("Paul Warren / @pwarren"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stPaulWarren->Wrap( -1 );
-	m_stSizer->Add( m_stPaulWarren, 0, wxALL, 5 );
-	
-	m_stSegesdiKaroly = new wxStaticText( m_stScroll, wxID_ANY, wxT("Segesdi Károly / @jazzkutya"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stSegesdiKaroly->Wrap( -1 );
-	m_stSizer->Add( m_stSegesdiKaroly, 0, wxALL, 5 );
-	
-	m_stRedditRTLSDR = new wxStaticText( m_stScroll, wxID_ANY, wxT("Reddit RTL-SDR group /r/rtlsdr"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stRedditRTLSDR->Wrap( -1 );
-	m_stSizer->Add( m_stRedditRTLSDR, 0, wxALL, 5 );
-	
-	m_stNooElec = new wxStaticText( m_stScroll, wxID_ANY, wxT("NooElec team / NooElec.com"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stNooElec->Wrap( -1 );
-	m_stSizer->Add( m_stNooElec, 0, wxALL, 5 );
-	
-	m_stGHIssues = new wxStaticText( m_stScroll, wxID_ANY, wxT("Everyone who's contributed to the GitHub issues; thanks!"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stGHIssues->Wrap( -1 );
-	m_stSizer->Add( m_stGHIssues, 0, wxALL, 5 );
-	
-	m_stNominate = new wxStaticText( m_stScroll, wxID_ANY, wxT("Please feel free to nominate anyone we might have missed."), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stNominate->Wrap( -1 );
-	m_stSizer->Add( m_stNominate, 0, wxALL, 5 );
-	
-	
-	m_stBSizer->Add( m_stSizer, 1, wxALL|wxEXPAND, 5 );
-	
-	
-	m_stScroll->SetSizer( m_stBSizer );
+	m_stSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_stHeader = new wxStaticText(m_stScroll, wxID_ANY, wxT("Special Thanks To"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_stHeader->Wrap(-1);
+	m_stHeader->SetFont(wxFont(15, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	m_stSizer->Add(m_stHeader, 0, wxALL, 5);
+
+	m_stDivider1 = new wxStaticLine(m_stScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL);
+	m_stSizer->Add(m_stDivider1, 0, wxEXPAND | wxALL, 5);
+
+	m_stSoapyDevAssistHeader = new wxStaticText(m_stScroll, wxID_ANY, wxT("SoapySDR Development and Assistance:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_stSoapyDevAssistHeader->Wrap(-1);
+	m_stSoapyDevAssistHeader->SetFont(wxFont(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString));
+
+	m_stSizer->Add(m_stSoapyDevAssistHeader, 0, wxALL, 5);
+
+	m_stJoshBlum = new wxStaticText(m_stScroll, wxID_ANY, wxT("Josh Blum / @guruofquality / pothosware.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stJoshBlum->Wrap(-1);
+	m_stSizer->Add(m_stJoshBlum, 0, wxALL, 5);
+
+	m_stDivider2 = new wxStaticLine(m_stScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL);
+	m_stSizer->Add(m_stDivider2, 0, wxEXPAND | wxALL, 5);
+
+	m_stLiquidDSPHeader = new wxStaticText(m_stScroll, wxID_ANY, wxT("Liquid-DSP Development and Assistance:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_stLiquidDSPHeader->Wrap(-1);
+	m_stLiquidDSPHeader->SetFont(wxFont(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString));
+
+	m_stSizer->Add(m_stLiquidDSPHeader, 0, wxALL, 5);
+
+	m_stJosephGaeddert = new wxStaticText(m_stScroll, wxID_ANY, wxT("Joseph D. Gaeddert / @jgaeddert / liquidsdr.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stJosephGaeddert->Wrap(-1);
+	m_stSizer->Add(m_stJosephGaeddert, 0, wxALL, 5);
+
+	m_stDivider3 = new wxStaticLine(m_stScroll, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL);
+	m_stSizer->Add(m_stDivider3, 0, wxEXPAND | wxALL, 5);
+
+	m_stIdeasDirectionsHeader = new wxStaticText(m_stScroll, wxID_ANY, wxT("Ideas, Direction && Encouragement:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+	m_stIdeasDirectionsHeader->Wrap(-1);
+	m_stIdeasDirectionsHeader->SetFont(wxFont(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxEmptyString));
+
+	m_stSizer->Add(m_stIdeasDirectionsHeader, 0, wxALL, 5);
+
+	m_stTonMachielsen = new wxStaticText(m_stScroll, wxID_ANY, wxT("Ton Machielsen / @Toontje / @EA3HOE "), wxDefaultPosition, wxDefaultSize, 0);
+	m_stTonMachielsen->Wrap(-1);
+	m_stSizer->Add(m_stTonMachielsen, 0, wxALL, 5);
+
+	m_stMikeLadd = new wxStaticText(m_stScroll, wxID_ANY, wxT("Mike Ladd / KD2KOG.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stMikeLadd->Wrap(-1);
+	m_stSizer->Add(m_stMikeLadd, 0, wxALL, 5);
+
+	m_stSDRplay = new wxStaticText(m_stScroll, wxID_ANY, wxT("SDRplay team / @SDRplay / SDRplay.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stSDRplay->Wrap(-1);
+	m_stSizer->Add(m_stSDRplay, 0, wxALL, 5);
+
+	m_stSDRplayFB = new wxStaticText(m_stScroll, wxID_ANY, wxT("SDRplay Facebook group"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stSDRplayFB->Wrap(-1);
+	m_stSizer->Add(m_stSDRplayFB, 0, wxALL, 5);
+
+	m_stPaulWarren = new wxStaticText(m_stScroll, wxID_ANY, wxT("Paul Warren / @pwarren"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stPaulWarren->Wrap(-1);
+	m_stSizer->Add(m_stPaulWarren, 0, wxALL, 5);
+
+	m_stSegesdiKaroly = new wxStaticText(m_stScroll, wxID_ANY, wxT("Segesdi Károly / @jazzkutya"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stSegesdiKaroly->Wrap(-1);
+	m_stSizer->Add(m_stSegesdiKaroly, 0, wxALL, 5);
+
+	m_stRedditRTLSDR = new wxStaticText(m_stScroll, wxID_ANY, wxT("Reddit RTL-SDR group /r/rtlsdr"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stRedditRTLSDR->Wrap(-1);
+	m_stSizer->Add(m_stRedditRTLSDR, 0, wxALL, 5);
+
+	m_stNooElec = new wxStaticText(m_stScroll, wxID_ANY, wxT("NooElec team / NooElec.com"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stNooElec->Wrap(-1);
+	m_stSizer->Add(m_stNooElec, 0, wxALL, 5);
+
+	m_stGHIssues = new wxStaticText(m_stScroll, wxID_ANY, wxT("Everyone who's contributed to the GitHub issues; thanks!"), wxDefaultPosition, wxDefaultSize, 0);
+	m_stGHIssues->Wrap(-1);
+	m_stSizer->Add(m_stGHIssues, 0, wxALL, 5);
+
+	m_stNominate = new wxStaticText(m_stScroll, wxID_ANY, wxT("Please feel free to nominate anyone we might have missed."), wxDefaultPosition, wxDefaultSize, 0);
+	m_stNominate->Wrap(-1);
+	m_stSizer->Add(m_stNominate, 0, wxALL, 5);
+
+
+	m_stBSizer->Add(m_stSizer, 1, wxALL | wxEXPAND, 5);
+
+
+	m_stScroll->SetSizer(m_stBSizer);
 	m_stScroll->Layout();
-	m_stBSizer->Fit( m_stScroll );
-	m_aboutNotebook->AddPage( m_stScroll, wxT("Special Thanks"), false );
-	
-	dlgSizer->Add( m_aboutNotebook, 1, wxEXPAND | wxALL, 5 );
-	
-	
-	this->SetSizer( dlgSizer );
+	m_stBSizer->Fit(m_stScroll);
+	m_aboutNotebook->AddPage(m_stScroll, wxT("Special Thanks"), false);
+
+	dlgSizer->Add(m_aboutNotebook, 1, wxEXPAND | wxALL, 5);
+
+
+	this->SetSizer(dlgSizer);
 	this->Layout();
-	
-	this->Centre( wxBOTH );
+
+	this->Centre(wxBOTH);
 }
 
 AboutDialogBase::~AboutDialogBase()

--- a/src/forms/Dialog/AboutDialogBase.h
+++ b/src/forms/Dialog/AboutDialogBase.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __ABOUTDIALOGBASE_H__
@@ -32,114 +32,114 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class AboutDialogBase
 ///////////////////////////////////////////////////////////////////////////////
-class AboutDialogBase : public wxDialog 
+class AboutDialogBase : public wxDialog
 {
-	private:
-	
-	protected:
-		wxPanel* m_hPanel;
-		wxStaticText* m_appName;
-		wxNotebook* m_aboutNotebook;
-		wxScrolledWindow* m_dbScroll;
-		wxStaticText* m_dbHeader;
-		wxStaticText* m_dbGHHeader;
-		wxStaticText* m_dbTwitter;
-		wxStaticText* m_dbCharlesCliffe;
-		wxStaticText* m_dbghCC;
-		wxStaticText* m_dbtCC;
-		wxStaticText* m_dbVincentSonnier;
-		wxStaticText* m_dbghVS;
-		wxStaticText* m_dbtVS;
-		wxStaticLine* m_dbDivider1;
-		wxStaticText* m_cContributorsHeader;
-		wxStaticText* m_cGitHub;
-		wxStaticText* m_cCorneLukken;
-		wxStaticText* m_cghCL;
-		wxStaticText* m_cStainislawPitucha;
-		wxStaticText* m_cghSP;
-		wxStaticText* m_cghStefanTalpalaru;
-		wxStaticText* m_cghST;
-		wxStaticText* m_cCrisMotch;
-		wxStaticText* m_cghCM;
-		wxStaticText* m_cMariuszRyndzionek;
-		wxStaticText* m_cghMR;
-		wxStaticText* m_cJiangWei;
-		wxStaticText* m_cghJW;
-		wxStaticText* m_cTomSwartz;
-		wxStaticText* m_cghTS;
-		wxStaticText* m_cInfinityCyberworks;
-		wxStaticText* m_cghIC;
-		wxScrolledWindow* m_dScroll;
-		wxStaticText* m_dHeader;
-		wxStaticLine* m_dDivider1;
-		wxStaticText* m_dSDRplay;
-		wxStaticText* m_dMichaelLadd;
-		wxStaticText* m_dAutoMotiveTemplates;
-		wxStaticText* m_dJorgeMorales;
-		wxStaticText* m_dMichaelRooke;
-		wxStaticText* m_dTNCOM;
-		wxStaticText* m_dErikWied;
-		wxStaticText* m_dRobertDuering;
-		wxStaticText* m_dJimDeitch;
-		wxStaticText* m_dNooElec;
-		wxStaticText* m_dDavidAhlgren;
-		wxStaticText* m_dRonaldCook;
-		wxStaticText* m_dEricPeterson;
-		wxStaticText* m_dGeoDistributing;
-		wxStaticText* m_dJamesCarson;
-		wxStaticText* m_dCraigWilliams;
-		wxStaticText* m_dRudolfShaffer;
-		wxStaticText* m_dJohnKaton;
-		wxStaticText* m_dVincentSonnier;
-		wxStaticText* m_dCorq;
-		wxStaticText* m_dIvanAlekseev;
-		wxStaticText* m_dOleJorgenKolsrud;
-		wxStaticText* m_dHenrikJagemyr;
-		wxStaticText* m_dPeterHaines;
-		wxStaticText* m_dLeonAbrassart;
-		wxStaticText* m_dGeorgeTalbot;
-		wxStaticText* m_dFranciscoPuerta;
-		wxStaticText* m_dRonaldLundeen;
-		wxStaticText* m_dWalterHorbert;
-		wxStaticText* m_dWilliamLD;
-		wxStaticText* m_dBratislavArandjelovic;
-		wxStaticText* m_dGaryMartin;
-		wxStaticText* m_dEinarsRepse;
-		wxStaticText* m_dTimothyGatton;
-		wxStaticText* m_dStephenCuccio;
-		wxStaticText* m_dKeshavlalPatel;
-		wxStaticText* m_dBobSchatzman;
-		wxStaticText* m_dRobertRoss;
-		wxStaticText* m_dRobertoBellotti;
-		wxStaticText* m_dSergeVanderTorre;
-		wxStaticText* m_dDieterSchneider;
-		wxStaticText* m_dPetrikaJaneku;
-		wxScrolledWindow* m_stScroll;
-		wxStaticText* m_stHeader;
-		wxStaticLine* m_stDivider1;
-		wxStaticText* m_stSoapyDevAssistHeader;
-		wxStaticText* m_stJoshBlum;
-		wxStaticLine* m_stDivider2;
-		wxStaticText* m_stLiquidDSPHeader;
-		wxStaticText* m_stJosephGaeddert;
-		wxStaticLine* m_stDivider3;
-		wxStaticText* m_stIdeasDirectionsHeader;
-		wxStaticText* m_stTonMachielsen;
-		wxStaticText* m_stMikeLadd;
-		wxStaticText* m_stSDRplay;
-		wxStaticText* m_stSDRplayFB;
-		wxStaticText* m_stPaulWarren;
-		wxStaticText* m_stSegesdiKaroly;
-		wxStaticText* m_stRedditRTLSDR;
-		wxStaticText* m_stNooElec;
-		wxStaticText* m_stGHIssues;
-		wxStaticText* m_stNominate;
-	
-	public:
-		
-		AboutDialogBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("About"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 530,420 ), long style = wxDEFAULT_DIALOG_STYLE ); 
-		~AboutDialogBase();
-	
+private:
+
+protected:
+	wxPanel* m_hPanel;
+	wxStaticText* m_appName;
+	wxNotebook* m_aboutNotebook;
+	wxScrolledWindow* m_dbScroll;
+	wxStaticText* m_dbHeader;
+	wxStaticText* m_dbGHHeader;
+	wxStaticText* m_dbTwitter;
+	wxStaticText* m_dbCharlesCliffe;
+	wxStaticText* m_dbghCC;
+	wxStaticText* m_dbtCC;
+	wxStaticText* m_dbVincentSonnier;
+	wxStaticText* m_dbghVS;
+	wxStaticText* m_dbtVS;
+	wxStaticLine* m_dbDivider1;
+	wxStaticText* m_cContributorsHeader;
+	wxStaticText* m_cGitHub;
+	wxStaticText* m_cCorneLukken;
+	wxStaticText* m_cghCL;
+	wxStaticText* m_cStainislawPitucha;
+	wxStaticText* m_cghSP;
+	wxStaticText* m_cghStefanTalpalaru;
+	wxStaticText* m_cghST;
+	wxStaticText* m_cCrisMotch;
+	wxStaticText* m_cghCM;
+	wxStaticText* m_cMariuszRyndzionek;
+	wxStaticText* m_cghMR;
+	wxStaticText* m_cJiangWei;
+	wxStaticText* m_cghJW;
+	wxStaticText* m_cTomSwartz;
+	wxStaticText* m_cghTS;
+	wxStaticText* m_cInfinityCyberworks;
+	wxStaticText* m_cghIC;
+	wxScrolledWindow* m_dScroll;
+	wxStaticText* m_dHeader;
+	wxStaticLine* m_dDivider1;
+	wxStaticText* m_dSDRplay;
+	wxStaticText* m_dMichaelLadd;
+	wxStaticText* m_dAutoMotiveTemplates;
+	wxStaticText* m_dJorgeMorales;
+	wxStaticText* m_dMichaelRooke;
+	wxStaticText* m_dTNCOM;
+	wxStaticText* m_dErikWied;
+	wxStaticText* m_dRobertDuering;
+	wxStaticText* m_dJimDeitch;
+	wxStaticText* m_dNooElec;
+	wxStaticText* m_dDavidAhlgren;
+	wxStaticText* m_dRonaldCook;
+	wxStaticText* m_dEricPeterson;
+	wxStaticText* m_dGeoDistributing;
+	wxStaticText* m_dJamesCarson;
+	wxStaticText* m_dCraigWilliams;
+	wxStaticText* m_dRudolfShaffer;
+	wxStaticText* m_dJohnKaton;
+	wxStaticText* m_dVincentSonnier;
+	wxStaticText* m_dCorq;
+	wxStaticText* m_dIvanAlekseev;
+	wxStaticText* m_dOleJorgenKolsrud;
+	wxStaticText* m_dHenrikJagemyr;
+	wxStaticText* m_dPeterHaines;
+	wxStaticText* m_dLeonAbrassart;
+	wxStaticText* m_dGeorgeTalbot;
+	wxStaticText* m_dFranciscoPuerta;
+	wxStaticText* m_dRonaldLundeen;
+	wxStaticText* m_dWalterHorbert;
+	wxStaticText* m_dWilliamLD;
+	wxStaticText* m_dBratislavArandjelovic;
+	wxStaticText* m_dGaryMartin;
+	wxStaticText* m_dEinarsRepse;
+	wxStaticText* m_dTimothyGatton;
+	wxStaticText* m_dStephenCuccio;
+	wxStaticText* m_dKeshavlalPatel;
+	wxStaticText* m_dBobSchatzman;
+	wxStaticText* m_dRobertRoss;
+	wxStaticText* m_dRobertoBellotti;
+	wxStaticText* m_dSergeVanderTorre;
+	wxStaticText* m_dDieterSchneider;
+	wxStaticText* m_dPetrikaJaneku;
+	wxScrolledWindow* m_stScroll;
+	wxStaticText* m_stHeader;
+	wxStaticLine* m_stDivider1;
+	wxStaticText* m_stSoapyDevAssistHeader;
+	wxStaticText* m_stJoshBlum;
+	wxStaticLine* m_stDivider2;
+	wxStaticText* m_stLiquidDSPHeader;
+	wxStaticText* m_stJosephGaeddert;
+	wxStaticLine* m_stDivider3;
+	wxStaticText* m_stIdeasDirectionsHeader;
+	wxStaticText* m_stTonMachielsen;
+	wxStaticText* m_stMikeLadd;
+	wxStaticText* m_stSDRplay;
+	wxStaticText* m_stSDRplayFB;
+	wxStaticText* m_stPaulWarren;
+	wxStaticText* m_stSegesdiKaroly;
+	wxStaticText* m_stRedditRTLSDR;
+	wxStaticText* m_stNooElec;
+	wxStaticText* m_stGHIssues;
+	wxStaticText* m_stNominate;
+
+public:
+
+	AboutDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("About"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(530, 420), long style = wxDEFAULT_DIALOG_STYLE);
+	~AboutDialogBase();
+
 };
 
 #endif //__ABOUTDIALOGBASE_H__

--- a/src/forms/Dialog/ActionDialogBase.cpp
+++ b/src/forms/Dialog/ActionDialogBase.cpp
@@ -1,53 +1,53 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "ActionDialogBase.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-ActionDialogBase::ActionDialogBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
+ActionDialogBase::ActionDialogBase(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
+	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+
 	wxBoxSizer* mainSizer;
-	mainSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_questionText = new wxStaticText( this, wxID_ANY, wxT("Question"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE );
-	m_questionText->Wrap( -1 );
-	mainSizer->Add( m_questionText, 1, wxALL|wxEXPAND, 5 );
-	
+	mainSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_questionText = new wxStaticText(this, wxID_ANY, wxT("Question"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);
+	m_questionText->Wrap(-1);
+	mainSizer->Add(m_questionText, 1, wxALL | wxEXPAND, 5);
+
 	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_cancelButton = new wxButton( this, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_cancelButton, 1, wxALL|wxEXPAND, 5 );
-	
-	m_okButton = new wxButton( this, wxID_ANY, wxT("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_okButton, 1, wxALL|wxEXPAND, 5 );
-	
-	
-	mainSizer->Add( buttonSizer, 1, wxEXPAND, 5 );
-	
-	
-	this->SetSizer( mainSizer );
+	buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	m_cancelButton = new wxButton(this, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0);
+	buttonSizer->Add(m_cancelButton, 1, wxALL | wxEXPAND, 5);
+
+	m_okButton = new wxButton(this, wxID_ANY, wxT("OK"), wxDefaultPosition, wxDefaultSize, 0);
+	buttonSizer->Add(m_okButton, 1, wxALL | wxEXPAND, 5);
+
+
+	mainSizer->Add(buttonSizer, 1, wxEXPAND, 5);
+
+
+	this->SetSizer(mainSizer);
 	this->Layout();
-	mainSizer->Fit( this );
-	
-	this->Centre( wxBOTH );
-	
+	mainSizer->Fit(this);
+
+	this->Centre(wxBOTH);
+
 	// Connect Events
-	m_cancelButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ActionDialogBase::onClickCancel ), NULL, this );
-	m_okButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ActionDialogBase::onClickOK ), NULL, this );
+	m_cancelButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ActionDialogBase::onClickCancel), NULL, this);
+	m_okButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ActionDialogBase::onClickOK), NULL, this);
 }
 
 ActionDialogBase::~ActionDialogBase()
 {
 	// Disconnect Events
-	m_cancelButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ActionDialogBase::onClickCancel ), NULL, this );
-	m_okButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ActionDialogBase::onClickOK ), NULL, this );
-	
+	m_cancelButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ActionDialogBase::onClickCancel), NULL, this);
+	m_okButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ActionDialogBase::onClickOK), NULL, this);
+
 }

--- a/src/forms/Dialog/ActionDialogBase.h
+++ b/src/forms/Dialog/ActionDialogBase.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __ACTIONDIALOGBASE_H__
@@ -26,25 +26,25 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class ActionDialogBase
 ///////////////////////////////////////////////////////////////////////////////
-class ActionDialogBase : public wxDialog 
+class ActionDialogBase : public wxDialog
 {
-	private:
-	
-	protected:
-		wxStaticText* m_questionText;
-		wxButton* m_cancelButton;
-		wxButton* m_okButton;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void onClickCancel( wxCommandEvent& event ) { event.Skip(); }
-		virtual void onClickOK( wxCommandEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		ActionDialogBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("QuestionTitle"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE ); 
-		~ActionDialogBase();
-	
+private:
+
+protected:
+	wxStaticText* m_questionText;
+	wxButton* m_cancelButton;
+	wxButton* m_okButton;
+
+	// Virtual event handlers, overide them in your derived class
+	virtual void onClickCancel(wxCommandEvent& event) { event.Skip(); }
+	virtual void onClickOK(wxCommandEvent& event) { event.Skip(); }
+
+
+public:
+
+	ActionDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("QuestionTitle"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE);
+	~ActionDialogBase();
+
 };
 
 #endif //__ACTIONDIALOGBASE_H__

--- a/src/forms/Dialog/PortSelectorDialogBase.cpp
+++ b/src/forms/Dialog/PortSelectorDialogBase.cpp
@@ -1,78 +1,78 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "PortSelectorDialogBase.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-PortSelectorDialogBase::PortSelectorDialogBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
+PortSelectorDialogBase::PortSelectorDialogBase(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
+	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+
 	wxBoxSizer* dlgSizer;
-	dlgSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticText1 = new wxStaticText( this, wxID_ANY, wxT("Select a detected port or enter your own"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText1->Wrap( -1 );
-	dlgSizer->Add( m_staticText1, 0, wxEXPAND|wxALL, 5 );
-	
-	m_portList = new wxListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	dlgSizer->Add( m_portList, 1, wxALL|wxEXPAND, 5 );
-	
+	dlgSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_staticText1 = new wxStaticText(this, wxID_ANY, wxT("Select a detected port or enter your own"), wxDefaultPosition, wxDefaultSize, 0);
+	m_staticText1->Wrap(-1);
+	dlgSizer->Add(m_staticText1, 0, wxEXPAND | wxALL, 5);
+
+	m_portList = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, 0);
+	dlgSizer->Add(m_portList, 1, wxALL | wxEXPAND, 5);
+
 	wxBoxSizer* bSizer3;
-	bSizer3 = new wxBoxSizer( wxHORIZONTAL );
-	
-	bSizer3->SetMinSize( wxSize( -1,30 ) ); 
-	m_staticText2 = new wxStaticText( this, wxID_ANY, wxT("Port"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText2->Wrap( -1 );
-	bSizer3->Add( m_staticText2, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
-	
-	m_portSelection = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer3->Add( m_portSelection, 1, wxEXPAND|wxRIGHT, 5 );
-	
-	
-	dlgSizer->Add( bSizer3, 1, wxEXPAND, 5 );
-	
-	m_buttonPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	bSizer3 = new wxBoxSizer(wxHORIZONTAL);
+
+	bSizer3->SetMinSize(wxSize(-1, 30));
+	m_staticText2 = new wxStaticText(this, wxID_ANY, wxT("Port"), wxDefaultPosition, wxDefaultSize, 0);
+	m_staticText2->Wrap(-1);
+	bSizer3->Add(m_staticText2, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+	m_portSelection = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
+	bSizer3->Add(m_portSelection, 1, wxEXPAND | wxRIGHT, 5);
+
+
+	dlgSizer->Add(bSizer3, 1, wxEXPAND, 5);
+
+	m_buttonPanel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer2;
-	bSizer2 = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_cancelButton = new wxButton( m_buttonPanel, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer2->Add( m_cancelButton, 0, wxALL|wxALIGN_BOTTOM, 5 );
-	
-	
-	bSizer2->Add( 0, 0, 1, wxEXPAND, 5 );
-	
-	m_okButton = new wxButton( m_buttonPanel, wxID_ANY, wxT("OK"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer2->Add( m_okButton, 0, wxALL|wxALIGN_BOTTOM, 5 );
-	
-	
-	m_buttonPanel->SetSizer( bSizer2 );
+	bSizer2 = new wxBoxSizer(wxHORIZONTAL);
+
+	m_cancelButton = new wxButton(m_buttonPanel, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer2->Add(m_cancelButton, 0, wxALL | wxALIGN_BOTTOM, 5);
+
+
+	bSizer2->Add(0, 0, 1, wxEXPAND, 5);
+
+	m_okButton = new wxButton(m_buttonPanel, wxID_ANY, wxT("OK"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer2->Add(m_okButton, 0, wxALL | wxALIGN_BOTTOM, 5);
+
+
+	m_buttonPanel->SetSizer(bSizer2);
 	m_buttonPanel->Layout();
-	bSizer2->Fit( m_buttonPanel );
-	dlgSizer->Add( m_buttonPanel, 0, wxEXPAND | wxALL, 5 );
-	
-	
-	this->SetSizer( dlgSizer );
+	bSizer2->Fit(m_buttonPanel);
+	dlgSizer->Add(m_buttonPanel, 0, wxEXPAND | wxALL, 5);
+
+
+	this->SetSizer(dlgSizer);
 	this->Layout();
-	
-	this->Centre( wxBOTH );
-	
+
+	this->Centre(wxBOTH);
+
 	// Connect Events
-	m_portList->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( PortSelectorDialogBase::onListSelect ), NULL, this );
-	m_cancelButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onCancelButton ), NULL, this );
-	m_okButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onOKButton ), NULL, this );
+	m_portList->Connect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(PortSelectorDialogBase::onListSelect), NULL, this);
+	m_cancelButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(PortSelectorDialogBase::onCancelButton), NULL, this);
+	m_okButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(PortSelectorDialogBase::onOKButton), NULL, this);
 }
 
 PortSelectorDialogBase::~PortSelectorDialogBase()
 {
 	// Disconnect Events
-	m_portList->Disconnect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( PortSelectorDialogBase::onListSelect ), NULL, this );
-	m_cancelButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onCancelButton ), NULL, this );
-	m_okButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onOKButton ), NULL, this );
-	
+	m_portList->Disconnect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(PortSelectorDialogBase::onListSelect), NULL, this);
+	m_cancelButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(PortSelectorDialogBase::onCancelButton), NULL, this);
+	m_okButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(PortSelectorDialogBase::onOKButton), NULL, this);
+
 }

--- a/src/forms/Dialog/PortSelectorDialogBase.h
+++ b/src/forms/Dialog/PortSelectorDialogBase.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __PORTSELECTORDIALOGBASE_H__
@@ -29,30 +29,30 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class PortSelectorDialogBase
 ///////////////////////////////////////////////////////////////////////////////
-class PortSelectorDialogBase : public wxDialog 
+class PortSelectorDialogBase : public wxDialog
 {
-	private:
-	
-	protected:
-		wxStaticText* m_staticText1;
-		wxListBox* m_portList;
-		wxStaticText* m_staticText2;
-		wxTextCtrl* m_portSelection;
-		wxPanel* m_buttonPanel;
-		wxButton* m_cancelButton;
-		wxButton* m_okButton;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void onListSelect( wxCommandEvent& event ) { event.Skip(); }
-		virtual void onCancelButton( wxCommandEvent& event ) { event.Skip(); }
-		virtual void onOKButton( wxCommandEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		PortSelectorDialogBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Select Port"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 304,197 ), long style = wxDEFAULT_DIALOG_STYLE ); 
-		~PortSelectorDialogBase();
-	
+private:
+
+protected:
+	wxStaticText* m_staticText1;
+	wxListBox* m_portList;
+	wxStaticText* m_staticText2;
+	wxTextCtrl* m_portSelection;
+	wxPanel* m_buttonPanel;
+	wxButton* m_cancelButton;
+	wxButton* m_okButton;
+
+	// Virtual event handlers, overide them in your derived class
+	virtual void onListSelect(wxCommandEvent& event) { event.Skip(); }
+	virtual void onCancelButton(wxCommandEvent& event) { event.Skip(); }
+	virtual void onOKButton(wxCommandEvent& event) { event.Skip(); }
+
+
+public:
+
+	PortSelectorDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Select Port"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(304, 197), long style = wxDEFAULT_DIALOG_STYLE);
+	~PortSelectorDialogBase();
+
 };
 
 #endif //__PORTSELECTORDIALOGBASE_H__

--- a/src/forms/DigitalConsole/DigitalConsoleFrame.cpp
+++ b/src/forms/DigitalConsole/DigitalConsoleFrame.cpp
@@ -1,73 +1,73 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "DigitalConsoleFrame.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-DigitalConsoleFrame::DigitalConsoleFrame( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxFrame( parent, id, title, pos, size, style )
+DigitalConsoleFrame::DigitalConsoleFrame(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxFrame(parent, id, title, pos, size, style)
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	this->SetExtraStyle( wxWS_EX_PROCESS_UI_UPDATES );
-	
+	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+	this->SetExtraStyle(wxWS_EX_PROCESS_UI_UPDATES);
+
 	wxBoxSizer* mainSizer;
-	mainSizer = new wxBoxSizer( wxVERTICAL );
-	
+	mainSizer = new wxBoxSizer(wxVERTICAL);
+
 	wxBoxSizer* dataViewSizer;
-	dataViewSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_dataView = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_CHARWRAP|wxTE_MULTILINE|wxTE_NOHIDESEL|wxTE_READONLY|wxTE_WORDWRAP|wxALWAYS_SHOW_SB|wxFULL_REPAINT_ON_RESIZE|wxNO_BORDER|wxSIMPLE_BORDER|wxVSCROLL );
-	m_dataView->SetExtraStyle( wxWS_EX_PROCESS_UI_UPDATES );
-	m_dataView->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 76, 90, 90, false, wxEmptyString ) );
-	
-	dataViewSizer->Add( m_dataView, 1, wxEXPAND, 5 );
-	
-	
-	mainSizer->Add( dataViewSizer, 1, wxEXPAND, 5 );
-	
+	dataViewSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_dataView = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_CHARWRAP | wxTE_MULTILINE | wxTE_NOHIDESEL | wxTE_READONLY | wxTE_WORDWRAP | wxALWAYS_SHOW_SB | wxFULL_REPAINT_ON_RESIZE | wxNO_BORDER | wxSIMPLE_BORDER | wxVSCROLL);
+	m_dataView->SetExtraStyle(wxWS_EX_PROCESS_UI_UPDATES);
+	m_dataView->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
+
+	dataViewSizer->Add(m_dataView, 1, wxEXPAND, 5);
+
+
+	mainSizer->Add(dataViewSizer, 1, wxEXPAND, 5);
+
 	wxBoxSizer* buttonSizer;
-	buttonSizer = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_clearButton = new wxButton( this, wxID_ANY, wxT("Clear"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_clearButton, 1, wxEXPAND, 5 );
-	
-	m_copyButton = new wxButton( this, wxID_ANY, wxT("Copy"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_copyButton, 1, wxEXPAND, 5 );
-	
-	m_pauseButton = new wxButton( this, wxID_ANY, wxT("Stop"), wxDefaultPosition, wxDefaultSize, 0 );
-	buttonSizer->Add( m_pauseButton, 1, wxEXPAND, 5 );
-	
-	
-	mainSizer->Add( buttonSizer, 0, wxALL|wxEXPAND, 5 );
-	
-	
-	this->SetSizer( mainSizer );
+	buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	m_clearButton = new wxButton(this, wxID_ANY, wxT("Clear"), wxDefaultPosition, wxDefaultSize, 0);
+	buttonSizer->Add(m_clearButton, 1, wxEXPAND, 5);
+
+	m_copyButton = new wxButton(this, wxID_ANY, wxT("Copy"), wxDefaultPosition, wxDefaultSize, 0);
+	buttonSizer->Add(m_copyButton, 1, wxEXPAND, 5);
+
+	m_pauseButton = new wxButton(this, wxID_ANY, wxT("Stop"), wxDefaultPosition, wxDefaultSize, 0);
+	buttonSizer->Add(m_pauseButton, 1, wxEXPAND, 5);
+
+
+	mainSizer->Add(buttonSizer, 0, wxALL | wxEXPAND, 5);
+
+
+	this->SetSizer(mainSizer);
 	this->Layout();
-	m_refreshTimer.SetOwner( this, wxID_ANY );
-	m_refreshTimer.Start( 250 );
-	
-	
-	this->Centre( wxBOTH );
-	
+	m_refreshTimer.SetOwner(this, wxID_ANY);
+	m_refreshTimer.Start(250);
+
+
+	this->Centre(wxBOTH);
+
 	// Connect Events
-	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( DigitalConsoleFrame::OnClose ) );
-	m_clearButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DigitalConsoleFrame::OnClear ), NULL, this );
-	m_copyButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DigitalConsoleFrame::OnCopy ), NULL, this );
-	m_pauseButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DigitalConsoleFrame::OnPause ), NULL, this );
-	this->Connect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( DigitalConsoleFrame::DoRefresh ) );
+	this->Connect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(DigitalConsoleFrame::OnClose));
+	m_clearButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(DigitalConsoleFrame::OnClear), NULL, this);
+	m_copyButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(DigitalConsoleFrame::OnCopy), NULL, this);
+	m_pauseButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(DigitalConsoleFrame::OnPause), NULL, this);
+	this->Connect(wxID_ANY, wxEVT_TIMER, wxTimerEventHandler(DigitalConsoleFrame::DoRefresh));
 }
 
 DigitalConsoleFrame::~DigitalConsoleFrame()
 {
 	// Disconnect Events
-	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( DigitalConsoleFrame::OnClose ) );
-	m_clearButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DigitalConsoleFrame::OnClear ), NULL, this );
-	m_copyButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DigitalConsoleFrame::OnCopy ), NULL, this );
-	m_pauseButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( DigitalConsoleFrame::OnPause ), NULL, this );
-	this->Disconnect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( DigitalConsoleFrame::DoRefresh ) );
-	
+	this->Disconnect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(DigitalConsoleFrame::OnClose));
+	m_clearButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(DigitalConsoleFrame::OnClear), NULL, this);
+	m_copyButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(DigitalConsoleFrame::OnCopy), NULL, this);
+	m_pauseButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(DigitalConsoleFrame::OnPause), NULL, this);
+	this->Disconnect(wxID_ANY, wxEVT_TIMER, wxTimerEventHandler(DigitalConsoleFrame::DoRefresh));
+
 }

--- a/src/forms/DigitalConsole/DigitalConsoleFrame.h
+++ b/src/forms/DigitalConsole/DigitalConsoleFrame.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __DIGITALCONSOLEFRAME_H__
@@ -27,31 +27,31 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class DigitalConsoleFrame
 ///////////////////////////////////////////////////////////////////////////////
-class DigitalConsoleFrame : public wxFrame 
+class DigitalConsoleFrame : public wxFrame
 {
-	private:
-	
-	protected:
-		wxTextCtrl* m_dataView;
-		wxButton* m_clearButton;
-		wxButton* m_copyButton;
-		wxButton* m_pauseButton;
-		wxTimer m_refreshTimer;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
-		virtual void OnClear( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnCopy( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnPause( wxCommandEvent& event ) { event.Skip(); }
-		virtual void DoRefresh( wxTimerEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		DigitalConsoleFrame( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Digital Output"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 441,394 ), long style = wxCAPTION|wxFRAME_FLOAT_ON_PARENT|wxMAXIMIZE|wxMAXIMIZE_BOX|wxMINIMIZE|wxMINIMIZE_BOX|wxRESIZE_BORDER|wxFULL_REPAINT_ON_RESIZE|wxTAB_TRAVERSAL );
-		
-		~DigitalConsoleFrame();
-	
+private:
+
+protected:
+	wxTextCtrl* m_dataView;
+	wxButton* m_clearButton;
+	wxButton* m_copyButton;
+	wxButton* m_pauseButton;
+	wxTimer m_refreshTimer;
+
+	// Virtual event handlers, overide them in your derived class
+	virtual void OnClose(wxCloseEvent& event) { event.Skip(); }
+	virtual void OnClear(wxCommandEvent& event) { event.Skip(); }
+	virtual void OnCopy(wxCommandEvent& event) { event.Skip(); }
+	virtual void OnPause(wxCommandEvent& event) { event.Skip(); }
+	virtual void DoRefresh(wxTimerEvent& event) { event.Skip(); }
+
+
+public:
+
+	DigitalConsoleFrame(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Digital Output"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(441, 394), long style = wxCAPTION | wxFRAME_FLOAT_ON_PARENT | wxMAXIMIZE | wxMAXIMIZE_BOX | wxMINIMIZE | wxMINIMIZE_BOX | wxRESIZE_BORDER | wxFULL_REPAINT_ON_RESIZE | wxTAB_TRAVERSAL);
+
+	~DigitalConsoleFrame();
+
 };
 
 #endif //__DIGITALCONSOLEFRAME_H__

--- a/src/forms/SDRDevices/SDRDeviceAddForm.cpp
+++ b/src/forms/SDRDevices/SDRDeviceAddForm.cpp
@@ -1,83 +1,83 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "SDRDeviceAddForm.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-SDRDeviceAddForm::SDRDeviceAddForm( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
+SDRDeviceAddForm::SDRDeviceAddForm(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxDialog(parent, id, title, pos, size, style)
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
+	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+
 	wxBoxSizer* bSizer6;
-	bSizer6 = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticText4 = new wxStaticText( this, wxID_ANY, wxT("Manually add a SoapyRemote or SoapySDR device.  \n\nUseful for a device that is not detected automatically."), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText4->Wrap( -1 );
-	bSizer6->Add( m_staticText4, 0, wxALL, 8 );
-	
-	
-	bSizer6->Add( 0, 0, 1, wxEXPAND, 5 );
-	
+	bSizer6 = new wxBoxSizer(wxVERTICAL);
+
+	m_staticText4 = new wxStaticText(this, wxID_ANY, wxT("Manually add a SoapyRemote or SoapySDR device.  \n\nUseful for a device that is not detected automatically."), wxDefaultPosition, wxDefaultSize, 0);
+	m_staticText4->Wrap(-1);
+	bSizer6->Add(m_staticText4, 0, wxALL, 8);
+
+
+	bSizer6->Add(0, 0, 1, wxEXPAND, 5);
+
 	wxArrayString m_soapyModuleChoices;
-	m_soapyModule = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_soapyModuleChoices, 0 );
-	m_soapyModule->SetSelection( 0 );
-	bSizer6->Add( m_soapyModule, 0, wxALL, 8 );
-	
-	
-	bSizer6->Add( 0, 0, 1, wxEXPAND, 5 );
-	
-	m_paramLabel = new wxStaticText( this, wxID_ANY, wxT("<Parameter>"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_paramLabel->Wrap( -1 );
-	bSizer6->Add( m_paramLabel, 0, wxALL, 8 );
-	
-	m_paramText = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_DONTWRAP|wxHSCROLL );
-	m_paramText->SetMinSize( wxSize( -1,48 ) );
-	
-	bSizer6->Add( m_paramText, 1, wxALL|wxEXPAND, 8 );
-	
-	
-	bSizer6->Add( 0, 0, 1, wxEXPAND, 5 );
-	
+	m_soapyModule = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_soapyModuleChoices, 0);
+	m_soapyModule->SetSelection(0);
+	bSizer6->Add(m_soapyModule, 0, wxALL, 8);
+
+
+	bSizer6->Add(0, 0, 1, wxEXPAND, 5);
+
+	m_paramLabel = new wxStaticText(this, wxID_ANY, wxT("<Parameter>"), wxDefaultPosition, wxDefaultSize, 0);
+	m_paramLabel->Wrap(-1);
+	bSizer6->Add(m_paramLabel, 0, wxALL, 8);
+
+	m_paramText = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_DONTWRAP | wxHSCROLL);
+	m_paramText->SetMinSize(wxSize(-1, 48));
+
+	bSizer6->Add(m_paramText, 1, wxALL | wxEXPAND, 8);
+
+
+	bSizer6->Add(0, 0, 1, wxEXPAND, 5);
+
 	wxBoxSizer* bSizer7;
-	bSizer7 = new wxBoxSizer( wxHORIZONTAL );
-	
-	
-	bSizer7->Add( 0, 0, 1, wxEXPAND, 5 );
-	
-	m_cancelButton = new wxButton( this, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer7->Add( m_cancelButton, 0, wxALL, 2 );
-	
-	m_OkButton = new wxButton( this, wxID_ANY, wxT("Ok"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer7->Add( m_OkButton, 0, wxALL, 2 );
-	
-	
-	bSizer6->Add( bSizer7, 1, wxEXPAND, 8 );
-	
-	
-	bSizer6->Add( 0, 0, 1, wxEXPAND, 5 );
-	
-	
-	this->SetSizer( bSizer6 );
+	bSizer7 = new wxBoxSizer(wxHORIZONTAL);
+
+
+	bSizer7->Add(0, 0, 1, wxEXPAND, 5);
+
+	m_cancelButton = new wxButton(this, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer7->Add(m_cancelButton, 0, wxALL, 2);
+
+	m_OkButton = new wxButton(this, wxID_ANY, wxT("Ok"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer7->Add(m_OkButton, 0, wxALL, 2);
+
+
+	bSizer6->Add(bSizer7, 1, wxEXPAND, 8);
+
+
+	bSizer6->Add(0, 0, 1, wxEXPAND, 5);
+
+
+	this->SetSizer(bSizer6);
 	this->Layout();
-	
-	this->Centre( wxBOTH );
-	
+
+	this->Centre(wxBOTH);
+
 	// Connect Events
-	m_soapyModule->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( SDRDeviceAddForm::OnSoapyModuleChanged ), NULL, this );
-	m_cancelButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SDRDeviceAddForm::OnCancelButton ), NULL, this );
-	m_OkButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SDRDeviceAddForm::OnOkButton ), NULL, this );
+	m_soapyModule->Connect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(SDRDeviceAddForm::OnSoapyModuleChanged), NULL, this);
+	m_cancelButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(SDRDeviceAddForm::OnCancelButton), NULL, this);
+	m_OkButton->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(SDRDeviceAddForm::OnOkButton), NULL, this);
 }
 
 SDRDeviceAddForm::~SDRDeviceAddForm()
 {
 	// Disconnect Events
-	m_soapyModule->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( SDRDeviceAddForm::OnSoapyModuleChanged ), NULL, this );
-	m_cancelButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SDRDeviceAddForm::OnCancelButton ), NULL, this );
-	m_OkButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SDRDeviceAddForm::OnOkButton ), NULL, this );
-	
+	m_soapyModule->Disconnect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(SDRDeviceAddForm::OnSoapyModuleChanged), NULL, this);
+	m_cancelButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(SDRDeviceAddForm::OnCancelButton), NULL, this);
+	m_OkButton->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(SDRDeviceAddForm::OnOkButton), NULL, this);
+
 }

--- a/src/forms/SDRDevices/SDRDeviceAddForm.h
+++ b/src/forms/SDRDevices/SDRDeviceAddForm.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __SDRDEVICEADDFORM_H__
@@ -28,29 +28,29 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class SDRDeviceAddForm
 ///////////////////////////////////////////////////////////////////////////////
-class SDRDeviceAddForm : public wxDialog 
+class SDRDeviceAddForm : public wxDialog
 {
-	private:
-	
-	protected:
-		wxStaticText* m_staticText4;
-		wxChoice* m_soapyModule;
-		wxStaticText* m_paramLabel;
-		wxTextCtrl* m_paramText;
-		wxButton* m_cancelButton;
-		wxButton* m_OkButton;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void OnSoapyModuleChanged( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnCancelButton( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnOkButton( wxCommandEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		SDRDeviceAddForm( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Add SoapySDR Device"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 395,293 ), long style = wxDEFAULT_DIALOG_STYLE ); 
-		~SDRDeviceAddForm();
-	
+private:
+
+protected:
+	wxStaticText* m_staticText4;
+	wxChoice* m_soapyModule;
+	wxStaticText* m_paramLabel;
+	wxTextCtrl* m_paramText;
+	wxButton* m_cancelButton;
+	wxButton* m_OkButton;
+
+	// Virtual event handlers, overide them in your derived class
+	virtual void OnSoapyModuleChanged(wxCommandEvent& event) { event.Skip(); }
+	virtual void OnCancelButton(wxCommandEvent& event) { event.Skip(); }
+	virtual void OnOkButton(wxCommandEvent& event) { event.Skip(); }
+
+
+public:
+
+	SDRDeviceAddForm(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Add SoapySDR Device"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(395, 293), long style = wxDEFAULT_DIALOG_STYLE);
+	~SDRDeviceAddForm();
+
 };
 
 #endif //__SDRDEVICEADDFORM_H__

--- a/src/forms/SDRDevices/SDRDevicesForm.cpp
+++ b/src/forms/SDRDevices/SDRDevicesForm.cpp
@@ -1,115 +1,115 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "SDRDevicesForm.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
-devFrame::devFrame( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxFrame( parent, id, title, pos, size, style )
+devFrame::devFrame(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style) : wxFrame(parent, id, title, pos, size, style)
 {
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	devStatusBar = this->CreateStatusBar( 1, wxST_SIZEGRIP, wxID_ANY );
+	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+
+	devStatusBar = this->CreateStatusBar(1, wxST_SIZEGRIP, wxID_ANY);
 	wxBoxSizer* devFrameSizer;
-	devFrameSizer = new wxBoxSizer( wxVERTICAL );
-	
-	m_panel3 = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	devFrameSizer = new wxBoxSizer(wxVERTICAL);
+
+	m_panel3 = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer4;
-	bSizer4 = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_panel6 = new wxPanel( m_panel3, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	bSizer4 = new wxBoxSizer(wxHORIZONTAL);
+
+	m_panel6 = new wxPanel(m_panel3, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer6;
-	bSizer6 = new wxBoxSizer( wxVERTICAL );
-	
-	devTree = new wxTreeCtrl( m_panel6, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE );
-	devTree->Enable( false );
-	
-	bSizer6->Add( devTree, 1, wxEXPAND, 5 );
-	
-	m_panel4 = new wxPanel( m_panel6, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	bSizer6 = new wxBoxSizer(wxVERTICAL);
+
+	devTree = new wxTreeCtrl(m_panel6, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE);
+	devTree->Enable(false);
+
+	bSizer6->Add(devTree, 1, wxEXPAND, 5);
+
+	m_panel4 = new wxPanel(m_panel6, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer5;
-	bSizer5 = new wxBoxSizer( wxHORIZONTAL );
-	
-	m_refreshButton = new wxButton( m_panel4, wxID_ANY, wxT("Refresh"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer5->Add( m_refreshButton, 1, wxALL, 5 );
-	
-	m_addRemoteButton = new wxButton( m_panel4, wxID_ANY, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer5->Add( m_addRemoteButton, 1, wxALL, 5 );
-	
-	m_useSelectedButton = new wxButton( m_panel4, wxID_ANY, wxT("Start"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer5->Add( m_useSelectedButton, 1, wxALL|wxALIGN_CENTER_VERTICAL, 5 );
-	
-	
-	m_panel4->SetSizer( bSizer5 );
+	bSizer5 = new wxBoxSizer(wxHORIZONTAL);
+
+	m_refreshButton = new wxButton(m_panel4, wxID_ANY, wxT("Refresh"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer5->Add(m_refreshButton, 1, wxALL, 5);
+
+	m_addRemoteButton = new wxButton(m_panel4, wxID_ANY, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer5->Add(m_addRemoteButton, 1, wxALL, 5);
+
+	m_useSelectedButton = new wxButton(m_panel4, wxID_ANY, wxT("Start"), wxDefaultPosition, wxDefaultSize, 0);
+	bSizer5->Add(m_useSelectedButton, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+
+	m_panel4->SetSizer(bSizer5);
 	m_panel4->Layout();
-	bSizer5->Fit( m_panel4 );
-	bSizer6->Add( m_panel4, 0, wxEXPAND, 5 );
-	
-	
-	m_panel6->SetSizer( bSizer6 );
+	bSizer5->Fit(m_panel4);
+	bSizer6->Add(m_panel4, 0, wxEXPAND, 5);
+
+
+	m_panel6->SetSizer(bSizer6);
 	m_panel6->Layout();
-	bSizer6->Fit( m_panel6 );
-	bSizer4->Add( m_panel6, 1, wxEXPAND | wxALL, 5 );
-	
-	m_panel61 = new wxPanel( m_panel3, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	bSizer6->Fit(m_panel6);
+	bSizer4->Add(m_panel6, 1, wxEXPAND | wxALL, 5);
+
+	m_panel61 = new wxPanel(m_panel3, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	wxBoxSizer* bSizer7;
-	bSizer7 = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticText1 = new wxStaticText( m_panel61, wxID_ANY, wxT("SoapySDR Device Options"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText1->Wrap( -1 );
-	bSizer7->Add( m_staticText1, 0, wxALL, 5 );
-	
+	bSizer7 = new wxBoxSizer(wxVERTICAL);
+
+	m_staticText1 = new wxStaticText(m_panel61, wxID_ANY, wxT("SoapySDR Device Options"), wxDefaultPosition, wxDefaultSize, 0);
+	m_staticText1->Wrap(-1);
+	bSizer7->Add(m_staticText1, 0, wxALL, 5);
+
 	m_propertyGrid = new wxPropertyGrid(m_panel61, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxPG_DEFAULT_STYLE);
-	bSizer7->Add( m_propertyGrid, 1, wxALL|wxEXPAND, 5 );
-	
-	
-	m_panel61->SetSizer( bSizer7 );
+	bSizer7->Add(m_propertyGrid, 1, wxALL | wxEXPAND, 5);
+
+
+	m_panel61->SetSizer(bSizer7);
 	m_panel61->Layout();
-	bSizer7->Fit( m_panel61 );
-	bSizer4->Add( m_panel61, 1, wxEXPAND | wxALL, 5 );
-	
-	
-	m_panel3->SetSizer( bSizer4 );
+	bSizer7->Fit(m_panel61);
+	bSizer4->Add(m_panel61, 1, wxEXPAND | wxALL, 5);
+
+
+	m_panel3->SetSizer(bSizer4);
 	m_panel3->Layout();
-	bSizer4->Fit( m_panel3 );
-	devFrameSizer->Add( m_panel3, 1, wxEXPAND | wxALL, 5 );
-	
-	
-	this->SetSizer( devFrameSizer );
+	bSizer4->Fit(m_panel3);
+	devFrameSizer->Add(m_panel3, 1, wxEXPAND | wxALL, 5);
+
+
+	this->SetSizer(devFrameSizer);
 	this->Layout();
-	m_deviceTimer.SetOwner( this, wxID_ANY );
-	
-	this->Centre( wxBOTH );
-	
+	m_deviceTimer.SetOwner(this, wxID_ANY);
+
+	this->Centre(wxBOTH);
+
 	// Connect Events
-	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( devFrame::OnClose ) );
-	devTree->Connect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( devFrame::OnTreeDoubleClick ), NULL, this );
-	devTree->Connect( wxEVT_COMMAND_TREE_DELETE_ITEM, wxTreeEventHandler( devFrame::OnDeleteItem ), NULL, this );
-	devTree->Connect( wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler( devFrame::OnSelectionChanged ), NULL, this );
-	m_refreshButton->Connect( wxEVT_LEFT_UP, wxMouseEventHandler( devFrame::OnRefreshDevices ), NULL, this );
-	m_addRemoteButton->Connect( wxEVT_LEFT_UP, wxMouseEventHandler( devFrame::OnAddRemote ), NULL, this );
-	m_useSelectedButton->Connect( wxEVT_LEFT_UP, wxMouseEventHandler( devFrame::OnUseSelected ), NULL, this );
-	m_propertyGrid->Connect( wxEVT_PG_CHANGED, wxPropertyGridEventHandler( devFrame::OnPropGridChanged ), NULL, this );
-	m_propertyGrid->Connect( wxEVT_SET_FOCUS, wxFocusEventHandler( devFrame::OnPropGridFocus ), NULL, this );
-	this->Connect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( devFrame::OnDeviceTimer ) );
+	this->Connect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(devFrame::OnClose));
+	devTree->Connect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(devFrame::OnTreeDoubleClick), NULL, this);
+	devTree->Connect(wxEVT_COMMAND_TREE_DELETE_ITEM, wxTreeEventHandler(devFrame::OnDeleteItem), NULL, this);
+	devTree->Connect(wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler(devFrame::OnSelectionChanged), NULL, this);
+	m_refreshButton->Connect(wxEVT_LEFT_UP, wxMouseEventHandler(devFrame::OnRefreshDevices), NULL, this);
+	m_addRemoteButton->Connect(wxEVT_LEFT_UP, wxMouseEventHandler(devFrame::OnAddRemote), NULL, this);
+	m_useSelectedButton->Connect(wxEVT_LEFT_UP, wxMouseEventHandler(devFrame::OnUseSelected), NULL, this);
+	m_propertyGrid->Connect(wxEVT_PG_CHANGED, wxPropertyGridEventHandler(devFrame::OnPropGridChanged), NULL, this);
+	m_propertyGrid->Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(devFrame::OnPropGridFocus), NULL, this);
+	this->Connect(wxID_ANY, wxEVT_TIMER, wxTimerEventHandler(devFrame::OnDeviceTimer));
 }
 
 devFrame::~devFrame()
 {
 	// Disconnect Events
-	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( devFrame::OnClose ) );
-	devTree->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( devFrame::OnTreeDoubleClick ), NULL, this );
-	devTree->Disconnect( wxEVT_COMMAND_TREE_DELETE_ITEM, wxTreeEventHandler( devFrame::OnDeleteItem ), NULL, this );
-	devTree->Disconnect( wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler( devFrame::OnSelectionChanged ), NULL, this );
-	m_refreshButton->Disconnect( wxEVT_LEFT_UP, wxMouseEventHandler( devFrame::OnRefreshDevices ), NULL, this );
-	m_addRemoteButton->Disconnect( wxEVT_LEFT_UP, wxMouseEventHandler( devFrame::OnAddRemote ), NULL, this );
-	m_useSelectedButton->Disconnect( wxEVT_LEFT_UP, wxMouseEventHandler( devFrame::OnUseSelected ), NULL, this );
-	m_propertyGrid->Disconnect( wxEVT_PG_CHANGED, wxPropertyGridEventHandler( devFrame::OnPropGridChanged ), NULL, this );
-	m_propertyGrid->Disconnect( wxEVT_SET_FOCUS, wxFocusEventHandler( devFrame::OnPropGridFocus ), NULL, this );
-	this->Disconnect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( devFrame::OnDeviceTimer ) );
-	
+	this->Disconnect(wxEVT_CLOSE_WINDOW, wxCloseEventHandler(devFrame::OnClose));
+	devTree->Disconnect(wxEVT_LEFT_DCLICK, wxMouseEventHandler(devFrame::OnTreeDoubleClick), NULL, this);
+	devTree->Disconnect(wxEVT_COMMAND_TREE_DELETE_ITEM, wxTreeEventHandler(devFrame::OnDeleteItem), NULL, this);
+	devTree->Disconnect(wxEVT_COMMAND_TREE_SEL_CHANGED, wxTreeEventHandler(devFrame::OnSelectionChanged), NULL, this);
+	m_refreshButton->Disconnect(wxEVT_LEFT_UP, wxMouseEventHandler(devFrame::OnRefreshDevices), NULL, this);
+	m_addRemoteButton->Disconnect(wxEVT_LEFT_UP, wxMouseEventHandler(devFrame::OnAddRemote), NULL, this);
+	m_useSelectedButton->Disconnect(wxEVT_LEFT_UP, wxMouseEventHandler(devFrame::OnUseSelected), NULL, this);
+	m_propertyGrid->Disconnect(wxEVT_PG_CHANGED, wxPropertyGridEventHandler(devFrame::OnPropGridChanged), NULL, this);
+	m_propertyGrid->Disconnect(wxEVT_SET_FOCUS, wxFocusEventHandler(devFrame::OnPropGridFocus), NULL, this);
+	this->Disconnect(wxID_ANY, wxEVT_TIMER, wxTimerEventHandler(devFrame::OnDeviceTimer));
+
 }

--- a/src/forms/SDRDevices/SDRDevicesForm.h
+++ b/src/forms/SDRDevices/SDRDevicesForm.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug 23 2015)
+// C++ code generated with wxFormBuilder (version Oct 27 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __SDRDEVICESFORM_H__
@@ -35,43 +35,43 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class devFrame
 ///////////////////////////////////////////////////////////////////////////////
-class devFrame : public wxFrame 
+class devFrame : public wxFrame
 {
-	private:
-	
-	protected:
-		wxStatusBar* devStatusBar;
-		wxPanel* m_panel3;
-		wxPanel* m_panel6;
-		wxTreeCtrl* devTree;
-		wxPanel* m_panel4;
-		wxButton* m_refreshButton;
-		wxButton* m_addRemoteButton;
-		wxButton* m_useSelectedButton;
-		wxPanel* m_panel61;
-		wxStaticText* m_staticText1;
-		wxPropertyGrid* m_propertyGrid;
-		wxTimer m_deviceTimer;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
-		virtual void OnTreeDoubleClick( wxMouseEvent& event ) { event.Skip(); }
-		virtual void OnDeleteItem( wxTreeEvent& event ) { event.Skip(); }
-		virtual void OnSelectionChanged( wxTreeEvent& event ) { event.Skip(); }
-		virtual void OnRefreshDevices( wxMouseEvent& event ) { event.Skip(); }
-		virtual void OnAddRemote( wxMouseEvent& event ) { event.Skip(); }
-		virtual void OnUseSelected( wxMouseEvent& event ) { event.Skip(); }
-		virtual void OnPropGridChanged( wxPropertyGridEvent& event ) { event.Skip(); }
-		virtual void OnPropGridFocus( wxFocusEvent& event ) { event.Skip(); }
-		virtual void OnDeviceTimer( wxTimerEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		devFrame( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("CubicSDR :: SDR Devices"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 700,467 ), long style = wxDEFAULT_FRAME_STYLE|wxTAB_TRAVERSAL );
-		
-		~devFrame();
-	
+private:
+
+protected:
+	wxStatusBar* devStatusBar;
+	wxPanel* m_panel3;
+	wxPanel* m_panel6;
+	wxTreeCtrl* devTree;
+	wxPanel* m_panel4;
+	wxButton* m_refreshButton;
+	wxButton* m_addRemoteButton;
+	wxButton* m_useSelectedButton;
+	wxPanel* m_panel61;
+	wxStaticText* m_staticText1;
+	wxPropertyGrid* m_propertyGrid;
+	wxTimer m_deviceTimer;
+
+	// Virtual event handlers, overide them in your derived class
+	virtual void OnClose(wxCloseEvent& event) { event.Skip(); }
+	virtual void OnTreeDoubleClick(wxMouseEvent& event) { event.Skip(); }
+	virtual void OnDeleteItem(wxTreeEvent& event) { event.Skip(); }
+	virtual void OnSelectionChanged(wxTreeEvent& event) { event.Skip(); }
+	virtual void OnRefreshDevices(wxMouseEvent& event) { event.Skip(); }
+	virtual void OnAddRemote(wxMouseEvent& event) { event.Skip(); }
+	virtual void OnUseSelected(wxMouseEvent& event) { event.Skip(); }
+	virtual void OnPropGridChanged(wxPropertyGridEvent& event) { event.Skip(); }
+	virtual void OnPropGridFocus(wxFocusEvent& event) { event.Skip(); }
+	virtual void OnDeviceTimer(wxTimerEvent& event) { event.Skip(); }
+
+
+public:
+
+	devFrame(wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("CubicSDR :: SDR Devices"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize(700, 467), long style = wxDEFAULT_FRAME_STYLE | wxTAB_TRAVERSAL);
+
+	~devFrame();
+
 };
 
 #endif //__SDRDEVICESFORM_H__


### PR DESCRIPTION
Squash some warnings:
- wxFont SetFont() deprecated warnings, suppressed by re-generating forms with latest wxFormBuilder, (seen on Ubuntu 16.04)
- double-to-float implicit conversion in CubicVR2 (seen on Visual Studio 2017)