### PR TITLE
Safer calls to setGainMode

### DIFF
--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -130,8 +130,10 @@ bool SDRThread::init() {
     } else {
         hasHardwareDC.store(false);
     }
-    
-    device->setGainMode(SOAPY_SDR_RX,0,agc_mode.load());
+
+	if (device->hasGainMode(SOAPY_SDR_RX, 0)) {
+		device->setGainMode(SOAPY_SDR_RX, 0, agc_mode.load());
+	}
     
     numChannels.store(getOptimalChannelCount(sampleRate.load()));
     numElems.store(getOptimalElementCount(sampleRate.load(), TARGET_DISPLAY_FPS));
@@ -484,7 +486,9 @@ void SDRThread::updateSettings() {
 //    }
     
     if (agc_mode_changed.load()) {
-        device->setGainMode(SOAPY_SDR_RX, 0, agc_mode.load());
+		if (device->hasGainMode(SOAPY_SDR_RX, 0)) {
+        	device->setGainMode(SOAPY_SDR_RX, 0, agc_mode.load());
+		}
         agc_mode_changed.store(false);
         if (!agc_mode.load()) {
             updateGains();


### PR DESCRIPTION
Will call hasGainMode first - this will prevent crashes when the underlying
device situationally doesn't support setGainMode calls.

This issue rears its head with the BladeRF - because AGC is only provided when a LUT is generated, it's really quite variable whether or not setGainMode will work, or will error out. As such, it would be best to avoid calling it without a call to hasGainMode to make sure it's supported.

Note that this requires a trustworthy result from hasGainMode; which is currently not the case for SoapyBladeRF. Things still crash because hasGainMode always returns true (for the RX channel), even when it actually doesn't. But that's a separate issue.