### PR TITLE
Fix typing errors

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -2034,7 +2034,7 @@ bool AppFrame::actionOnMenuDBOffset(wxCommandEvent &event) {
 
 bool AppFrame::actionOnMenuFreqOffset(wxCommandEvent &event) {
     if (event.GetId() == wxID_SET_FREQ_OFFSET) {
-        //enter in KHz to accomodate > 2GHz shifts for down/upconverters on 32 bit platforms.
+        //enter in KHz to accommodate > 2GHz shifts for down/upconverters on 32 bit platforms.
         long ofs = wxGetNumberFromUser(
                 "Shift the displayed frequency by this amount of KHz.\ni.e. -125000 for -125 MHz", "Frequency (KHz)",
                 "Frequency Offset", (long long) (wxGetApp().getOffset() / 1000.0), -2000000000, 2000000000, this);
@@ -2661,7 +2661,7 @@ bool AppFrame::loadSession(const std::string& fileName) {
 
     int sample_rate = wxGetApp().getSampleRate();
 
-    //scan the available sample rates and see if it matches a predifined one
+    //scan the available sample rates and see if it matches a predefined one
     int menuIndex = -1;
     for (auto discreteRate : sampleRates) {
         if (discreteRate == sample_rate) {
@@ -2930,7 +2930,7 @@ int AppFrame::OnGlobalKeyDown(wxKeyEvent &event) {
     
     //Re-dispatch the key events if the mouse cursor is within a given
     //widget region, effectively activating its specific key shortcuts,
-    //which else are overriden by this global key handler.
+    //which else are overridden by this global key handler.
     if (demodTuner->getMouseTracker()->mouseInView()) {
         demodTuner->OnKeyDown(event);
     } else if (waterfallCanvas->getMouseTracker()->mouseInView()) {
@@ -3067,7 +3067,7 @@ int AppFrame::OnGlobalKeyUp(wxKeyEvent &event) {
 
     //Re-dispatch the key events if the mouse cursor is within a given
     //widget region, effectively activating its specific key shortcuts,
-    //which else are overriden by this global key handler.
+    //which else are overridden by this global key handler.
     if (demodTuner->getMouseTracker()->mouseInView()) {
         demodTuner->OnKeyUp(event);
     }

--- a/src/BookmarkMgr.h
+++ b/src/BookmarkMgr.h
@@ -118,7 +118,7 @@ protected:
     void trimRecents();
 	void loadDefaultRanges();
 
-    //utility method that attemts to decode the childNodeName as std::wstring, else as std::string, else 
+    //utility method that attempts to decode the childNodeName as std::wstring, else as std::string, else 
     //return an empty string.
     static std::wstring getSafeWstringValue(DataNode* node, const std::string& childNodeName);
     

--- a/src/CubicSDR.cpp
+++ b/src/CubicSDR.cpp
@@ -275,7 +275,7 @@ bool CubicSDR::OnInit() {
     }
 
     //Deactivated code to allocate an explicit Console on Windows.
-    //This tends to hang the apllication on heavy demod (re)creation.
+    //This tends to hang the application on heavy demod (re)creation.
     //To continue to debug with std::cout traces, simply run CubicSDR in a MINSYS2 compatble shell on Windows:
     //ex: Cygwin shell, Git For Windows Bash shell....
 #if (0)
@@ -766,7 +766,7 @@ void CubicSDR::setSampleRate(long long rate_in) {
 
 void CubicSDR::stopDevice(bool store, int waitMsForTermination) {
     
-    //Firt we must stop the threads
+    //First we must stop the threads
     sdrThread->terminate();
     sdrThread->isTerminated(waitMsForTermination);
 

--- a/src/CubicSDR.h
+++ b/src/CubicSDR.h
@@ -260,7 +260,7 @@ static const wxCmdLineEntryDesc commandLineInfo [] =
 {
     { wxCMD_LINE_SWITCH, "h", "help", "Command line parameter help", wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
     { wxCMD_LINE_OPTION, "c", "config", "Specify a named configuration to use, i.e. '-c ham'", wxCMD_LINE_VAL_STRING, 0 },
-    { wxCMD_LINE_OPTION, "m", "modpath", "Load modules from suppplied path, i.e. '-m ~/SoapyMods/'", wxCMD_LINE_VAL_STRING, 0 },
+    { wxCMD_LINE_OPTION, "m", "modpath", "Load modules from supplied path, i.e. '-m ~/SoapyMods/'", wxCMD_LINE_VAL_STRING, 0 },
 #ifdef BUNDLE_SOAPY_MODS
     { wxCMD_LINE_SWITCH, "b", "bundled", "Use bundled SoapySDR modules first instead of local.", wxCMD_LINE_VAL_NONE, 0 },
 #endif

--- a/src/SessionMgr.cpp
+++ b/src/SessionMgr.cpp
@@ -70,7 +70,7 @@ bool SessionMgr::loadSession(const std::string& fileName) {
         DataNode *header = l.rootNode()->getNext("header");
 
         if (header->hasAnother("version")) {
-            //"Force" the retreiving of the value as string, even if its look like a number internally ! (ex: "0.2.0")
+            //"Force" the retrieving of the value as string, even if it looks like a number internally ! (ex: "0.2.0")
             DataNode *versionNode = header->getNext("version");
             std::wstring version;
             try {
@@ -92,7 +92,7 @@ bool SessionMgr::loadSession(const std::string& fileName) {
 
             SDRDeviceInfo *dev = wxGetApp().getSDRThread()->getDevice();
             if (dev) {
-                //retreive the available sample rates. A valid previously chosen manual
+                //retrieve the available sample rates. A valid previously chosen manual
                 //value is constrained within these limits. If it doesn't behave, lets the device choose
                 //for us.
                 long minRate = MANUAL_SAMPLE_RATE_MIN;

--- a/src/demod/DemodulatorMgr.h
+++ b/src/demod/DemodulatorMgr.h
@@ -81,7 +81,7 @@ public:
 
 private:
 
-    //utility method that attemts to decode node value as std::wstring, else as std::string, else 
+    //utility method that attempts to decode node value as std::wstring, else as std::string, else 
     //return an empty string.
     static std::wstring getSafeWstringValue(DataNode* node);
 

--- a/src/demod/DemodulatorThread.cpp
+++ b/src/demod/DemodulatorThread.cpp
@@ -356,7 +356,7 @@ void DemodulatorThread::run() {
 void DemodulatorThread::terminate() {
     IOThread::terminate();
 
-    //unblock the curretly blocked push()
+    //unblock the currently blocked push()
     iqInputQueue->flush();
     audioOutputQueue->flush();
 }

--- a/src/forms/Bookmark/BookmarkPanel.h
+++ b/src/forms/Bookmark/BookmarkPanel.h
@@ -53,7 +53,7 @@ class BookmarkPanel : public wxPanel
 		wxPanel* m_buttonPanel;
 		wxTimer m_updateTimer;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void onEnterWindow( wxMouseEvent& event ) { event.Skip(); }
 		virtual void onLeaveWindow( wxMouseEvent& event ) { event.Skip(); }
 		virtual void onMotion( wxMouseEvent& event ) { event.Skip(); }

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -943,7 +943,7 @@ void BookmarkView::activateBookmark(const BookmarkEntryPtr& bmEnt) {
 
 void BookmarkView::activateRange(const BookmarkRangeEntryPtr& rangeEnt) {
     
-	//the following oly works if rangeEnt->freq is the middle of [rangeEnt->startFreq ; rangeEnt->startFreq]
+	//the following only works if rangeEnt->freq is the middle of [rangeEnt->startFreq ; rangeEnt->startFreq]
 	wxGetApp().setFrequency(rangeEnt->freq);
 	
 	// Change View limits to fit the range exactly.

--- a/src/forms/Bookmark/BookmarkView.h
+++ b/src/forms/Bookmark/BookmarkView.h
@@ -60,11 +60,11 @@ public:
     ~BookmarkView() override;
     
     //order an asynchronous refresh/rebuild of the whole tree,
-    //will take effect at the next onUpdateTimer() occurence.
+    //will take effect at the next onUpdateTimer() occurrence.
     void updateActiveList();
     
     //order asynchronous updates of the bookmarks,
-    //will take effect at the next onUpdateTimer() occurence.
+    //will take effect at the next onUpdateTimer() occurrence.
     void updateBookmarks();
     void updateBookmarks(const std::string& group);
 
@@ -101,7 +101,7 @@ protected:
     
     void onUpdateTimer( wxTimerEvent& event ) override;
 
-    //refresh / rebuild the whole tree item immediatly
+    //refresh / rebuild the whole tree item immediately
     void doUpdateActiveList();
 
     void onKeyUp( wxKeyEvent& event ) override;

--- a/src/forms/Dialog/ActionDialogBase.h
+++ b/src/forms/Dialog/ActionDialogBase.h
@@ -38,7 +38,7 @@ class ActionDialogBase : public wxDialog
 		wxButton* m_cancelButton;
 		wxButton* m_okButton;
 		
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void onClickCancel( wxCommandEvent& event ) { event.Skip(); }
 		virtual void onClickOK( wxCommandEvent& event ) { event.Skip(); }
 		

--- a/src/forms/Dialog/PortSelectorDialogBase.h
+++ b/src/forms/Dialog/PortSelectorDialogBase.h
@@ -42,7 +42,7 @@ class PortSelectorDialogBase : public wxDialog
 		wxButton* m_cancelButton;
 		wxButton* m_okButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void onClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void onListSelect( wxCommandEvent& event ) { event.Skip(); }
 		virtual void onCancelButton( wxCommandEvent& event ) { event.Skip(); }

--- a/src/forms/DigitalConsole/DigitalConsoleFrame.h
+++ b/src/forms/DigitalConsole/DigitalConsoleFrame.h
@@ -41,7 +41,7 @@ class DigitalConsoleFrame : public wxFrame
 		wxButton* m_pauseButton;
 		wxTimer m_refreshTimer;
 		
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void OnClear( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCopy( wxCommandEvent& event ) { event.Skip(); }

--- a/src/forms/SDRDevices/SDRDeviceAddForm.h
+++ b/src/forms/SDRDevices/SDRDeviceAddForm.h
@@ -43,7 +43,7 @@ class SDRDeviceAddForm : public wxDialog
 		wxButton* m_cancelButton;
 		wxButton* m_OkButton;
 		
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnSoapyModuleChanged( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCancelButton( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnOkButton( wxCommandEvent& event ) { event.Skip(); }

--- a/src/forms/SDRDevices/SDRDevices.cpp
+++ b/src/forms/SDRDevices/SDRDevices.cpp
@@ -151,7 +151,7 @@ void SDRDevicesDialog::refreshDeviceProperties() {
                 antennaToSelect = currentSetAntenna;
             }
             else {
-                //erroneous antenna name, re-write device config with the first choice of teh list.
+                //erroneous antenna name, re-write device config with the first choice of the list.
                 devConfig->setAntennaName(antennaToSelect);
             }
 

--- a/src/forms/SDRDevices/SDRDevicesForm.h
+++ b/src/forms/SDRDevices/SDRDevicesForm.h
@@ -53,7 +53,7 @@ class devFrame : public wxFrame
 		wxPropertyGrid* m_propertyGrid;
 		wxTimer m_deviceTimer;
 		
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void OnTreeDoubleClick( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnDeleteItem( wxTreeEvent& event ) { event.Skip(); }

--- a/src/process/FFTDataDistributor.cpp
+++ b/src/process/FFTDataDistributor.cpp
@@ -67,7 +67,7 @@ void FFTDataDistributor::process() {
                 memmove(&inputBuffer.data[0], &inputBuffer.data[bufferOffset], bufferedItems*sizeof(liquid_float_complex));
                 bufferOffset = 0;
                 //if there are too much samples, we may even overflow !
-                //as a fallback strategy, drop the last incomming new samples not fitting in inputBuffer.data.
+                //as a fallback strategy, drop the last incoming new samples not fitting in inputBuffer.data.
                 if (bufferedItems + inp->data.size() > bufferMax) {
                     //clamp nbSamplesToAdd
                     nbSamplesToAdd = bufferMax - bufferedItems;

--- a/src/process/VisualProcessor.h
+++ b/src/process/VisualProcessor.h
@@ -120,7 +120,7 @@ public:
     
 protected:
     // derived class must implement a  process() interface
-    //where typically 'input' data is consummed, processed, and then dispatched
+    //where typically 'input' data is consumed, processed, and then dispatched
     //with distribute() to all 'outputs'.
     virtual void process() = 0;
 

--- a/src/sdr/SDRPostThread.cpp
+++ b/src/sdr/SDRPostThread.cpp
@@ -49,7 +49,7 @@ void SDRPostThread::updateActiveDemodulators() {
 
     long long centerFreq = wxGetApp().getFrequency();
 
-    //retreive the current list of demodulators:
+    //retrieve the current list of demodulators:
     auto demodulators = wxGetApp().getDemodMgr().getDemodulators();
    
     for (const auto& demod : demodulators) {
@@ -99,7 +99,7 @@ void SDRPostThread::updateActiveDemodulators() {
 
 
 void SDRPostThread::resetAllDemodulators() {
-    //retreive the current list of demodulators:
+    //retrieve the current list of demodulators:
     auto demodulators = wxGetApp().getDemodMgr().getDemodulators();
 
     for (const auto& demod : demodulators) {

--- a/src/sdr/SoapySDRThread.cpp
+++ b/src/sdr/SoapySDRThread.cpp
@@ -214,13 +214,13 @@ int SDRThread::readStream(const SDRThreadIQDataQueuePtr& iqDataOutQueue) {
     // readStream() is suited to device MTU and cannot be really adapted dynamically.
     //TODO: Add in doc the need to reduce SoapySDR device buffer length (if available) to restore higher fps.
 
-    //0. Retreive a new batch 
+    //0. Retrieve a new batch 
     SDRThreadIQDataPtr dataOut = buffers.getBuffer();
 
     //resize to the target size immedialetly, to minimize later reallocs:
     assureBufferMinSize(dataOut.get(), nElems);
 
-    //1.If overflow occured on the previous readStream(), transfer it in dataOut directly. 
+    //1.If overflow occurred on the previous readStream(), transfer it in dataOut directly. 
     if (numOverflow > 0) {
         int n_overflow = std::min(numOverflow, nElems);
         
@@ -235,7 +235,7 @@ int SDRThread::readStream(const SDRThreadIQDataQueuePtr& iqDataOutQueue) {
 
         // std::cout << "SDRThread::readStream() 1.1 overflowBuffer not empty, collect the remaining " << n_overflow << " samples in it..." << std::endl;
         
-        if (numOverflow > 0) { // still some left, shift the remaining samples to the begining..
+        if (numOverflow > 0) { // still some left, shift the remaining samples to the beginning.
             ::memmove(&overflowBuffer.data[0], &overflowBuffer.data[n_overflow], numOverflow * sizeof(liquid_float_complex));
 
         //    std::cout << "SDRThread::readStream() 1.2 overflowBuffer still not empty, compact the remaining " << numOverflow << " samples in it..." << std::endl;
@@ -285,7 +285,7 @@ int SDRThread::readStream(const SDRThreadIQDataQueuePtr& iqDataOutQueue) {
             }
         }
         
-        //sucess read beyond nElems, so with overflow:
+        //success read beyond nElems, so with overflow:
         if ((n_read + n_stream_read) > nElems) {
 
             //n_requested is the exact number to reach nElems.
@@ -295,7 +295,7 @@ int SDRThread::readStream(const SDRThreadIQDataQueuePtr& iqDataOutQueue) {
             //starting at n_read position.
             //inspired from SoapyRTLSDR code, this mysterious void** is indeed an array of CF32(real/imag) samples, indeed an array of 
             //float with the following layout [sample 1 real part , sample 1 imag part,  sample 2 real part , sample 2 imag part,sample 3 real part , sample 3 imag part,...etc]
-            //Since there is indeed no garantee that sizeof(liquid_float_complex) = 2 * sizeof (float)
+            //Since there is indeed no guarantee that sizeof(liquid_float_complex) = 2 * sizeof (float)
             //nor that the Re/Im layout of fields matches the float array order, assign liquid_float_complex field by field.
             float *pp = (float *)buffs[0];
 
@@ -383,7 +383,7 @@ int SDRThread::readStream(const SDRThreadIQDataQueuePtr& iqDataOutQueue) {
         
         if (!iqDataOutQueue->try_push(dataOut)) {
             //The rest of the system saturates,
-            //finally the push didn't suceeded.
+            //finally the push didn't succeeded.
             readStreamCode = 0;
             std::cout << "SDRThread::readStream(): 3.2 iqDataOutQueue output queue is full, discard processing of the batch..." << std::endl;
 

--- a/src/util/ThreadBlockingQueue.h
+++ b/src/util/ThreadBlockingQueue.h
@@ -77,7 +77,7 @@ public:
      * \param[in] timeout a max waiting timeout in microseconds for an item to be pushed. 
      * by default, = 0 means indefinite wait.
      * \param[in] errorMessage if != nullptr (is nullptr by default) an error message written on std::cout in case of the timeout wait
-     * \return true if an item was pushed into the queue, else a timeout has occured.
+     * \return true if an item was pushed into the queue, else a timeout has occurred.
      */
     bool push(const value_type& item, std::uint64_t timeout = BLOCKING_INFINITE_TIMEOUT,const char* errorMessage = nullptr) {
         std::unique_lock < SpinMutex > lock(m_mutex);
@@ -109,7 +109,7 @@ public:
     }
 
     /**
-    * Try to pushes the item into the queue, immediatly, without waiting. If the queue is full, the item
+    * Try to pushes the item into the queue, immediately, without waiting. If the queue is full, the item
     * is not inserted and the function returns false. 
     * \param[in] item An item.
     */

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -82,7 +82,7 @@ public:
     /// Timer update
     /**
      *	Calling the update command will bring the timer value up to date, this is meant
-     *	to be called at the begining of the frame to establish the time index which is being drawn.
+     *	to be called at the beginning of the frame to establish the time index which is being drawn.
      */
     void update();
 

--- a/src/visual/GainCanvas.cpp
+++ b/src/visual/GainCanvas.cpp
@@ -287,7 +287,7 @@ bool GainCanvas::updateGainValues() {
 
 				//update the config with this value : 
 				//a consequence of such updates is that the use setting 
-				// is overriden by the current one in AGC mode.
+				// is overridden by the current one in AGC mode.
 				//TODO: if it not desirable, do not update in AGC mode.
 				devConfig->setGain(gi.first, actualRoundedGain);
 

--- a/src/visual/ScopeContext.cpp
+++ b/src/visual/ScopeContext.cpp
@@ -40,7 +40,7 @@ void ScopeContext::DrawTunerTitles(bool ppmMode) {
 
     GLFont::Drawer refDrawingFont = GLFont::getFont(12, GLFont::getScaleFactor());
 
-    //better position frequency/bandwith labels according to font scale
+    //better position frequency/bandwidth labels according to font scale
     double shiftFactor = GLFont::getScaleFactor()+0.5;
    
     refDrawingFont.drawString(ppmMode?"Device PPM":"Frequency", -0.66f, -1.0 +hPos*shiftFactor, GLFont::GLFONT_ALIGN_CENTER, GLFont::GLFONT_ALIGN_CENTER, 0, 0, true);

--- a/src/visual/SpectrumCanvas.cpp
+++ b/src/visual/SpectrumCanvas.cpp
@@ -242,7 +242,7 @@ void SpectrumCanvas::OnMouseMoved(wxMouseEvent& event) {
 
     } else {
         if (scaleFactorEnabled) {
-            setStatusText("Drag horizontal to adjust center frequency. Arrow keys or wheel to navigate/zoom bandwith. Right-drag or SHIFT+UP/DOWN to adjust visual gain, right-click to reset it. 'B' to toggle decibels display.");
+            setStatusText("Drag horizontal to adjust center frequency. Arrow keys or wheel to navigate/zoom bandwidth. Right-drag or SHIFT+UP/DOWN to adjust visual gain, right-click to reset it. 'B' to toggle decibels display.");
         } else {
             setStatusText("Displaying spectrum of active demodulator.");
         }

--- a/src/visual/WaterfallCanvas.cpp
+++ b/src/visual/WaterfallCanvas.cpp
@@ -580,7 +580,7 @@ void WaterfallCanvas::updateHoverState() {
         }
         else {
             setStatusText(
-                "Click to set demodulator frequency or hold ALT to drag range; hold SHIFT to create new. Arrow keys or wheel to navigate/zoom bandwith, C to center. Right-drag or SHIFT+UP/DOWN to adjust visual gain. Shift-R record/stop all.");
+                "Click to set demodulator frequency or hold ALT to drag range; hold SHIFT to create new. Arrow keys or wheel to navigate/zoom bandwidth, C to center. Right-drag or SHIFT+UP/DOWN to adjust visual gain. Shift-R record/stop all.");
         }
     }
 }


### PR DESCRIPTION
Most errors are in comments.
Only 3 are in messages visible to users:
* src/CubicSDR.h
* src/visual/SpectrumCanvas.cpp
* src/visual/WaterfallCanvas.cpp

Found with:
codespell --skip=external --ignore-words-list=axix,bord,parm,soley,ue --write-changes --interactive 2
and a manual edit.