### PR TITLE
Fix modem bandwidth interaction lag; favor visual responsiveness

### DIFF
--- a/src/demod/DemodulatorPreThread.h
+++ b/src/demod/DemodulatorPreThread.h
@@ -62,7 +62,7 @@ protected:
     
     std::atomic_llong currentSampleRate, newSampleRate;
     std::atomic_llong currentFrequency, newFrequency;
-    std::atomic_int currentBandwidth, newBandwidth;
+    std::atomic_int currentBandwidth;
     std::atomic_int currentAudioSampleRate, newAudioSampleRate;
 
     std::atomic_bool sampleRateChanged, frequencyChanged, bandwidthChanged, audioSampleRateChanged;


### PR DESCRIPTION
- Trying to always show the active bandwidth state when liquid-dsp is being slow to generate resamplers makes interaction janky.  Let the audio state lag behind the visuals for a better experience.
- Minor out-of-order fixes for variable set/notify.
- Side thought; why is liquid-dsp slow at generating resamplers now?