### PR TITLE
Modified ModemAM

### DIFF
--- a/src/modules/modem/analog/ModemAM.h
+++ b/src/modules/modem/analog/ModemAM.h
@@ -9,15 +9,15 @@ class ModemAM : public ModemAnalog {
 public:
     ModemAM();
     ~ModemAM();
-    
+
     std::string getName();
-    
+
     static ModemBase *factory();
-    
+
     int getDefaultSampleRate();
 
     void demodulate(ModemKit *kit, ModemIQData *input, AudioThreadInput *audioOut);
-    
+
 private:
-    ampmodem demodAM;
+    firfilt_rrrf mDCBlock;
 };


### PR DESCRIPTION
Implement an AM demodulator in ModemAM module. Replaces ampmodem based code which is too narrowband to be usable in many situations. DSB demodulator is not modified and is essentially identical to the AM one replaced by this.