### PR TITLE
Proper OpenGL HiDPI handling. 

### DIFF
--- a/src/ui/UITestCanvas.cpp
+++ b/src/ui/UITestCanvas.cpp
@@ -39,7 +39,7 @@ UITestCanvas::~UITestCanvas() {
 
 void UITestCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
     
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -52,7 +52,7 @@ GainCanvas::~GainCanvas() {
 
 void GainCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/MeterCanvas.cpp
+++ b/src/visual/MeterCanvas.cpp
@@ -83,7 +83,7 @@ void MeterCanvas::setShowUserInput(bool showUserInput) {
 
 void MeterCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
  //   wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/ModeSelectorCanvas.cpp
+++ b/src/visual/ModeSelectorCanvas.cpp
@@ -52,7 +52,7 @@ int ModeSelectorCanvas::getHoveredSelection() {
 
 void ModeSelectorCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
    // wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -102,7 +102,7 @@ bool ScopeCanvas::getShowDb() {
 
 void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
     
     ScopeRenderDataPtr avData;
     while (inputData->try_pop(avData)) {

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -52,7 +52,7 @@ SpectrumCanvas::~SpectrumCanvas() {
 
 void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
     
     SpectrumVisualDataPtr vData;
     if (visualDataQueue->try_pop(vData)) {

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -85,7 +85,7 @@ void TuningCanvas::setHalfBand(bool hb) {
 
 void TuningCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
  //   wxPaintDC dc(this);
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
     
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -130,7 +130,7 @@ void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     std::lock_guard < std::mutex > lock(tex_update);
 //    wxPaintDC dc(this);
     
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
     long double currentZoom = zoom;
     
     if (mouseZoom != 1) {


### PR DESCRIPTION
Fixes problems with size of OpenGL widgets. MacOS tested #758 
Probably worth testing on WIndows and Linux (#727).
In addition, the question remains open about the correct scaling of fonts... The Display -> Text Size option works correctly, but it does not affect all interface elements. There are screenshots in #758.