### PR TITLE
Migration to wxWidgets v3.11

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -88,10 +88,10 @@ AppFrame::AppFrame() :
     wxBoxSizer *demodScopeTray = new wxBoxSizer(wxVERTICAL);
     wxBoxSizer *demodTunerTray = new wxBoxSizer(wxHORIZONTAL);
 
-    std::vector<int> attribList = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, 0 };
-    //wxGLAttributes attribList;
-    //attribList.PlatformDefaults().RGBA().DoubleBuffer().EndList();
-    //attribList.PlatformDefaults().MinRGBA(8, 8, 8, 8).DoubleBuffer().Depth(16).EndList();
+    // OpenGL settings:
+    //deprecated format: std::vector<int> attribList = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, 0 };
+    wxGLAttributes attribList;
+    attribList.PlatformDefaults().RGBA().MinRGBA(8, 8, 8, 8).DoubleBuffer().EndList();
 
     mainSplitter = new wxSplitterWindow( this, wxID_MAIN_SPLITTER, wxDefaultPosition, wxDefaultSize, wxSP_3DSASH | wxSP_LIVE_UPDATE );
     mainSplitter->SetSashGravity(10.0f / 37.0f);

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -206,6 +206,14 @@ CubicSDR::CubicSDR() : frequency(0), offset(0), ppm(0), snap(1), sampleRate(DEFA
         shuttingDown.store(false);
         fdlgTarget = FrequencyDialog::FDIALOG_TARGET_DEFAULT;
         stoppedDev = nullptr;
+
+        //set OpenGL configuration:
+        m_glContextAttributes = new wxGLContextAttrs();
+        
+        wxGLContextAttrs glSettings;
+        glSettings.PlatformDefaults().EndList();
+
+        *m_glContextAttributes = glSettings;
 }
 
 bool CubicSDR::OnInit() {
@@ -495,11 +503,16 @@ int CubicSDR::OnExit() {
 PrimaryGLContext& CubicSDR::GetContext(wxGLCanvas *canvas) {
     PrimaryGLContext *glContext;
     if (!m_glContext) {
-        m_glContext = new PrimaryGLContext(canvas, NULL);
+        m_glContext = new PrimaryGLContext(canvas, NULL, GetContextAttributes());
     }
     glContext = m_glContext;
 
     return *glContext;
+}
+
+wxGLContextAttrs* CubicSDR::GetContextAttributes() {
+   
+    return m_glContextAttributes;
 }
 
 void CubicSDR::OnInitCmdLine(wxCmdLineParser& parser) {

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -71,6 +71,7 @@ public:
     CubicSDR();
 
     PrimaryGLContext &GetContext(wxGLCanvas *canvas);
+    wxGLContextAttrs* GetContextAttributes();
 
     virtual bool OnInit();
     virtual int OnExit();
@@ -94,9 +95,7 @@ public:
 
     void setAntennaName(const std::string& name);
     const std::string& getAntennaName();
-    
-    void setDBOffset(int ofs);
-    int getDBOffset();
+   
 
     void setSampleRate(long long rate_in);
     long long getSampleRate();
@@ -186,6 +185,8 @@ private:
     AppFrame *appframe = nullptr;
     AppConfig config;
     PrimaryGLContext *m_glContext = nullptr;
+    wxGLContextAttrs *m_glContextAttributes = nullptr;
+
     std::vector<SDRDeviceInfo *> *devs = nullptr;
 
     DemodulatorMgr demodMgr;

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -190,6 +190,10 @@ void BookmarkView::onUpdateTimer( wxTimerEvent& /* event */ ) {
     }
 }
 
+bool BookmarkView::skipUserEvents() {
+
+    return !this->IsShown() || doUpdateActive || doUpdateBookmarks;
+}
 
 void BookmarkView::updateTheme() {
     wxColour bgColor(ThemeMgr::mgr.currentTheme->generalBackground);
@@ -513,6 +517,10 @@ void BookmarkView::doUpdateActiveList() {
 
 void BookmarkView::onTreeActivate( wxTreeEvent& event ) {
 
+    if (skipUserEvents()) {
+        return;
+    }
+
     wxTreeItemId itm = event.GetItem();
     TreeViewItem* tvi = dynamic_cast<TreeViewItem*>(m_treeView->GetItemData(itm));
 
@@ -538,6 +546,11 @@ void BookmarkView::onTreeActivate( wxTreeEvent& event ) {
 
 
 void BookmarkView::onTreeCollapse( wxTreeEvent& event ) {
+    
+    if (skipUserEvents()) {
+        return;
+    }
+
     bool searchState = (searchKeywords.size() != 0);
     
     if (searchState) {
@@ -567,6 +580,11 @@ void BookmarkView::onTreeCollapse( wxTreeEvent& event ) {
 
 
 void BookmarkView::onTreeExpanded( wxTreeEvent& event ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     bool searchState = (searchKeywords.size() != 0);
     
     if (searchState) {
@@ -596,6 +614,11 @@ void BookmarkView::onTreeExpanded( wxTreeEvent& event ) {
 
 
 void BookmarkView::onTreeItemMenu( wxTreeEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (m_treeView->GetSelection() == bookmarkBranch) {
         wxMenu menu;
         menu.Append(wxCONTEXT_ADD_GROUP_ID, BOOKMARK_VIEW_STR_ADD_GROUP);
@@ -606,6 +629,11 @@ void BookmarkView::onTreeItemMenu( wxTreeEvent& /* event */ ) {
 
 
 void BookmarkView::onMenuItem(wxCommandEvent& event) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (event.GetId() == wxCONTEXT_ADD_GROUP_ID) {
         onAddGroup(event);
     }
@@ -762,6 +790,10 @@ void BookmarkView::addBookmarkChoice(wxWindow *parent) {
 
 
 void BookmarkView::onBookmarkChoice( wxCommandEvent & /* event */ ) {
+    
+    if (skipUserEvents()) {
+        return;
+    }
 
     TreeViewItem *tvi = itemToTVI(m_treeView->GetSelection());
     
@@ -1053,6 +1085,11 @@ void BookmarkView::activeBranchSelection() {
 
 
 void BookmarkView::onTreeSelect( wxTreeEvent& event ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     wxTreeItemId itm = event.GetItem();
     TreeViewItem* tvi = dynamic_cast<TreeViewItem*>(m_treeView->GetItemData(itm));
 
@@ -1097,11 +1134,21 @@ void BookmarkView::onTreeSelect( wxTreeEvent& event ) {
 
 
 void BookmarkView::onTreeSelectChanging( wxTreeEvent& event ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     event.Skip();
 }
 
 
 void BookmarkView::onLabelText( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     std::wstring newLabel = m_labelText->GetValue().ToStdWstring();
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
@@ -1135,6 +1182,10 @@ void BookmarkView::onLabelText( wxCommandEvent& /* event */ ) {
 
 void BookmarkView::onDoubleClickFreq( wxMouseEvent& /* event */ ) {
 
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_ACTIVE) {
@@ -1146,6 +1197,11 @@ void BookmarkView::onDoubleClickFreq( wxMouseEvent& /* event */ ) {
 
 
 void BookmarkView::onDoubleClickBandwidth( wxMouseEvent& /* event */ ) {
+    
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
 
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_ACTIVE) {
@@ -1157,6 +1213,11 @@ void BookmarkView::onDoubleClickBandwidth( wxMouseEvent& /* event */ ) {
 
 
 void BookmarkView::onRemoveActive( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
 
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_ACTIVE) {
@@ -1168,6 +1229,11 @@ void BookmarkView::onRemoveActive( wxCommandEvent& /* event */ ) {
 }
 
 void BookmarkView::onStartRecording( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_ACTIVE) {
@@ -1180,6 +1246,11 @@ void BookmarkView::onStartRecording( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onStopRecording( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_ACTIVE) {
@@ -1193,6 +1264,11 @@ void BookmarkView::onStopRecording( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onRemoveBookmark( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (editingLabel) {
         return;
     }
@@ -1206,6 +1282,11 @@ void BookmarkView::onRemoveBookmark( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onActivateBookmark( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
 
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_BOOKMARK) {
@@ -1215,6 +1296,11 @@ void BookmarkView::onActivateBookmark( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onActivateRecent( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_RECENT) {
@@ -1230,6 +1316,11 @@ void BookmarkView::onActivateRecent( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onRemoveRecent ( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (editingLabel) {
         return;
     }
@@ -1247,6 +1338,11 @@ void BookmarkView::onRemoveRecent ( wxCommandEvent& /* event */ ) {
 }
 
 void BookmarkView::onClearRecents ( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (editingLabel) {
         return;
     }
@@ -1255,6 +1351,11 @@ void BookmarkView::onClearRecents ( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onAddGroup( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     wxString stringVal = wxGetTextFromUser(BOOKMARK_VIEW_STR_ADD_GROUP_DESC, BOOKMARK_VIEW_STR_ADD_GROUP, "");
     if (stringVal.ToStdString() != "") {
         wxGetApp().getBookmarkMgr().addGroup(stringVal.ToStdString());
@@ -1264,6 +1365,11 @@ void BookmarkView::onAddGroup( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onRemoveGroup( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (editingLabel) {
         return;
     }
@@ -1277,6 +1383,10 @@ void BookmarkView::onRemoveGroup( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onAddRange( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
     
     BookmarkRangeEntryPtr re = BookmarkView::makeActiveRangeEntry();
     
@@ -1288,6 +1398,11 @@ void BookmarkView::onAddRange( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onRemoveRange( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     if (editingLabel) {
         return;
     }
@@ -1301,6 +1416,11 @@ void BookmarkView::onRemoveRange( wxCommandEvent& /* event */ ) {
 
 
 void BookmarkView::onRenameRange( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (!curSel || curSel->type != TreeViewItem::TREEVIEW_ITEM_TYPE_GROUP) {
@@ -1319,6 +1439,11 @@ void BookmarkView::onRenameRange( wxCommandEvent& /* event */ ) {
 }
 
 void BookmarkView::onActivateRange( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_RANGE) {
@@ -1327,6 +1452,11 @@ void BookmarkView::onActivateRange( wxCommandEvent& /* event */ ) {
 }
 
 void BookmarkView::onUpdateRange( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem *curSel = itemToTVI(m_treeView->GetSelection());
     
     if (curSel && curSel->type == TreeViewItem::TREEVIEW_ITEM_TYPE_RANGE) {
@@ -1335,6 +1465,11 @@ void BookmarkView::onUpdateRange( wxCommandEvent& /* event */ ) {
 }
 
 void BookmarkView::onTreeBeginDrag( wxTreeEvent& event ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     TreeViewItem* tvi = dynamic_cast<TreeViewItem*>(m_treeView->GetItemData(event.GetItem()));
     
     dragItem = nullptr;
@@ -1379,6 +1514,10 @@ void BookmarkView::onTreeBeginDrag( wxTreeEvent& event ) {
 
 
 void BookmarkView::onTreeEndDrag( wxTreeEvent& event ) {
+    
+    if (skipUserEvents()) {
+        return;
+    }
 
     wxColour bgColor(ThemeMgr::mgr.currentTheme->generalBackground);
     wxColour textColor(ThemeMgr::mgr.currentTheme->text);
@@ -1439,6 +1578,10 @@ void BookmarkView::onTreeEndDrag( wxTreeEvent& event ) {
 
 void BookmarkView::onTreeItemGetTooltip( wxTreeEvent& event ) {
     
+    if (skipUserEvents()) {
+        return;
+    }
+
     event.Skip();
 }
 
@@ -1491,6 +1634,11 @@ TreeViewItem *BookmarkView::itemToTVI(wxTreeItemId item) {
 }
 
 void BookmarkView::onSearchTextFocus( wxMouseEvent&  event ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     mouseTracker.OnMouseMoved(event);
     
     //apparently needed ???
@@ -1515,6 +1663,11 @@ void BookmarkView::onSearchTextFocus( wxMouseEvent&  event ) {
 
 
 void BookmarkView::onSearchText( wxCommandEvent& event ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     std::wstring searchText = m_searchText->GetValue().Trim().Lower().ToStdWstring();
     
    searchKeywords.clear();
@@ -1545,6 +1698,11 @@ void BookmarkView::onSearchText( wxCommandEvent& event ) {
 
 
 void BookmarkView::onClearSearch( wxCommandEvent& /* event */ ) {
+
+    if (skipUserEvents()) {
+        return;
+    }
+
     m_clearSearchButton->Hide();
     m_searchText->SetValue(L"Search..");
     m_treeView->SetFocus();

--- a/src/forms/Bookmark/BookmarkView.h
+++ b/src/forms/Bookmark/BookmarkView.h
@@ -161,6 +161,8 @@ protected:
     void onRenameRange( wxCommandEvent& event );
     void onActivateRange( wxCommandEvent& event );
     void onUpdateRange( wxCommandEvent& event );
+
+    bool skipUserEvents();
     
     TreeViewItem *itemToTVI(wxTreeItemId item);
     

--- a/src/ui/UITestCanvas.cpp
+++ b/src/ui/UITestCanvas.cpp
@@ -27,10 +27,10 @@ EVT_LEAVE_WINDOW(UITestCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(UITestCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-UITestCanvas::UITestCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+UITestCanvas::UITestCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
 InteractiveCanvas(parent, dispAttrs) {
     
-    glContext = new UITestContext(this, &wxGetApp().GetContext(this));
+    glContext = new UITestContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
 }
 
 UITestCanvas::~UITestCanvas() {

--- a/src/ui/UITestCanvas.h
+++ b/src/ui/UITestCanvas.h
@@ -17,7 +17,7 @@
 
 class UITestCanvas: public InteractiveCanvas {
 public:
-    UITestCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    UITestCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~UITestCanvas();
     
 private:

--- a/src/ui/UITestContext.cpp
+++ b/src/ui/UITestContext.cpp
@@ -5,8 +5,8 @@
 #include "UITestCanvas.h"
 #include "ColorTheme.h"
 
-UITestContext::UITestContext(UITestCanvas *canvas, wxGLContext *sharedContext) :
-PrimaryGLContext(canvas, sharedContext), testMeter("TEST",0,100,50) {
+UITestContext::UITestContext(UITestCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs) :
+PrimaryGLContext(canvas, sharedContext, ctxAttrs), testMeter("TEST",0,100,50) {
     
     testPanel.setPosition(0.0, 0.0);
     testPanel.setSize(1.0, 1.0);

--- a/src/ui/UITestContext.h
+++ b/src/ui/UITestContext.h
@@ -11,7 +11,7 @@ class UITestCanvas;
 
 class UITestContext: public PrimaryGLContext {
 public:
-    UITestContext(UITestCanvas *canvas, wxGLContext *sharedContext);
+    UITestContext(UITestCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs);
     
     void DrawBegin();
     void Draw();

--- a/src/util/GLExt.cpp
+++ b/src/util/GLExt.cpp
@@ -46,7 +46,8 @@ void initGLExtensions() {
 
 #ifdef _WIN32
     if (GLExtSupported("WGL_EXT_swap_control")) {
-        std::cout << "Initializing WGL swap control extensions.." << std::endl;
+        std::cout << "Initializing WGL swap control extensions.." << std::endl << std::flush;
+
         wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC) wglGetProcAddress("wglSwapIntervalEXT");
         wglGetSwapIntervalEXT = (PFNWGLGETSWAPINTERVALEXTPROC) wglGetProcAddress("wglGetSwapIntervalEXT");
 

--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -29,10 +29,10 @@ EVT_ENTER_WINDOW(GainCanvas::OnMouseEnterWindow)
 EVT_MOUSEWHEEL(GainCanvas::OnMouseWheelMoved)
 wxEND_EVENT_TABLE()
 
-GainCanvas::GainCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+GainCanvas::GainCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
         InteractiveCanvas(parent, dispAttrs) {
 
-    glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this));
+    glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
     bgPanel.setCoordinateSystem(GLPanel::GLPANEL_Y_UP);
     bgPanel.setFill(GLPanel::GLPANEL_FILL_GRAD_X);
 

--- a/src/visual/GainCanvas.h
+++ b/src/visual/GainCanvas.h
@@ -21,7 +21,7 @@
 
 class GainCanvas: public InteractiveCanvas {
 public:
-    GainCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    GainCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~GainCanvas();
 
     void setHelpTip(std::string tip);

--- a/src/visual/InteractiveCanvas.cpp
+++ b/src/visual/InteractiveCanvas.cpp
@@ -20,9 +20,9 @@
 
 #include <wx/numformatter.h>
 
-InteractiveCanvas::InteractiveCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
-        wxGLCanvas(parent, wxID_ANY, dispAttrs.data(), wxDefaultPosition, wxDefaultSize,
-        wxFULL_REPAINT_ON_RESIZE), parent(parent), shiftDown(false), altDown(false), ctrlDown(false), centerFreq(0), bandwidth(0), lastBandwidth(0), isView(
+InteractiveCanvas::InteractiveCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
+        wxGLCanvas(parent, dispAttrs, wxID_ANY,  wxDefaultPosition, wxDefaultSize, wxFULL_REPAINT_ON_RESIZE), 
+        parent(parent), shiftDown(false), altDown(false), ctrlDown(false), centerFreq(0), bandwidth(0), lastBandwidth(0), isView(
         false) {
     mouseTracker.setTarget(this);
 }

--- a/src/visual/InteractiveCanvas.h
+++ b/src/visual/InteractiveCanvas.h
@@ -12,7 +12,7 @@
 
 class InteractiveCanvas: public wxGLCanvas {
 public:
-    InteractiveCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    InteractiveCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     virtual ~InteractiveCanvas();
 
     long long getFrequencyAt(float x);

--- a/src/visual/MeterCanvas.cpp
+++ b/src/visual/MeterCanvas.cpp
@@ -30,10 +30,10 @@ EVT_LEAVE_WINDOW(MeterCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(MeterCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-MeterCanvas::MeterCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+MeterCanvas::MeterCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), level(0), level_min(0), level_max(1), inputValue(0), userInputValue(0), showUserInput(true) {
 
-    glContext = new MeterContext(this, &wxGetApp().GetContext(this));
+    glContext = new MeterContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
 }
 
 MeterCanvas::~MeterCanvas() {

--- a/src/visual/MeterCanvas.h
+++ b/src/visual/MeterCanvas.h
@@ -17,7 +17,7 @@
 
 class MeterCanvas: public InteractiveCanvas {
 public:
-    MeterCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    MeterCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~MeterCanvas();
 
     void setLevel(float level_in);

--- a/src/visual/MeterContext.cpp
+++ b/src/visual/MeterContext.cpp
@@ -5,8 +5,8 @@
 #include "MeterCanvas.h"
 #include "ColorTheme.h"
 
-MeterContext::MeterContext(MeterCanvas *canvas, wxGLContext *sharedContext) :
-        PrimaryGLContext(canvas, sharedContext) {
+MeterContext::MeterContext(MeterCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs) :
+        PrimaryGLContext(canvas, sharedContext, ctxAttrs) {
 }
 
 void MeterContext::DrawBegin() {

--- a/src/visual/MeterContext.h
+++ b/src/visual/MeterContext.h
@@ -12,7 +12,7 @@ class MeterCanvas;
 
 class MeterContext: public PrimaryGLContext {
 public:
-    MeterContext(MeterCanvas *canvas, wxGLContext *sharedContext);
+    MeterContext(MeterCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs);
 
     void DrawBegin();
     void Draw(float r, float g, float b, float a, float level);

--- a/src/visual/ModeSelectorCanvas.cpp
+++ b/src/visual/ModeSelectorCanvas.cpp
@@ -27,10 +27,10 @@ EVT_LEAVE_WINDOW(ModeSelectorCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(ModeSelectorCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-ModeSelectorCanvas::ModeSelectorCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+ModeSelectorCanvas::ModeSelectorCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
 InteractiveCanvas(parent, dispAttrs), numChoices(0), currentSelection(-1), toggleMode(false), inputChanged(false), padX(4.0), padY(4.0), highlightOverride(false) {
 
-    glContext = new ModeSelectorContext(this, &wxGetApp().GetContext(this));
+    glContext = new ModeSelectorContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
     
     highlightColor = RGBA4f(1.0,1.0,1.0,1.0);
 }

--- a/src/visual/ModeSelectorCanvas.h
+++ b/src/visual/ModeSelectorCanvas.h
@@ -27,7 +27,7 @@ public:
 
 class ModeSelectorCanvas: public InteractiveCanvas {
 public:
-    ModeSelectorCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    ModeSelectorCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~ModeSelectorCanvas();
 
     int getHoveredSelection();

--- a/src/visual/ModeSelectorContext.cpp
+++ b/src/visual/ModeSelectorContext.cpp
@@ -6,8 +6,8 @@
 #include "ColorTheme.h"
 
 
-ModeSelectorContext::ModeSelectorContext(ModeSelectorCanvas *canvas, wxGLContext *sharedContext) :
-        PrimaryGLContext(canvas, sharedContext) {
+ModeSelectorContext::ModeSelectorContext(ModeSelectorCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs) :
+        PrimaryGLContext(canvas, sharedContext, ctxAttrs) {
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);
 

--- a/src/visual/ModeSelectorContext.h
+++ b/src/visual/ModeSelectorContext.h
@@ -12,7 +12,7 @@ class ModeSelectorCanvas;
 
 class ModeSelectorContext: public PrimaryGLContext {
 public:
-    ModeSelectorContext(ModeSelectorCanvas *canvas, wxGLContext *sharedContext);
+    ModeSelectorContext(ModeSelectorCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs);
 
     void DrawBegin();
     void DrawSelector(std::string label, int c, int cMax, bool on, float r, float g, float b, float a, float padx, float pady);

--- a/src/visual/PrimaryGLContext.cpp
+++ b/src/visual/PrimaryGLContext.cpp
@@ -50,8 +50,11 @@ void PrimaryGLContext::CheckGLError() {
     }
 }
 
-PrimaryGLContext::PrimaryGLContext(wxGLCanvas *canvas, wxGLContext *sharedContext) :
-        wxGLContext(canvas, sharedContext), hoverAlpha(1.0) {
+PrimaryGLContext::PrimaryGLContext(wxGLCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs* ctxAttrs) :
+        wxGLContext(canvas, sharedContext, (const wxGLContextAttrs*) ctxAttrs), hoverAlpha(1.0) {
+
+
+
 //#ifndef __linux__
 //    SetCurrent(*canvas);
 //    // Pre-load fonts

--- a/src/visual/PrimaryGLContext.h
+++ b/src/visual/PrimaryGLContext.h
@@ -16,7 +16,7 @@
 
 class PrimaryGLContext: public wxGLContext {
 public:
-    PrimaryGLContext(wxGLCanvas *canvas, wxGLContext *sharedContext);
+    PrimaryGLContext(wxGLCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs* ctxAttrs);
 
     static wxString glGetwxString(GLenum name);
     static void CheckGLError();

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -31,9 +31,9 @@ EVT_LEAVE_WINDOW(ScopeCanvas::OnMouseLeftWindow)
 EVT_ENTER_WINDOW(ScopeCanvas::OnMouseEnterWindow)
 wxEND_EVENT_TABLE()
 
-ScopeCanvas::ScopeCanvas(wxWindow *parent, std::vector<int> dispAttrs) : InteractiveCanvas(parent, dispAttrs), ppmMode(false), ctr(0), ctrTarget(0), dragAccel(0), helpTip("") {
+ScopeCanvas::ScopeCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) : InteractiveCanvas(parent, dispAttrs), ppmMode(false), ctr(0), ctrTarget(0), dragAccel(0), helpTip("") {
 
-    glContext = new ScopeContext(this, &wxGetApp().GetContext(this));
+    glContext = new ScopeContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
     inputData->set_max_num_items(2);
     bgPanel.setFill(GLPanel::GLPANEL_FILL_GRAD_Y);
     bgPanel.setSize(1.0, 0.5f);

--- a/src/visual/ScopeCanvas.h
+++ b/src/visual/ScopeCanvas.h
@@ -18,7 +18,7 @@
 
 class ScopeCanvas: public InteractiveCanvas {
 public:
-    ScopeCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    ScopeCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~ScopeCanvas();
 
     //This is public because it is indeed forwarded from

--- a/src/visual/ScopeContext.cpp
+++ b/src/visual/ScopeContext.cpp
@@ -6,8 +6,8 @@
 #include "ScopeCanvas.h"
 #include "ColorTheme.h"
 
-ScopeContext::ScopeContext(ScopeCanvas *canvas, wxGLContext *sharedContext) :
-        PrimaryGLContext(canvas, sharedContext) {
+ScopeContext::ScopeContext(ScopeCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs) :
+        PrimaryGLContext(canvas, sharedContext, ctxAttrs) {
     glDisable (GL_CULL_FACE);
     glDisable (GL_DEPTH_TEST);
 

--- a/src/visual/ScopeContext.h
+++ b/src/visual/ScopeContext.h
@@ -12,7 +12,7 @@ class ScopeCanvas;
 
 class ScopeContext: public PrimaryGLContext {
 public:
-    ScopeContext(ScopeCanvas *canvas, wxGLContext *sharedContext);
+    ScopeContext(ScopeCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs);
 
     void DrawBegin(bool clear=true);
     void DrawTunerTitles(bool ppmMode=false);

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -32,10 +32,10 @@ EVT_RIGHT_DOWN(SpectrumCanvas::OnMouseRightDown)
 EVT_RIGHT_UP(SpectrumCanvas::OnMouseRightReleased)
 wxEND_EVENT_TABLE()
 
-SpectrumCanvas::SpectrumCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+SpectrumCanvas::SpectrumCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), waterfallCanvas(NULL) {
 
-    glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this));
+    glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
 
     visualDataQueue->set_max_num_items(1);
             

--- a/src/visual/SpectrumCanvas.h
+++ b/src/visual/SpectrumCanvas.h
@@ -17,7 +17,7 @@ class WaterfallCanvas;
 
 class SpectrumCanvas: public InteractiveCanvas {
 public:
-    SpectrumCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    SpectrumCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~SpectrumCanvas();
 
     //This is public because it is indeed forwarded from

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -33,10 +33,10 @@ EVT_MOUSEWHEEL(TuningCanvas::OnMouseWheelMoved)
 //EVT_KEY_UP(TuningCanvas::OnKeyUp)
 wxEND_EVENT_TABLE()
 
-TuningCanvas::TuningCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+TuningCanvas::TuningCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), dragAccum(0), uxDown(0), top(false), bottom(false), freq(-1), bw(-1), center(-1), halfBand(false) {
 
-    glContext = new TuningContext(this, &wxGetApp().GetContext(this));
+    glContext = new TuningContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
 
     hoverIndex = 0;
     downIndex = 0;
@@ -272,7 +272,6 @@ void TuningCanvas::OnIdle(wxIdleEvent &event) {
     if (mouseTracker.mouseInView() || changed()) {
         Refresh();
     }
-    event.RequestMore();
 }
 
 void TuningCanvas::OnMouseMoved(wxMouseEvent& event) {

--- a/src/visual/TuningCanvas.h
+++ b/src/visual/TuningCanvas.h
@@ -20,7 +20,7 @@ public:
     enum ActiveState {
         TUNING_HOVER_NONE, TUNING_HOVER_FREQ, TUNING_HOVER_BW, TUNING_HOVER_PPM, TUNING_HOVER_CENTER
     };
-    TuningCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    TuningCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     ~TuningCanvas();
 
     void setHelpTip(std::string tip);

--- a/src/visual/TuningContext.cpp
+++ b/src/visual/TuningContext.cpp
@@ -18,8 +18,8 @@ protected:
     }
 };
 
-TuningContext::TuningContext(TuningCanvas *canvas, wxGLContext *sharedContext) :
-        PrimaryGLContext(canvas, sharedContext) {
+TuningContext::TuningContext(TuningCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs) :
+        PrimaryGLContext(canvas, sharedContext, ctxAttrs) {
     glDisable(GL_CULL_FACE);
     glDisable(GL_DEPTH_TEST);
 

--- a/src/visual/TuningContext.h
+++ b/src/visual/TuningContext.h
@@ -12,7 +12,7 @@ class TuningCanvas;
 
 class TuningContext: public PrimaryGLContext {
 public:
-    TuningContext(TuningCanvas *canvas, wxGLContext *sharedContext);
+    TuningContext(TuningCanvas *canvas, wxGLContext *sharedContext, wxGLContextAttrs *ctxAttrs);
 
     void DrawBegin();
     void Draw(float r, float g, float b, float a, float p1, float p2);

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -39,11 +39,11 @@ EVT_ENTER_WINDOW(WaterfallCanvas::OnMouseEnterWindow)
 EVT_MOUSEWHEEL(WaterfallCanvas::OnMouseWheelMoved)
 wxEND_EVENT_TABLE()
 
-WaterfallCanvas::WaterfallCanvas(wxWindow *parent, std::vector<int> dispAttrs) :
+WaterfallCanvas::WaterfallCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs) :
         InteractiveCanvas(parent, dispAttrs), dragState(WF_DRAG_NONE), nextDragState(WF_DRAG_NONE), fft_size(0), new_fft_size(0), waterfall_lines(0),
         dragOfs(0), mouseZoom(1), zoom(1), freqMoving(false), freqMove(0.0), hoverAlpha(1.0) {
 
-    glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this));
+    glContext = new PrimaryGLContext(this, &wxGetApp().GetContext(this), wxGetApp().GetContextAttributes());
     linesPerSecond = DEFAULT_WATERFALL_LPS;
     lpsIndex = 0;
     preBuf = false;
@@ -486,7 +486,6 @@ void WaterfallCanvas::OnKeyDown(wxKeyEvent& event) {
 void WaterfallCanvas::OnIdle(wxIdleEvent &event) {
     processInputQueue();
     Refresh();
-    event.RequestMore();
 }
 
 void WaterfallCanvas::updateHoverState() {

--- a/src/visual/WaterfallCanvas.h
+++ b/src/visual/WaterfallCanvas.h
@@ -21,7 +21,7 @@ public:
         WF_DRAG_NONE, WF_DRAG_BANDWIDTH_LEFT, WF_DRAG_BANDWIDTH_RIGHT, WF_DRAG_FREQUENCY, WF_DRAG_RANGE
     };
 
-    WaterfallCanvas(wxWindow *parent, std::vector<int> dispAttrs);
+    WaterfallCanvas(wxWindow *parent, const wxGLAttributes& dispAttrs);
     void setup(unsigned int fft_size_in, int waterfall_lines_in);
     void setFFTSize(unsigned int fft_size_in);
     ~WaterfallCanvas();


### PR DESCRIPTION
List of changes:
- Seen on Windows: BookmarkView slow update because the controls are self-reacting to the rebuild control events, so fix nullify them during control rebuilding.
- Update OpenGL initialization using v3.1 level context and canvas attributes instead of the deprecated calls.

The changes are compatible with wxWidgets 3.10 so far as my testing goes in Windows 10 x64.

