### PR TITLE
More Spin locks experiments

### DIFF
--- a/src/util/SpinMutex.h
+++ b/src/util/SpinMutex.h
@@ -4,7 +4,7 @@
 #pragma once 
 #include <atomic>
 
-// A non-recursive Mutex implemented as a spin-lock.
+// A non-recursive Mutex implemented as a spin-lock, implementing the Lockable requirement
 class SpinMutex {
 
 public:
@@ -17,6 +17,8 @@ public:
     ~SpinMutex() { lock_state.clear(std::memory_order_release); }
 
     void lock() { while (lock_state.test_and_set(std::memory_order_acquire)); }
+
+    bool try_lock() {return !lock_state.test_and_set(std::memory_order_acquire); }
 
     void unlock() { lock_state.clear(std::memory_order_release); }
 

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -88,7 +88,7 @@ void WaterfallCanvas::attachSpectrumCanvas(SpectrumCanvas *canvas_in) {
 }
 
 void WaterfallCanvas::processInputQueue() {
-    std::lock_guard < SpinMutex > lock(tex_update);
+    std::lock_guard < std::mutex > lock(tex_update);
     
     gTimer.update();
     
@@ -127,7 +127,7 @@ void WaterfallCanvas::processInputQueue() {
 }
 
 void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
-    std::lock_guard < SpinMutex > lock(tex_update);
+    std::lock_guard < std::mutex > lock(tex_update);
     wxPaintDC dc(this);
     
     const wxSize ClientSize = GetClientSize();
@@ -913,7 +913,7 @@ void WaterfallCanvas::updateCenterFrequency(long long freq) {
 }
 
 void WaterfallCanvas::setLinesPerSecond(int lps) {
-    std::lock_guard < SpinMutex > lock(tex_update);
+    std::lock_guard < std::mutex > lock(tex_update);
     
     linesPerSecond = lps;
 

--- a/src/visual/WaterfallCanvas.h
+++ b/src/visual/WaterfallCanvas.h
@@ -14,7 +14,6 @@
 #include "SpectrumCanvas.h"
 #include "WaterfallPanel.h"
 #include "Timer.h"
-#include "SpinMutex.h"
 
 class WaterfallCanvas: public InteractiveCanvas {
 public:
@@ -94,7 +93,7 @@ private:
     Timer gTimer;
     double lpsIndex;
     bool preBuf;
-    SpinMutex tex_update;
+    std::mutex tex_update;
     int minBandwidth;
     std::atomic_bool fft_size_changed;
     // event table


### PR DESCRIPTION
Contrary to what I said in #713, `ThreadBlockingQueue` can support `SpinMutex` through the usage of `std::condition_variable_any`. Turns out the "sleep or wake" semantic is done through the condition variable
not the lock itself.
Lets try this. 
Also reverted spin-lock usage in `WaterfallCanvas`, the operation is not that short-lived, so a proper `std::mutex` is more fitted there.