### PR TITLE
fix build with wxWidgets 3.1.3

### DIFF
--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -9,6 +9,7 @@
 #include <wx/sizer.h>
 #include <wx/bitmap.h>
 #include <wx/statbmp.h>
+#include <wx/tooltip.h>
 
 #include "PrimaryGLContext.h"
 


### PR DESCRIPTION
AppFrame.cpp use wxToolTip() without including the library