### PR TITLE
temporary patch to support retina display on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,6 +708,12 @@ IF (APPLE)
         -DHAVE_TYPE_TRAITS=1
         -mmacosx-version-min=10.9
     )
+    SET(USE_OSX_RETINA OFF CACHE BOOL "Enable support for retina display on macOS.")
+    IF (USE_OSX_RETINA)
+        ADD_DEFINITIONS(
+            -DUSE_OSX_RETINA=1
+        )
+    ENDIF()
 ENDIF(APPLE)
 
 IF (APPLE AND BUNDLE_APP)

--- a/src/ui/UITestCanvas.cpp
+++ b/src/ui/UITestCanvas.cpp
@@ -39,7 +39,11 @@ UITestCanvas::~UITestCanvas() {
 
 void UITestCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
     
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/util/GLFont.cpp
+++ b/src/util/GLFont.cpp
@@ -847,15 +847,25 @@ double GLFont::getScaleFactor() {
     GLFontScale scale = currentScale.load();
 
     if (scale == GLFONT_SCALE_MEDIUM) {
-
+#ifdef USE_OSX_RETINA
+        return 2.5;
+#else
         return 1.5;
+#endif
     }
     else if (scale == GLFONT_SCALE_LARGE) {
-
+#ifdef USE_OSX_RETINA
+        return 3;
+#else
         return 2.0;
+#endif
     }
 
+#ifdef USE_OSX_RETINA
+    return 2;
+#else
     return 1.0;
+#endif
 }
 
 int GLFont::getScaledPx(int basicFontSize, double scaleFactor) {

--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -52,7 +52,11 @@ GainCanvas::~GainCanvas() {
 
 void GainCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
 
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/MeterCanvas.cpp
+++ b/src/visual/MeterCanvas.cpp
@@ -83,7 +83,11 @@ void MeterCanvas::setShowUserInput(bool showUserInput) {
 
 void MeterCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
  //   wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
 
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/ModeSelectorCanvas.cpp
+++ b/src/visual/ModeSelectorCanvas.cpp
@@ -52,7 +52,11 @@ int ModeSelectorCanvas::getHoveredSelection() {
 
 void ModeSelectorCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
    // wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
 
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/ModeSelectorContext.cpp
+++ b/src/visual/ModeSelectorContext.cpp
@@ -32,10 +32,18 @@ void ModeSelectorContext::DrawSelector(std::string label, int c, int cMax, bool 
     float viewHeight = (float) vp[3];
     float viewWidth = (float) vp[2];
 
+#ifdef USE_OSX_RETINA
+    int fontSize = 18 * GLFont::getScaleFactor();
+#else
     int fontSize = 18;
+#endif
 
     if (viewWidth < 30 || viewHeight < 200) {
+#ifdef USE_OSX_RETINA
+        fontSize = 16 * GLFont::getScaleFactor();
+#else
         fontSize = 16;
+#endif
     }
 
     glColor4f(r, g, b, a);

--- a/src/visual/ScopeCanvas.cpp
+++ b/src/visual/ScopeCanvas.cpp
@@ -102,7 +102,11 @@ bool ScopeCanvas::getShowDb() {
 
 void ScopeCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
     
     ScopeRenderDataPtr avData;
     while (inputData->try_pop(avData)) {

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -52,7 +52,11 @@ SpectrumCanvas::~SpectrumCanvas() {
 
 void SpectrumCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
   //  wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
     
     SpectrumVisualDataPtr vData;
     if (visualDataQueue->try_pop(vData)) {

--- a/src/visual/TuningCanvas.cpp
+++ b/src/visual/TuningCanvas.cpp
@@ -85,7 +85,11 @@ void TuningCanvas::setHalfBand(bool hb) {
 
 void TuningCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
  //   wxPaintDC dc(this);
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
     
     glContext->SetCurrent(*this);
     initGLExtensions();

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -129,8 +129,12 @@ void WaterfallCanvas::processInputQueue() {
 void WaterfallCanvas::OnPaint(wxPaintEvent& WXUNUSED(event)) {
     std::lock_guard < std::mutex > lock(tex_update);
 //    wxPaintDC dc(this);
-    
+#ifdef USE_OSX_RETINA
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
+#else
     const wxSize ClientSize = GetClientSize();
+#endif
+
     long double currentZoom = zoom;
     
     if (mouseZoom != 1) {


### PR DESCRIPTION
this simple patch enable support of retina displays on macOS.
to enable the support you need to pass `-DUSE_OSX_RETINA=1` to cmake

It is a follow-up of https://github.com/cjcliffe/CubicSDR/pull/769

just a side note: macports's version apply this as default.

thanks @Magalex2x14