### PR TITLE
Move config load out of commandline parse to prevent wrong path in AppImage

### DIFF
--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -200,6 +200,8 @@ public:
 
 CubicSDR::CubicSDR() : frequency(0), offset(0), ppm(0), snap(1), sampleRate(DEFAULT_SAMPLE_RATE), agcMode(false)
 {
+        config.load();
+
         sampleRateInitialized.store(false);
         agcMode.store(true);
         soloMode.store(false);
@@ -550,8 +552,6 @@ bool CubicSDR::OnCmdLineParsed(wxCmdLineParser& parser) {
             config.setConfigName(confName->ToStdString());
         }
     }
-    
-    config.load();
 
 #ifdef BUNDLE_SOAPY_MODS
     if (parser.Found("b")) {


### PR DESCRIPTION
Fix for #705 
- WX was providing a settings path matching the binary name instead of the application name since the configuration was being loaded too early (during command line parse) before the app name was set.