### PR TITLE
Bookmark refreshing, port selection and device selector UI fixes

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -501,8 +501,9 @@ wxMenu *AppFrame::makeRigMenu() {
     rigFollowModemMenuItem = pMenu->AppendCheckItem(wxID_RIG_FOLLOW_MODEM, wxT("Track Modem"));
     rigFollowModemMenuItem->Check(wxGetApp().getConfig()->getRigFollowModem());
 
-    auto *rigModelMenu = new wxMenu;
+    rigModelMenu = new wxMenu;
     RigList &rl = RigThread::enumerate();
+    numRigs = rl.size();
 
     std::map<string, int> mfgCount;
     std::map<string, wxMenu *> mfgMenu;
@@ -1863,7 +1864,9 @@ bool AppFrame::actionOnMenuRig(wxCommandEvent &event) {
         bManaged = true;
 
         for (auto ri : rigModelMenuItems) {
-            ri.second->Check(false);
+            if (ri.second->IsChecked()) {
+                ri.second->Check(false);
+            }
         }
 
         rigModelMenuItems[rigModel]->Check(true);

--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -296,6 +296,7 @@ private:
 
     std::map<int, wxMenuItem *> rigSerialMenuItems;
     std::map<int, wxMenuItem *> rigModelMenuItems;
+    wxMenu *rigModelMenu;
     int rigModel;
     int rigSerialRate;
     long long rigSDRIF;

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -589,7 +589,12 @@ void CubicSDR::deviceSelector() {
         return;
     }
     deviceSelectorOpen.store(true);
-    deviceSelectorDialog = new SDRDevicesDialog(appframe);
+    wxRect *winRect = getConfig()->getWindow();
+    wxPoint pos(wxDefaultPosition);
+    if (winRect != nullptr) {
+        pos = wxPoint(winRect->x, winRect->y);
+    }
+    deviceSelectorDialog = new SDRDevicesDialog(appframe, pos);
     deviceSelectorDialog->Show();
 }
 

--- a/src/forms/Bookmark/BookmarkPanel.cpp
+++ b/src/forms/Bookmark/BookmarkPanel.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug  8 2018)
+// C++ code generated with wxFormBuilder (version Oct 26 2018)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -13,75 +13,78 @@ BookmarkPanel::BookmarkPanel( wxWindow* parent, wxWindowID id, const wxPoint& po
 {
 	wxBoxSizer* bSizer1;
 	bSizer1 = new wxBoxSizer( wxVERTICAL );
-	
+
 	m_searchText = new wxTextCtrl( this, wxID_ANY, wxT("Search.."), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
 	bSizer1->Add( m_searchText, 0, wxALL|wxEXPAND, 5 );
-	
+
 	m_clearSearchButton = new wxButton( this, wxID_ANY, wxT("Clear Search"), wxDefaultPosition, wxDefaultSize, 0 );
-	bSizer1->Add( m_clearSearchButton, 0, wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT, 5 );
-	
+	bSizer1->Add( m_clearSearchButton, 0, wxALL|wxEXPAND, 5 );
+
 	m_treeView = new wxTreeCtrl( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE|wxTR_HAS_VARIABLE_ROW_HEIGHT|wxTR_HIDE_ROOT|wxTR_SINGLE );
 	bSizer1->Add( m_treeView, 1, wxEXPAND, 5 );
-	
+
+	m_propPanelDivider = new wxStaticLine( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
+	bSizer1->Add( m_propPanelDivider, 0, wxEXPAND, 5 );
+
 	m_propPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 	wxFlexGridSizer* fgPropSizer;
 	fgPropSizer = new wxFlexGridSizer( 0, 2, 0, 0 );
 	fgPropSizer->AddGrowableCol( 1 );
 	fgPropSizer->SetFlexibleDirection( wxBOTH );
 	fgPropSizer->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
+
 	m_labelLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("Label"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_labelLabel->Wrap( -1 );
-	fgPropSizer->Add( m_labelLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
+	fgPropSizer->Add( m_labelLabel, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+
 	m_labelText = new wxTextCtrl( m_propPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
 	fgPropSizer->Add( m_labelText, 0, wxALL|wxEXPAND, 5 );
-	
+
 	m_frequencyLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("Freq"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_frequencyLabel->Wrap( -1 );
-	fgPropSizer->Add( m_frequencyLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
+	fgPropSizer->Add( m_frequencyLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxALL, 5 );
+
 	m_frequencyVal = new wxStaticText( m_propPanel, wxID_ANY, wxT("FrequencyVal"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_frequencyVal->Wrap( -1 );
-	fgPropSizer->Add( m_frequencyVal, 0, wxALL, 5 );
-	
+	fgPropSizer->Add( m_frequencyVal, 0, wxALL|wxEXPAND, 5 );
+
 	m_bandwidthLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("BW"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_bandwidthLabel->Wrap( -1 );
-	fgPropSizer->Add( m_bandwidthLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
+	fgPropSizer->Add( m_bandwidthLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxLEFT|wxRIGHT, 5 );
+
 	m_bandwidthVal = new wxStaticText( m_propPanel, wxID_ANY, wxT("BandwidthVal"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_bandwidthVal->Wrap( -1 );
-	fgPropSizer->Add( m_bandwidthVal, 0, wxALL, 5 );
-	
+	fgPropSizer->Add( m_bandwidthVal, 0, wxEXPAND|wxLEFT|wxRIGHT, 5 );
+
 	m_modulationLabel = new wxStaticText( m_propPanel, wxID_ANY, wxT("Type"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_modulationLabel->Wrap( -1 );
-	fgPropSizer->Add( m_modulationLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT, 5 );
-	
+	fgPropSizer->Add( m_modulationLabel, 0, wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxALL, 5 );
+
 	m_modulationVal = new wxStaticText( m_propPanel, wxID_ANY, wxT("TypeVal"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_modulationVal->Wrap( -1 );
-	fgPropSizer->Add( m_modulationVal, 0, wxALL, 5 );
-	
-	
+	fgPropSizer->Add( m_modulationVal, 0, wxALL|wxEXPAND, 5 );
+
+
 	m_propPanel->SetSizer( fgPropSizer );
 	m_propPanel->Layout();
 	fgPropSizer->Fit( m_propPanel );
-	bSizer1->Add( m_propPanel, 0, wxALL|wxBOTTOM|wxEXPAND|wxTOP, 5 );
-	
+	bSizer1->Add( m_propPanel, 0, wxALL|wxEXPAND, 5 );
+
 	m_buttonPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 	wxBoxSizer* m_buttonPanelSizer;
 	m_buttonPanelSizer = new wxBoxSizer( wxVERTICAL );
-	
-	
+
+
 	m_buttonPanel->SetSizer( m_buttonPanelSizer );
 	m_buttonPanel->Layout();
 	m_buttonPanelSizer->Fit( m_buttonPanel );
 	bSizer1->Add( m_buttonPanel, 0, wxALL|wxEXPAND, 5 );
-	
-	
+
+
 	this->SetSizer( bSizer1 );
 	this->Layout();
 	m_updateTimer.SetOwner( this, wxID_ANY );
-	
+
 	// Connect Events
 	this->Connect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( BookmarkPanel::onEnterWindow ) );
 	this->Connect( wxEVT_LEAVE_WINDOW, wxMouseEventHandler( BookmarkPanel::onLeaveWindow ) );
@@ -132,5 +135,5 @@ BookmarkPanel::~BookmarkPanel()
 	m_frequencyVal->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( BookmarkPanel::onDoubleClickFreq ), NULL, this );
 	m_bandwidthVal->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( BookmarkPanel::onDoubleClickBandwidth ), NULL, this );
 	this->Disconnect( wxID_ANY, wxEVT_TIMER, wxTimerEventHandler( BookmarkPanel::onUpdateTimer ) );
-	
+
 }

--- a/src/forms/Bookmark/BookmarkPanel.fbp
+++ b/src/forms/Bookmark/BookmarkPanel.fbp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <wxFormBuilder_Project>
-    <FileVersion major="1" minor="14" />
+    <FileVersion major="1" minor="15" />
     <object class="Project" expanded="1">
         <property name="class_decoration"></property>
         <property name="code_generation">C++</property>
@@ -49,43 +49,9 @@
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
-            <event name="OnAuiPaneActivated"></event>
-            <event name="OnAuiPaneButton"></event>
-            <event name="OnAuiPaneClose"></event>
-            <event name="OnAuiPaneMaximize"></event>
-            <event name="OnAuiPaneRestore"></event>
-            <event name="OnAuiRender"></event>
-            <event name="OnAux1DClick"></event>
-            <event name="OnAux1Down"></event>
-            <event name="OnAux1Up"></event>
-            <event name="OnAux2DClick"></event>
-            <event name="OnAux2Down"></event>
-            <event name="OnAux2Up"></event>
-            <event name="OnChar"></event>
-            <event name="OnCharHook"></event>
             <event name="OnEnterWindow">onEnterWindow</event>
-            <event name="OnEraseBackground"></event>
-            <event name="OnInitDialog"></event>
-            <event name="OnKeyDown"></event>
-            <event name="OnKeyUp"></event>
-            <event name="OnKillFocus"></event>
             <event name="OnLeaveWindow">onLeaveWindow</event>
-            <event name="OnLeftDClick"></event>
-            <event name="OnLeftDown"></event>
-            <event name="OnLeftUp"></event>
-            <event name="OnMiddleDClick"></event>
-            <event name="OnMiddleDown"></event>
-            <event name="OnMiddleUp"></event>
             <event name="OnMotion">onMotion</event>
-            <event name="OnMouseEvents"></event>
-            <event name="OnMouseWheel"></event>
-            <event name="OnPaint"></event>
-            <event name="OnRightDClick"></event>
-            <event name="OnRightDown"></event>
-            <event name="OnRightUp"></event>
-            <event name="OnSetFocus"></event>
-            <event name="OnSize"></event>
-            <event name="OnUpdateUI"></event>
             <object class="wxBoxSizer" expanded="1">
                 <property name="minimum_size"></property>
                 <property name="name">bSizer1</property>
@@ -153,45 +119,13 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style"></property>
-                        <event name="OnAux1DClick"></event>
-                        <event name="OnAux1Down"></event>
-                        <event name="OnAux1Up"></event>
-                        <event name="OnAux2DClick"></event>
-                        <event name="OnAux2Down"></event>
-                        <event name="OnAux2Up"></event>
-                        <event name="OnChar"></event>
-                        <event name="OnCharHook"></event>
-                        <event name="OnEnterWindow"></event>
-                        <event name="OnEraseBackground"></event>
-                        <event name="OnKeyDown"></event>
-                        <event name="OnKeyUp"></event>
-                        <event name="OnKillFocus"></event>
-                        <event name="OnLeaveWindow"></event>
-                        <event name="OnLeftDClick"></event>
                         <event name="OnLeftDown">onSearchTextFocus</event>
-                        <event name="OnLeftUp"></event>
-                        <event name="OnMiddleDClick"></event>
-                        <event name="OnMiddleDown"></event>
-                        <event name="OnMiddleUp"></event>
-                        <event name="OnMotion"></event>
-                        <event name="OnMouseEvents"></event>
-                        <event name="OnMouseWheel"></event>
-                        <event name="OnPaint"></event>
-                        <event name="OnRightDClick"></event>
-                        <event name="OnRightDown"></event>
-                        <event name="OnRightUp"></event>
-                        <event name="OnSetFocus"></event>
-                        <event name="OnSize"></event>
                         <event name="OnText">onSearchText</event>
-                        <event name="OnTextEnter"></event>
-                        <event name="OnTextMaxLen"></event>
-                        <event name="OnTextURL"></event>
-                        <event name="OnUpdateUI"></event>
                     </object>
                 </object>
                 <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
-                    <property name="flag">wxBOTTOM|wxEXPAND|wxLEFT|wxRIGHT</property>
+                    <property name="flag">wxALL|wxEXPAND</property>
                     <property name="proportion">0</property>
                     <object class="wxButton" expanded="1">
                         <property name="BottomDockable">1</property>
@@ -259,37 +193,7 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style"></property>
-                        <event name="OnAux1DClick"></event>
-                        <event name="OnAux1Down"></event>
-                        <event name="OnAux1Up"></event>
-                        <event name="OnAux2DClick"></event>
-                        <event name="OnAux2Down"></event>
-                        <event name="OnAux2Up"></event>
                         <event name="OnButtonClick">onClearSearch</event>
-                        <event name="OnChar"></event>
-                        <event name="OnCharHook"></event>
-                        <event name="OnEnterWindow"></event>
-                        <event name="OnEraseBackground"></event>
-                        <event name="OnKeyDown"></event>
-                        <event name="OnKeyUp"></event>
-                        <event name="OnKillFocus"></event>
-                        <event name="OnLeaveWindow"></event>
-                        <event name="OnLeftDClick"></event>
-                        <event name="OnLeftDown"></event>
-                        <event name="OnLeftUp"></event>
-                        <event name="OnMiddleDClick"></event>
-                        <event name="OnMiddleDown"></event>
-                        <event name="OnMiddleUp"></event>
-                        <event name="OnMotion"></event>
-                        <event name="OnMouseEvents"></event>
-                        <event name="OnMouseWheel"></event>
-                        <event name="OnPaint"></event>
-                        <event name="OnRightDClick"></event>
-                        <event name="OnRightDown"></event>
-                        <event name="OnRightUp"></event>
-                        <event name="OnSetFocus"></event>
-                        <event name="OnSize"></event>
-                        <event name="OnUpdateUI"></event>
                     </object>
                 </object>
                 <object class="sizeritem" expanded="1">
@@ -348,62 +252,81 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style"></property>
-                        <event name="OnAux1DClick"></event>
-                        <event name="OnAux1Down"></event>
-                        <event name="OnAux1Up"></event>
-                        <event name="OnAux2DClick"></event>
-                        <event name="OnAux2Down"></event>
-                        <event name="OnAux2Up"></event>
-                        <event name="OnChar"></event>
-                        <event name="OnCharHook"></event>
                         <event name="OnEnterWindow">onEnterWindow</event>
-                        <event name="OnEraseBackground"></event>
-                        <event name="OnKeyDown"></event>
-                        <event name="OnKeyUp"></event>
-                        <event name="OnKillFocus"></event>
                         <event name="OnLeaveWindow">onLeaveWindow</event>
-                        <event name="OnLeftDClick"></event>
-                        <event name="OnLeftDown"></event>
-                        <event name="OnLeftUp"></event>
-                        <event name="OnMiddleDClick"></event>
-                        <event name="OnMiddleDown"></event>
-                        <event name="OnMiddleUp"></event>
                         <event name="OnMotion">onMotion</event>
-                        <event name="OnMouseEvents"></event>
-                        <event name="OnMouseWheel"></event>
-                        <event name="OnPaint"></event>
-                        <event name="OnRightDClick"></event>
-                        <event name="OnRightDown"></event>
-                        <event name="OnRightUp"></event>
-                        <event name="OnSetFocus"></event>
-                        <event name="OnSize"></event>
                         <event name="OnTreeBeginDrag">onTreeBeginDrag</event>
-                        <event name="OnTreeBeginLabelEdit"></event>
-                        <event name="OnTreeBeginRDrag"></event>
-                        <event name="OnTreeDeleteItem"></event>
                         <event name="OnTreeEndDrag">onTreeEndDrag</event>
-                        <event name="OnTreeEndLabelEdit"></event>
-                        <event name="OnTreeGetInfo"></event>
                         <event name="OnTreeItemActivated">onTreeActivate</event>
                         <event name="OnTreeItemCollapsed">onTreeCollapse</event>
-                        <event name="OnTreeItemCollapsing"></event>
                         <event name="OnTreeItemExpanded">onTreeExpanded</event>
-                        <event name="OnTreeItemExpanding"></event>
                         <event name="OnTreeItemGetTooltip">onTreeItemGetTooltip</event>
                         <event name="OnTreeItemMenu">onTreeItemMenu</event>
-                        <event name="OnTreeItemMiddleClick"></event>
-                        <event name="OnTreeItemRightClick"></event>
-                        <event name="OnTreeKeyDown"></event>
                         <event name="OnTreeSelChanged">onTreeSelect</event>
                         <event name="OnTreeSelChanging">onTreeSelectChanging</event>
-                        <event name="OnTreeSetInfo"></event>
-                        <event name="OnTreeStateImageClick"></event>
-                        <event name="OnUpdateUI"></event>
                     </object>
                 </object>
                 <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
-                    <property name="flag">wxALL|wxBOTTOM|wxEXPAND|wxTOP</property>
+                    <property name="flag">wxEXPAND</property>
+                    <property name="proportion">0</property>
+                    <object class="wxStaticLine" expanded="1">
+                        <property name="BottomDockable">1</property>
+                        <property name="LeftDockable">1</property>
+                        <property name="RightDockable">1</property>
+                        <property name="TopDockable">1</property>
+                        <property name="aui_layer"></property>
+                        <property name="aui_name"></property>
+                        <property name="aui_position"></property>
+                        <property name="aui_row"></property>
+                        <property name="best_size"></property>
+                        <property name="bg"></property>
+                        <property name="caption"></property>
+                        <property name="caption_visible">1</property>
+                        <property name="center_pane">0</property>
+                        <property name="close_button">1</property>
+                        <property name="context_help"></property>
+                        <property name="context_menu">1</property>
+                        <property name="default_pane">0</property>
+                        <property name="dock">Dock</property>
+                        <property name="dock_fixed">0</property>
+                        <property name="docking">Left</property>
+                        <property name="enabled">1</property>
+                        <property name="fg"></property>
+                        <property name="floatable">1</property>
+                        <property name="font"></property>
+                        <property name="gripper">0</property>
+                        <property name="hidden">0</property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="max_size"></property>
+                        <property name="maximize_button">0</property>
+                        <property name="maximum_size"></property>
+                        <property name="min_size"></property>
+                        <property name="minimize_button">0</property>
+                        <property name="minimum_size"></property>
+                        <property name="moveable">1</property>
+                        <property name="name">m_propPanelDivider</property>
+                        <property name="pane_border">1</property>
+                        <property name="pane_position"></property>
+                        <property name="pane_size"></property>
+                        <property name="permission">protected</property>
+                        <property name="pin_button">1</property>
+                        <property name="pos"></property>
+                        <property name="resize">Resizable</property>
+                        <property name="show">1</property>
+                        <property name="size"></property>
+                        <property name="style">wxLI_HORIZONTAL</property>
+                        <property name="subclass">; ; forward_declare</property>
+                        <property name="toolbar_pane">0</property>
+                        <property name="tooltip"></property>
+                        <property name="window_extra_style"></property>
+                        <property name="window_name"></property>
+                        <property name="window_style"></property>
+                    </object>
+                </object>
+                <object class="sizeritem" expanded="1">
+                    <property name="border">5</property>
+                    <property name="flag">wxALL|wxEXPAND</property>
                     <property name="proportion">0</property>
                     <object class="wxPanel" expanded="1">
                         <property name="BottomDockable">1</property>
@@ -456,37 +379,7 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style">wxTAB_TRAVERSAL</property>
-                        <event name="OnAux1DClick"></event>
-                        <event name="OnAux1Down"></event>
-                        <event name="OnAux1Up"></event>
-                        <event name="OnAux2DClick"></event>
-                        <event name="OnAux2Down"></event>
-                        <event name="OnAux2Up"></event>
-                        <event name="OnChar"></event>
-                        <event name="OnCharHook"></event>
-                        <event name="OnEnterWindow"></event>
-                        <event name="OnEraseBackground"></event>
-                        <event name="OnKeyDown"></event>
-                        <event name="OnKeyUp"></event>
-                        <event name="OnKillFocus"></event>
-                        <event name="OnLeaveWindow"></event>
-                        <event name="OnLeftDClick"></event>
-                        <event name="OnLeftDown"></event>
-                        <event name="OnLeftUp"></event>
-                        <event name="OnMiddleDClick"></event>
-                        <event name="OnMiddleDown"></event>
-                        <event name="OnMiddleUp"></event>
-                        <event name="OnMotion"></event>
-                        <event name="OnMouseEvents"></event>
-                        <event name="OnMouseWheel"></event>
-                        <event name="OnPaint"></event>
-                        <event name="OnRightDClick"></event>
-                        <event name="OnRightDown"></event>
-                        <event name="OnRightUp"></event>
-                        <event name="OnSetFocus"></event>
-                        <event name="OnSize"></event>
-                        <event name="OnUpdateUI"></event>
-                        <object class="wxFlexGridSizer" expanded="1">
+                        <object class="wxFlexGridSizer" expanded="0">
                             <property name="cols">2</property>
                             <property name="flexible_direction">wxBOTH</property>
                             <property name="growablecols">1</property>
@@ -500,7 +393,7 @@
                             <property name="vgap">0</property>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</property>
+                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -557,36 +450,6 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
-                                    <event name="OnLeftDClick"></event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
@@ -651,45 +514,12 @@
                                     <property name="window_extra_style"></property>
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
-                                    <event name="OnLeftDClick"></event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnText"></event>
                                     <event name="OnTextEnter">onLabelText</event>
-                                    <event name="OnTextMaxLen"></event>
-                                    <event name="OnTextURL"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</property>
+                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxALL</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -746,41 +576,11 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
-                                    <event name="OnLeftDClick"></event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALL</property>
+                                <property name="flag">wxALL|wxEXPAND</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -837,41 +637,12 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
                                     <event name="OnLeftDClick">onDoubleClickFreq</event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</property>
+                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxLEFT|wxRIGHT</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -928,41 +699,11 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
-                                    <event name="OnLeftDClick"></event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALL</property>
+                                <property name="flag">wxEXPAND|wxLEFT|wxRIGHT</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -1019,41 +760,12 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
                                     <event name="OnLeftDClick">onDoubleClickBandwidth</event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT</property>
+                                <property name="flag">wxALIGN_CENTER_VERTICAL|wxALIGN_RIGHT|wxALL</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -1110,41 +822,11 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
-                                    <event name="OnLeftDClick"></event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                             <object class="sizeritem" expanded="0">
                                 <property name="border">5</property>
-                                <property name="flag">wxALL</property>
+                                <property name="flag">wxALL|wxEXPAND</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
                                     <property name="BottomDockable">1</property>
@@ -1201,36 +883,6 @@
                                     <property name="window_name"></property>
                                     <property name="window_style"></property>
                                     <property name="wrap">-1</property>
-                                    <event name="OnAux1DClick"></event>
-                                    <event name="OnAux1Down"></event>
-                                    <event name="OnAux1Up"></event>
-                                    <event name="OnAux2DClick"></event>
-                                    <event name="OnAux2Down"></event>
-                                    <event name="OnAux2Up"></event>
-                                    <event name="OnChar"></event>
-                                    <event name="OnCharHook"></event>
-                                    <event name="OnEnterWindow"></event>
-                                    <event name="OnEraseBackground"></event>
-                                    <event name="OnKeyDown"></event>
-                                    <event name="OnKeyUp"></event>
-                                    <event name="OnKillFocus"></event>
-                                    <event name="OnLeaveWindow"></event>
-                                    <event name="OnLeftDClick"></event>
-                                    <event name="OnLeftDown"></event>
-                                    <event name="OnLeftUp"></event>
-                                    <event name="OnMiddleDClick"></event>
-                                    <event name="OnMiddleDown"></event>
-                                    <event name="OnMiddleUp"></event>
-                                    <event name="OnMotion"></event>
-                                    <event name="OnMouseEvents"></event>
-                                    <event name="OnMouseWheel"></event>
-                                    <event name="OnPaint"></event>
-                                    <event name="OnRightDClick"></event>
-                                    <event name="OnRightDown"></event>
-                                    <event name="OnRightUp"></event>
-                                    <event name="OnSetFocus"></event>
-                                    <event name="OnSize"></event>
-                                    <event name="OnUpdateUI"></event>
                                 </object>
                             </object>
                         </object>
@@ -1291,37 +943,7 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style">wxTAB_TRAVERSAL</property>
-                        <event name="OnAux1DClick"></event>
-                        <event name="OnAux1Down"></event>
-                        <event name="OnAux1Up"></event>
-                        <event name="OnAux2DClick"></event>
-                        <event name="OnAux2Down"></event>
-                        <event name="OnAux2Up"></event>
-                        <event name="OnChar"></event>
-                        <event name="OnCharHook"></event>
-                        <event name="OnEnterWindow"></event>
-                        <event name="OnEraseBackground"></event>
-                        <event name="OnKeyDown"></event>
-                        <event name="OnKeyUp"></event>
-                        <event name="OnKillFocus"></event>
-                        <event name="OnLeaveWindow"></event>
-                        <event name="OnLeftDClick"></event>
-                        <event name="OnLeftDown"></event>
-                        <event name="OnLeftUp"></event>
-                        <event name="OnMiddleDClick"></event>
-                        <event name="OnMiddleDown"></event>
-                        <event name="OnMiddleUp"></event>
-                        <event name="OnMotion"></event>
-                        <event name="OnMouseEvents"></event>
-                        <event name="OnMouseWheel"></event>
-                        <event name="OnPaint"></event>
-                        <event name="OnRightDClick"></event>
-                        <event name="OnRightDown"></event>
-                        <event name="OnRightUp"></event>
-                        <event name="OnSetFocus"></event>
-                        <event name="OnSize"></event>
-                        <event name="OnUpdateUI"></event>
-                        <object class="wxBoxSizer" expanded="1">
+                        <object class="wxBoxSizer" expanded="0">
                             <property name="minimum_size"></property>
                             <property name="name">m_buttonPanelSizer</property>
                             <property name="orient">wxVERTICAL</property>

--- a/src/forms/Bookmark/BookmarkPanel.h
+++ b/src/forms/Bookmark/BookmarkPanel.h
@@ -1,12 +1,11 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Aug  8 2018)
+// C++ code generated with wxFormBuilder (version Oct 26 2018)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
-#ifndef __BOOKMARKPANEL_H__
-#define __BOOKMARKPANEL_H__
+#pragma once
 
 #include <wx/artprov.h>
 #include <wx/xrc/xmlres.h>
@@ -21,6 +20,7 @@
 #include <wx/icon.h>
 #include <wx/button.h>
 #include <wx/treectrl.h>
+#include <wx/statline.h>
 #include <wx/stattext.h>
 #include <wx/sizer.h>
 #include <wx/panel.h>
@@ -32,14 +32,15 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class BookmarkPanel
 ///////////////////////////////////////////////////////////////////////////////
-class BookmarkPanel : public wxPanel 
+class BookmarkPanel : public wxPanel
 {
 	private:
-	
+
 	protected:
 		wxTextCtrl* m_searchText;
 		wxButton* m_clearSearchButton;
 		wxTreeCtrl* m_treeView;
+		wxStaticLine* m_propPanelDivider;
 		wxPanel* m_propPanel;
 		wxStaticText* m_labelLabel;
 		wxTextCtrl* m_labelText;
@@ -51,7 +52,7 @@ class BookmarkPanel : public wxPanel
 		wxStaticText* m_modulationVal;
 		wxPanel* m_buttonPanel;
 		wxTimer m_updateTimer;
-		
+
 		// Virtual event handlers, overide them in your derived class
 		virtual void onEnterWindow( wxMouseEvent& event ) { event.Skip(); }
 		virtual void onLeaveWindow( wxMouseEvent& event ) { event.Skip(); }
@@ -72,13 +73,12 @@ class BookmarkPanel : public wxPanel
 		virtual void onDoubleClickFreq( wxMouseEvent& event ) { event.Skip(); }
 		virtual void onDoubleClickBandwidth( wxMouseEvent& event ) { event.Skip(); }
 		virtual void onUpdateTimer( wxTimerEvent& event ) { event.Skip(); }
-		
-	
+
+
 	public:
-		
-		BookmarkPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 169,471 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString ); 
+
+		BookmarkPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 169,471 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
 		~BookmarkPanel();
-	
+
 };
 
-#endif //__BOOKMARKPANEL_H__

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -25,7 +25,7 @@
 #define BOOKMARK_VIEW_STR_RENAME_GROUP "Rename Group"
 
 
-BookmarkViewVisualDragItem::BookmarkViewVisualDragItem(wxString labelValue) : wxDialog(NULL, wxID_ANY, L"", wxPoint(20,20), wxSize(-1,-1), wxSTAY_ON_TOP | wxALL ) {
+BookmarkViewVisualDragItem::BookmarkViewVisualDragItem(wxString labelValue) : wxDialog(NULL, wxID_ANY, L"", wxPoint(20,20), wxSize(-1,-1), wxFRAME_TOOL_WINDOW | wxNO_BORDER | wxSTAY_ON_TOP | wxALL ) {
     
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
     wxStaticText *label = new wxStaticText( this, wxID_ANY, labelValue, wxDefaultPosition, wxDefaultSize, wxEXPAND );
@@ -403,7 +403,6 @@ void BookmarkView::doUpdateActiveList() {
         
         if (nextDemod != nullptr && nextDemod == demod_i) {
             selItem = itm;
-            wxGetApp().getDemodMgr().setActiveDemodulator(nextDemod, false);
             nextDemod = nullptr;
         } else if (!selItem && activeExpandState && lastActiveDemodulator && lastActiveDemodulator == demod_i) {
             selItem = itm;
@@ -528,6 +527,7 @@ void BookmarkView::onTreeActivate( wxTreeEvent& event ) {
             if (!tvi->demod->isActive()) {                
                 wxGetApp().setFrequency(tvi->demod->getFrequency());
                 nextDemod = tvi->demod;
+                wxGetApp().getDemodMgr().setActiveDemodulator(nextDemod, false);
             }
         } else if (tvi->type == TreeViewItem::TREEVIEW_ITEM_TYPE_RECENT) {
              
@@ -659,13 +659,15 @@ void BookmarkView::hideProps() {
     
     m_labelText->Hide();
     m_labelLabel->Hide();
-    
+
+    m_propPanelDivider->Hide();
     m_propPanel->Hide();
     m_buttonPanel->Hide();
 }
 
 
 void BookmarkView::showProps() {
+    m_propPanelDivider->Show();
     m_propPanel->Show();
     m_propPanel->GetSizer()->Layout();
 }
@@ -886,8 +888,9 @@ void BookmarkView::activateBookmark(BookmarkEntryPtr bmEnt) {
 	}
 
 	nextDemod = matchingDemod;
-  
-	wxGetApp().getBookmarkMgr().updateActiveList();
+    wxGetApp().getDemodMgr().setActiveDemodulator(nextDemod, false);
+
+    //wxGetApp().getBookmarkMgr().updateActiveList();
 }
 
 
@@ -1504,7 +1507,7 @@ void BookmarkView::onMotion( wxMouseEvent& event ) {
 
     wxPoint pos = ClientToScreen(event.GetPosition());
     
-    pos += wxPoint(30,-10);
+    pos += wxPoint(15,-5);
     
     if (visualDragItem != nullptr) {
         visualDragItem->SetPosition(pos);

--- a/src/forms/Dialog/PortSelectorDialog.cpp
+++ b/src/forms/Dialog/PortSelectorDialog.cpp
@@ -7,13 +7,20 @@ PortSelectorDialog::PortSelectorDialog( wxWindow* parent, wxWindowID id, std::st
     comEnumerate();
     
     int nPorts = comGetNoPorts();
-    
+
+    if (!defaultPort.empty()) {
+        m_portList->Append(defaultPort);
+    }
+
     for (int i = 0; i < nPorts; i++) {
 #ifdef WIN32
-        m_portList->Append(comGetPortName(i));
+        string portName(comGetPortName(i));
 #else
-        m_portList->Append(comGetInternalName(i));
+        string portName(comGetInternalName(i));
 #endif
+        if (portName != defaultPort) {
+            m_portList->Append(portName);
+        }
     }
     
     comTerminate();
@@ -36,4 +43,9 @@ void PortSelectorDialog::onCancelButton( wxCommandEvent& /* event */ ) {
 
 void PortSelectorDialog::onOKButton( wxCommandEvent& /* event */ ) {
     wxGetApp().getAppFrame()->setRigControlPort(m_portSelection->GetValue().ToStdString());
+}
+
+
+void PortSelectorDialog::onClose(wxCloseEvent & /* event */) {
+    wxGetApp().getAppFrame()->dismissRigControlPortDialog();
 }

--- a/src/forms/Dialog/PortSelectorDialog.fbp
+++ b/src/forms/Dialog/PortSelectorDialog.fbp
@@ -53,6 +53,7 @@
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style"></property>
+            <event name="OnClose">onClose</event>
             <object class="wxBoxSizer" expanded="1">
                 <property name="minimum_size"></property>
                 <property name="name">dlgSizer</property>

--- a/src/forms/Dialog/PortSelectorDialog.h
+++ b/src/forms/Dialog/PortSelectorDialog.h
@@ -8,4 +8,5 @@ protected:
     void onListSelect( wxCommandEvent& event );
     void onCancelButton( wxCommandEvent& event );
     void onOKButton( wxCommandEvent& event );
+    void onClose( wxCloseEvent& event );
 };

--- a/src/forms/Dialog/PortSelectorDialogBase.cpp
+++ b/src/forms/Dialog/PortSelectorDialogBase.cpp
@@ -59,6 +59,7 @@ PortSelectorDialogBase::PortSelectorDialogBase( wxWindow* parent, wxWindowID id,
 	this->Centre( wxBOTH );
 
 	// Connect Events
+	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( PortSelectorDialogBase::onClose ) );
 	m_portList->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( PortSelectorDialogBase::onListSelect ), NULL, this );
 	m_cancelButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onCancelButton ), NULL, this );
 	m_okButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onOKButton ), NULL, this );
@@ -67,6 +68,7 @@ PortSelectorDialogBase::PortSelectorDialogBase( wxWindow* parent, wxWindowID id,
 PortSelectorDialogBase::~PortSelectorDialogBase()
 {
 	// Disconnect Events
+	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( PortSelectorDialogBase::onClose ) );
 	m_portList->Disconnect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( PortSelectorDialogBase::onListSelect ), NULL, this );
 	m_cancelButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onCancelButton ), NULL, this );
 	m_okButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PortSelectorDialogBase::onOKButton ), NULL, this );

--- a/src/forms/Dialog/PortSelectorDialogBase.h
+++ b/src/forms/Dialog/PortSelectorDialogBase.h
@@ -43,6 +43,7 @@ class PortSelectorDialogBase : public wxDialog
 		wxButton* m_okButton;
 
 		// Virtual event handlers, overide them in your derived class
+		virtual void onClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void onListSelect( wxCommandEvent& event ) { event.Skip(); }
 		virtual void onCancelButton( wxCommandEvent& event ) { event.Skip(); }
 		virtual void onOKButton( wxCommandEvent& event ) { event.Skip(); }

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -14,7 +14,7 @@
 #include "CubicSDR.xpm"
 #endif
 
-SDRDevicesDialog::SDRDevicesDialog( wxWindow* parent ): devFrame( parent, wxID_ANY, wxT(CUBICSDR_INSTALL_NAME " :: SDR Devices")) {
+SDRDevicesDialog::SDRDevicesDialog( wxWindow* parent, const wxPoint &pos): devFrame( parent, wxID_ANY, wxT(CUBICSDR_INSTALL_NAME " :: SDR Devices"), pos) {
     refresh = true;
     failed = false;
     m_refreshButton->Disable();

--- a/src/forms/SDRDevices/SDRDevices.h
+++ b/src/forms/SDRDevices/SDRDevices.h
@@ -13,7 +13,7 @@
 
 class SDRDevicesDialog: public devFrame {
 public:
-    SDRDevicesDialog( wxWindow* parent );
+    SDRDevicesDialog( wxWindow* parent, const wxPoint &wxPos = wxDefaultPosition);
     
     void OnClose( wxCloseEvent& event );
     void OnDeleteItem( wxTreeEvent& event );


### PR DESCRIPTION
- fix UI race causing corrupt layout when activating bookmark
- fix init of numRigs in appframe causing multiple rig selections
- fix device dialog appearing on default display instead of where cubisdr is
- fix closing port dialog with X making it unable to open again
- bookmark panel UI layout fixes
- add separation line between tree and info panel
- fix display of freq/bandwidth/mode
- add last/custom serial port to top of list in port selection dialog