### PR TITLE
Fix missing import for GLX on linux.

### DIFF
--- a/src/util/GLExt.cpp
+++ b/src/util/GLExt.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__)
+#include <GL/glx.h>
 #include <dlfcn.h>
 #endif
 


### PR DESCRIPTION
Without this Display (for instance) is not defined in the scope.