### PR TITLE
Fix build errors against wxWidgets 3.3

### DIFF
--- a/src/AppFrame.cpp
+++ b/src/AppFrame.cpp
@@ -1184,7 +1184,7 @@ void AppFrame::handleUpdateDeviceParams() {
         sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->Enable(false);
     }
     else {
-        sampleRateMenuItems[wxID_BANDWIDTH_MANUAL] = newSampleRateMenu->AppendRadioItem(wxID_BANDWIDTH_MANUAL, wxT("Manual :  ") + frequencyToStr(manualSampleRate));
+        sampleRateMenuItems[wxID_BANDWIDTH_MANUAL] = newSampleRateMenu->AppendRadioItem(wxID_BANDWIDTH_MANUAL, wxString("Manual :  ") + wxString(frequencyToStr(manualSampleRate)));
         sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->Enable(true);
     }
 
@@ -1606,7 +1606,7 @@ bool AppFrame::actionOnMenuSampleRate(wxCommandEvent& event) {
                 manualSampleRate = bw;
                 sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->Enable(true);
 
-                sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->SetItemLabel(wxT("Manual :  ") + frequencyToStr(manualSampleRate));
+                sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->SetItemLabel(wxString("Manual :  ") + wxString(frequencyToStr(manualSampleRate)));
                 sampleRateMenuItems[wxID_BANDWIDTH_MANUAL]->Check(true);
                 wxGetApp().setSampleRate(manualSampleRate);
             }

--- a/src/SessionMgr.cpp
+++ b/src/SessionMgr.cpp
@@ -76,7 +76,7 @@ bool SessionMgr::loadSession(const std::string& fileName) {
             try {
                 versionNode->element()->get(version);
 
-                std::cout << "Loading session file version: '" << version << "'..." << std::endl;
+                std::cout << "Loading session file version: '" << std::string(version.begin(), version.end()) << "'..." << std::endl;
             }
             catch (DataTypeMismatchException &e) {
                 //this is for managing the old session format NOT encoded as std:wstring,

--- a/src/forms/Bookmark/BookmarkView.cpp
+++ b/src/forms/Bookmark/BookmarkView.cpp
@@ -39,7 +39,7 @@ class ActionDialogRemoveBookmark : public ActionDialog {
 public:
     explicit ActionDialogRemoveBookmark( BookmarkEntryPtr be ) : ActionDialog(wxGetApp().getAppFrame(), wxID_ANY, wxT("Remove Bookmark?")) {
         subject = be;
-        m_questionText->SetLabelText(wxT("Are you sure you want to remove the bookmark\n '" + BookmarkMgr::getBookmarkEntryDisplayName(subject) + "'?"));
+        m_questionText->SetLabelText(wxString(L"Are you sure you want to remove the bookmark\n '") + wxString(BookmarkMgr::getBookmarkEntryDisplayName(subject)) + wxString("'?"));
     }
     
     void doClickOK() override {
@@ -55,7 +55,7 @@ class ActionDialogRemoveGroup : public ActionDialog {
 public:
     explicit ActionDialogRemoveGroup( std::string groupName ) : ActionDialog(wxGetApp().getAppFrame(), wxID_ANY, wxT("Remove Group?")) {
         subject = groupName;
-        m_questionText->SetLabelText(wxT("Warning: Are you sure you want to remove the group\n '" + subject + "' AND ALL BOOKMARKS WITHIN IT?"));
+        m_questionText->SetLabelText(wxString(L"Warning: Are you sure you want to remove the group\n '") + wxString(subject) + wxString("' AND ALL BOOKMARKS WITHIN IT?"));
     }
     
     void doClickOK() override {

--- a/src/util/GLFont.cpp
+++ b/src/util/GLFont.cpp
@@ -397,7 +397,7 @@ void GLFont::loadFontOnce() {
 
             if (png_size != nbRead) {
 
-                std::cout << "Error loading the full PNG image file in memory: '" << imageFile << "'" << std::endl;
+                std::cout << "Error loading the full PNG image file in memory: '" << std::string(imageFile.begin(), imageFile.end()) << "'" << std::endl;
             }
         }
 
@@ -408,7 +408,7 @@ void GLFont::loadFontOnce() {
         png_file.Close();
 
         if (error) {
-            std::cout << "Error decoding PNG image file: '" << imageFile << "'" << std::endl;
+            std::cout << "Error decoding PNG image file: '" << std::string(imageFile.begin(), imageFile.end()) << "'" << std::endl;
         }
  
         glGenTextures(1, &texId);
@@ -461,11 +461,11 @@ void GLFont::loadFontOnce() {
             ofs += 8;
         }
 
-        std::cout << "Loaded font '" << fontName << "' from '" << imageFile << "', parsed " << characters.size() << " characters." << std::endl;
+        std::cout << "Loaded font '" << std::string(fontName.begin(), fontName.end()) << "' from '" << std::string(imageFile.begin(), imageFile.end()) << "', parsed " << characters.size() << " characters." << std::endl;
 
         loaded = true;
     } else {
-        std::cout << "Error loading font file " << imageFile << std::endl;
+        std::cout << "Error loading font file " << std::string(imageFile.begin(), imageFile.end()) << std::endl;
     }
 
     input.close();


### PR DESCRIPTION
## Problem

CubicSDR fails to compile against wxWidgets 3.3 (current Homebrew release on macOS). Newer wxWidgets removes implicit conversions that older releases tolerated:

- `wxT()` literals no longer concatenate with `std::string` / `std::wstring` operands (`AppFrame.cpp`, `BookmarkView.cpp`)
- `std::wstring` no longer streams into `std::cout` implicitly (`SessionMgr.cpp`, `GLFont.cpp`)

## Fix

Wrap the affected concatenations in explicit `wxString` constructors and convert wide strings before streaming to stdout. No functional changes; labels and log output are identical.

## Testing

Builds and runs cleanly on macOS (arm64) against Homebrew wxWidgets 3.3; menu labels, bookmark dialogs, and session/font log lines render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)