### PR TITLE
FILPATHLEN is now HAMLIB_FILPATHLEN in 4.2

### DIFF
--- a/external/hamlib/hamlib/rig.h
+++ b/external/hamlib/hamlib/rig.h
@@ -147,7 +147,7 @@ typedef struct rig RIG;
 
 #define RIGNAMSIZ 30
 #define RIGVERSIZ 8
-#define FILPATHLEN 100
+#define HAMLIB_FILPATHLEN 100
 #define FRQRANGESIZ 30
 #define MAXCHANDESC 30      /* describe channel eg: "WWV 5Mhz" */
 #define TSLSTSIZ 20         /* max tuning step list size, zero ended */
@@ -1479,7 +1479,7 @@ typedef struct hamlib_port {
     int timeout;            /*!< Timeout, in mS */
     int retry;              /*!< Maximum number of retries, 0 to disable */
 
-    char pathname[FILPATHLEN];      /*!< Port pathname */
+    char pathname[HAMLIB_FILPATHLEN];      /*!< Port pathname */
 
     union {
         struct {

--- a/src/rig/RigThread.cpp
+++ b/src/rig/RigThread.cpp
@@ -114,7 +114,7 @@ void RigThread::run() {
     std::cout << "Rig thread starting." << std::endl;
 
     rig = rig_init(rigModel);
-	strncpy(rig->state.rigport.pathname, rigFile.c_str(), FILPATHLEN - 1);
+	strncpy(rig->state.rigport.pathname, rigFile.c_str(), HAMLIB_FILPATHLEN - 1);
 	rig->state.rigport.parm.serial.rate = serialRate;
 	retcode = rig_open(rig);
     


### PR DESCRIPTION
Minimal patch for hamlib 4.2. Some version checking or existence checking of HAMLIB_FILPATHLEN and aliasing needs to be added.