### PR TITLE
Fix Hamlib build 

### DIFF
--- a/src/AppFrame.h
+++ b/src/AppFrame.h
@@ -33,6 +33,7 @@
 
 
 #ifdef USE_HAMLIB
+#include <hamlib/rig.h>
 class PortSelectorDialog;
 #endif
 
@@ -297,7 +298,7 @@ private:
     std::map<int, wxMenuItem *> rigSerialMenuItems;
     std::map<int, wxMenuItem *> rigModelMenuItems;
     wxMenu *rigModelMenu;
-    int rigModel;
+    rig_model_t rigModel;
     int rigSerialRate;
     long long rigSDRIF;
     std::vector<int> rigSerialRates;

--- a/src/rig/RigThread.cpp
+++ b/src/rig/RigThread.cpp
@@ -32,7 +32,11 @@ RigList &RigThread::enumerate() {
     return RigThread::rigCaps;
 }
 
+#ifdef RIGCAPS_NOT_CONST
+int RigThread::add_hamlib_rig(struct rig_caps *rc, void* /* f */)
+#else
 int RigThread::add_hamlib_rig(const struct rig_caps *rc, void* /* f */)
+#endif
 {
     rigCaps.push_back(rc);
     return 1;

--- a/src/rig/RigThread.h
+++ b/src/rig/RigThread.h
@@ -50,7 +50,11 @@ public:
     std::string getErrorMessage();
 
     static RigList &enumerate();
+#ifdef RIGCAPS_NOT_CONST
+    static int add_hamlib_rig(struct rig_caps *rc, void* f);
+#else
     static int add_hamlib_rig(const struct rig_caps *rc, void* f);
+#endif
 
 protected:
     void setErrorStateFromHamlibCode(int errcode);


### PR DESCRIPTION
Fix Hamlib build to work with older and newer hamlib/rig.h by using R…IGCAPS_NOT_CONST flag
Change rig_model to standard type from rig.h