### PR TITLE
Fix crash on device start when the driver reports sample rates as a range

### DIFF
--- a/src/sdr/SDRDeviceInfo.cpp
+++ b/src/sdr/SDRDeviceInfo.cpp
@@ -196,6 +196,48 @@ std::vector<long> SDRDeviceInfo::getSampleRates(int direction, size_t channel) {
 	//the original list returned from the driver:
     std::vector<double> sampleRates = dev->listSampleRates(direction, channel);
 
+	//drop bogus non-positive rates: range-only drivers (e.g. usdr/xsdr) go through
+	//the SoapySDR deprecated-API shim, which can emit a 0 entry that later gets
+	//selected and makes the driver throw on setSampleRate(0).
+	sampleRates.erase(std::remove_if(sampleRates.begin(), sampleRates.end(),
+		[](double r) { return r <= 0; }), sampleRates.end());
+
+	//some drivers (e.g. usdr/xsdr) only report a continuous range and return an
+	//empty discrete list; synthesize candidate rates from the range instead.
+	if (sampleRates.empty()) {
+
+		SoapySDR::RangeList rateRanges = dev->getSampleRateRange(direction, channel);
+
+		const double candidateRates[] = { 250000, 500000, 1000000, 2000000, 2500000,
+			4000000, 5000000, 8000000, 10000000, 16000000, 20000000, 25000000,
+			32000000, 40000000, 50000000, 64000000, 80000000, 100000000, 125000000 };
+
+		for (double candidate : candidateRates) {
+			for (const auto& range : rateRanges) {
+				if (candidate >= range.minimum() && candidate <= range.maximum()) {
+					sampleRates.push_back(candidate);
+					break;
+				}
+			}
+		}
+
+		//still nothing usable: fall back to the range endpoints themselves
+		if (sampleRates.empty()) {
+			for (const auto& range : rateRanges) {
+				sampleRates.push_back(range.minimum());
+				if (range.maximum() != range.minimum()) {
+					sampleRates.push_back(range.maximum());
+				}
+			}
+		}
+	}
+
+	//no rate info at all: bail out with an empty list rather than reading
+	//past the end of an empty vector below.
+	if (sampleRates.empty()) {
+		return result;
+	}
+
 	//be paranoid, sort by increasing rates...
 	std::sort(sampleRates.begin(), sampleRates.end(), [](double a, double b) -> bool { return a < b; });
 


### PR DESCRIPTION
## Problem

Selecting a device whose SoapySDR driver only implements `getSampleRateRange()` (no discrete `listSampleRates()`) aborts CubicSDR on start:

```
[INFO] SoapyUSDR::setSampleRate(0, RX, 0 MHz)
[INFO] SoapyUSDR::setSampleRate(0, RX, 0 MHz) - error -22
libc++abi: terminating due to uncaught exception of type std::runtime_error:
SoapyUSDR::setSampleRate() unable to set samplerate!
```

Observed with the Wavelet Lab xSDR (`usdr` Soapy module, reports a continuous 1-125 MSps range), but any range-only driver is affected.

## Root cause

Two issues in `SDRDeviceInfo::getSampleRates()`:

1. For range-only drivers, SoapySDR's deprecated-API shim expands the range into a stepped list whose first entry is `0.0`. The 0 survives CubicSDR's decimation step, `getSampleRateNear()` selects it (it wins ties against valid rates), and the driver throws on `setSampleRate(0)`. The exception is never caught, so the app aborts.
2. If a driver returns an empty rate list, the existing code calls `sampleRates.back()` on an empty vector, which is undefined behavior.

## Fix

- Filter non-positive rates out of the `listSampleRates()` result.
- If the list is empty, synthesize candidates from `getSampleRateRange()` (common rates that fall within the reported ranges, falling back to the range endpoints).
- Return an empty list cleanly if the driver provides no rate information at all, instead of reading past the end of an empty vector.

Existing discrete-list drivers are unaffected: their lists contain no non-positive entries and are non-empty, so both new paths are no-ops.

## Testing

Verified on a Wavelet Lab xSDR over USB on macOS (arm64, SoapySDR 0.8.1): device selection previously aborted the app 100% of the time; with this change it starts, streams, and the sample-rate menu is populated with valid rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)