### PR TITLE
Misc. enhancements (driven by RSPDuo support needs)

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1404,7 +1404,13 @@ bool AppFrame::actionOnMenuReset(wxCommandEvent& event) {
         wxGetApp().getSpectrumProcessor()->setFFTAverageRate(0.65f);
         spectrumAvgMeter->setLevel(0.65f);
 
-        SetTitle(CUBICSDR_TITLE);
+        wxString titleBar = CUBICSDR_TITLE;
+        //append the name of the current Device, if any.
+        if (wxGetApp().getDevice()) {
+            titleBar += " - " + wxGetApp().getDevice()->getName();
+        }
+
+        SetTitle(titleBar);
         currentSessionFile = "";
 		currentBookmarkFile = "";
         bookmarkSplitter->Unsplit(bookmarkView);
@@ -2642,7 +2648,14 @@ void AppFrame::saveSession(std::string fileName) {
     currentSessionFile = fileName;
     std::string filePart = fileName.substr(fileName.find_last_of(filePathSeparator) + 1);
     GetStatusBar()->SetStatusText(wxString::Format(wxT("Saved session: %s"), currentSessionFile.c_str()));
-    SetTitle(wxString::Format(wxT("%s: %s"), CUBICSDR_TITLE, filePart.c_str()));
+
+    wxString titleBar = CUBICSDR_TITLE;
+    //append the name of the current Device, if any.
+    if (wxGetApp().getDevice()) {
+        titleBar += " - " + wxGetApp().getDevice()->getName();
+    }
+    titleBar += ": " + filePart;
+    SetTitle(titleBar);
 }
 
 bool AppFrame::loadSession(std::string fileName) {
@@ -2677,7 +2690,14 @@ bool AppFrame::loadSession(std::string fileName) {
     std::string filePart = fileName.substr(fileName.find_last_of(filePathSeparator) + 1);
 
     GetStatusBar()->SetStatusText(wxString::Format(wxT("Loaded session file: %s"), currentSessionFile.c_str()));
-    SetTitle(wxString::Format(wxT("%s: %s"), CUBICSDR_TITLE, filePart.c_str()));
+
+    wxString titleBar = CUBICSDR_TITLE;
+    //append the name of the current Device, if any.
+    if (wxGetApp().getDevice()) {
+        titleBar += " - " + wxGetApp().getDevice()->getName();
+    }
+    titleBar += ": " + filePart;
+    SetTitle(titleBar);
 
     wxGetApp().getBookmarkMgr().updateActiveList();
 

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -32,7 +32,6 @@ SDRDevicesDialog::SDRDevicesDialog( wxWindow* parent, const wxPoint &pos): devFr
 #elif _WIN32
     SetIcon(wxICON(frame_icon));
 #endif
-
 }
 
 void SDRDevicesDialog::OnClose( wxCloseEvent& /* event */) {
@@ -395,6 +394,12 @@ void SDRDevicesDialog::OnUseSelected( wxMouseEvent& event) {
         wxGetApp().setDeviceArgs(settingArgs);
         wxGetApp().setStreamArgs(streamArgs);
         wxGetApp().setDevice(dev,0);
+        
+        //update main application title with Device name:
+        wxString titleBar = CUBICSDR_TITLE;
+        titleBar += " - " + wxGetApp().getDevice()->getName();
+        wxGetApp().getAppFrame()->SetTitle(titleBar);
+
         Close();
     }
     event.Skip();

--- a/src/sdr/SoapySDRThread.h
+++ b/src/sdr/SoapySDRThread.h
@@ -49,7 +49,7 @@ private:
     void deinit();
     
     //returns the SoapyDevice readStream return value,
-    //i.e if >= 0 the numbre of samples read, else if < 0 an error code.
+    //i.e if >= 0 the number of samples read, else if < 0 an error code.
     int readStream(SDRThreadIQDataQueuePtr iqDataOutQueue);
 
     void readLoop();


### PR DESCRIPTION
Hello @fventuri, @SDRplay. This is PR for CubicSDR destined to have better support for RSPDuo, but staying generic at the same time.
- Addition of Device name in the Title bar: this will allow to distinct between `Master` and `Slave` instance names in the Duo context.
- Better handling of "lost device" by checking SoapySDR `readStream` return code `SOAPY_SDR_NOT_SUPPORTED`, or catching exception on `readStream` and stopping the Cubic streaming thread cleanly.

Some notes on the second point : 
Soapy API has a special code meaning `SOAPY_SDR_NOT_SUPPORTED` that should be returned by the `readStream` on the `Slave` instance when the `Master` get lost.

Although the Cubic code now also catch any exception around the `readStream` code to stop Cubic side cleanly, last time I checked (pre-Cx11 I confess) it is considered very bad practice to throw exceptions between threads, especially for a parfect valid case of "dying Master instance" like this.

Of course there is also less garantees that other clients of Soapy API are expecting exceptions to be managed at all in their particular application.

Either way even with those changes from the user perspective the Waterfall and Spectrum will simply stop animating in case of Duo Master loss on the Slave side. Not much more can be done without developping an insane amount of code compared to this small use case.

I've tested on RSP2 (old driver) with a testing piece of code either throwing a `std:runtime_error` or returning `SOAPY_SDR_NOT_SUPPORTED` after some time to simulate it: The WF/Spectrum stream animation stops, but I can still going to either `Start/Stop device`or `Devices` dialogs to restart it. So it is as clean as it can get I think.
 