### PR TITLE
Make stream deactivated before a sample-rate change and reactivated afterwards

### DIFF
--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -106,9 +106,9 @@ protected:
     void updateSettings();
     SoapySDR::Kwargs combineArgs(SoapySDR::Kwargs a, SoapySDR::Kwargs b);
 
-    SoapySDR::Stream *stream;
+    SoapySDR::Stream *stream = nullptr;
     SoapySDR::Device *device;
-    void *buffs[1];
+    void *buffs[1] = { nullptr };
     ReBuffer<SDRThreadIQData> buffers;
     SDRThreadIQData overflowBuffer;
     int numOverflow;


### PR DESCRIPTION
Origin : #716 where LimeSDR do not like `setSampleRate` while streaming. This PR changes CubicSDR behaviour to shut-up stream with `deactivateStream` before doing the sample rate change, then only `activateStream` again at the end.

I've tested this on RTL-SDR, SDRPlay RSP2, Adalm-PlutoSDR on Windows10 1809 x64. With these, changing sample rates works nor better not worse that before.

I've also tried these devices through a (localhost) SoapyRemote connection, everything is fine.

For these devices at least, the change if not visibly longer on CubicSDR.